### PR TITLE
replay: answer get_owner_request so strict clients reach ready

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes are documented here. Format loosely follows
 ## [Unreleased]
 
 ### Added
+- **Replay answers `get_owner_request`** — the simulated device now emulates the firmware's owner
+  admin round-trip (replies with the owner `User` + a session passkey, echoing the request id), so
+  strict clients that block their post-NodeDB "seeding" step on it can reach a ready/connected
+  state. Previously the replay device only handled `want_config_id`, so such a client drained
+  config + the full NodeDB and then timed out. Read-only still holds: mutating admin writes are
+  not honored (replay has tx disabled).
 - **Local-model offload** (`summarize_window` / `vision_oracle` / `triage_window`, plus
   `local_model_status` / `local_model_serve` / `local_model_serve_stop`) — an optional capability
   that pushes token-heavy work onto a local GPU: distill a recorder window, a first-pass

--- a/src/meshtastic_mcp/replay/engine.py
+++ b/src/meshtastic_mcp/replay/engine.py
@@ -30,7 +30,7 @@ import time
 from dataclasses import dataclass, field
 from typing import Any
 
-from meshtastic.protobuf import channel_pb2, config_pb2, mesh_pb2
+from meshtastic.protobuf import admin_pb2, channel_pb2, config_pb2, mesh_pb2, portnums_pb2
 
 from .capture import Capture, node_to_nodeinfo
 from .fuzz import FuzzConfig, Fuzzer
@@ -44,6 +44,10 @@ NONCE_DB = 69421
 
 # Synthetic observer node the app connects "as" (must not collide with capture).
 OBSERVER_NUM = 0x42524331  # "BRC1"
+# Opaque 8-byte admin session passkey the replay device hands a client in its
+# get_owner_response. Value is irrelevant (replay is read-only / tx disabled);
+# strict clients only need *a* passkey to finish their post-NodeDB seeding step.
+OWNER_SESSION_PASSKEY = b"replay01"
 
 
 class PortInUseError(RuntimeError):
@@ -285,6 +289,8 @@ class ReplaySession:
                         ).start()
                 else:
                     self._send_config_phase(send, nonce)
+            elif tr.HasField("packet"):
+                self._handle_client_packet(tr.packet, send)
             # heartbeats / other ToRadio: drain and ignore
 
     # -- handshake phases --
@@ -371,6 +377,49 @@ class ReplaySession:
                 time.sleep(self.params.node_delay)
         fr = mesh_pb2.FromRadio()
         fr.config_complete_id = nonce
+        send(fr)
+
+    def _handle_client_packet(self, pkt: mesh_pb2.MeshPacket, send: Any) -> None:
+        """Answer the admin round-trips a strict client issues during the handshake.
+
+        Real firmware replies to ``get_owner_request`` with the device owner and a
+        session passkey; the replay device emulates that one round-trip so strict
+        clients (e.g. the Kotlin SDK, which blocks ``Connected`` on a post-NodeDB
+        "seeding" step) can reach a ready state. Everything else is drained and
+        ignored — replay is read-only (tx disabled), so mutating admin writes are
+        never honored.
+        """
+        if pkt.decoded.portnum != portnums_pb2.PortNum.ADMIN_APP:
+            return
+        try:
+            req = admin_pb2.AdminMessage()
+            req.ParseFromString(pkt.decoded.payload)
+        except Exception:  # malformed admin payload: ignore, like firmware
+            return
+        if req.WhichOneof("payload_variant") != "get_owner_request":
+            return
+
+        requester = getattr(pkt, "from", 0) or OBSERVER_NUM
+        resp = admin_pb2.AdminMessage()
+        owner = resp.get_owner_response
+        owner.id = f"!{OBSERVER_NUM:08x}"
+        owner.long_name = "Replay Observer"
+        owner.short_name = "RPLY"
+        owner.hw_model = mesh_pb2.HardwareModel.HELTEC_V3
+        owner.role = config_pb2.Config.DeviceConfig.Role.CLIENT
+        resp.session_passkey = OWNER_SESSION_PASSKEY
+
+        fr = mesh_pb2.FromRadio()
+        mp = fr.packet
+        setattr(mp, "from", OBSERVER_NUM)  # responder identity; client keys the passkey on this
+        mp.to = requester & 0xFFFFFFFF
+        mp.id = int(time.time() * 1000) & 0x7FFFFFFF
+        mp.rx_time = int(time.time())
+        mp.channel = 0
+        mp.decoded.portnum = portnums_pb2.PortNum.ADMIN_APP
+        if pkt.id:
+            mp.decoded.request_id = pkt.id
+        mp.decoded.payload = resp.SerializeToString()
         send(fr)
 
     def _observer_nodeinfo(self) -> mesh_pb2.FromRadio:

--- a/tests/unit/test_replay.py
+++ b/tests/unit/test_replay.py
@@ -136,6 +136,72 @@ def test_session_handshake_and_stream():
         sess.stop()
 
 
+def test_get_owner_request_is_answered_for_strict_clients():
+    """A get_owner_request during seeding gets an owner+passkey response.
+
+    Strict clients (e.g. the Kotlin SDK) block their post-NodeDB "seeding" step
+    on this admin round-trip; the replay device must emulate the firmware reply
+    so they can reach a ready state.
+    """
+    from meshtastic.protobuf import admin_pb2, portnums_pb2
+
+    from meshtastic_mcp.replay.engine import OBSERVER_NUM
+
+    cap = sim.generate(nodes=8, days=1, seed=5)
+    probe = socket.socket()
+    probe.bind(("127.0.0.1", 0))
+    port = probe.getsockname()[1]
+    probe.close()
+    sess = ReplaySession("owner", cap, ReplayParams(host="127.0.0.1", port=port, node_delay=0))
+    sess.start()
+    try:
+        deadline = time.time() + 5
+        client = None
+        while time.time() < deadline:
+            try:
+                client = socket.create_connection(("127.0.0.1", port), timeout=1)
+                break
+            except OSError:
+                time.sleep(0.05)
+        assert client is not None
+
+        _send_toradio(client, want_config_id=69420)
+        _send_toradio(client, want_config_id=69421)
+
+        # Send the admin get_owner_request the SDK issues to seed the passkey.
+        req = admin_pb2.AdminMessage(get_owner_request=True)
+        mp = mesh_pb2.MeshPacket()
+        mp.to = OBSERVER_NUM
+        mp.id = 0xABCDEF
+        mp.decoded.portnum = portnums_pb2.PortNum.ADMIN_APP
+        mp.decoded.payload = req.SerializeToString()
+        _send_toradio(client, packet=mp)
+
+        owner_resp = None
+        t0 = time.time()
+        while time.time() - t0 < 4 and owner_resp is None:
+            fr = _read_frame(client)
+            if fr.WhichOneof("payload_variant") != "packet":
+                continue
+            d = fr.packet.decoded
+            if d.portnum != portnums_pb2.PortNum.ADMIN_APP:
+                continue
+            am = admin_pb2.AdminMessage()
+            am.ParseFromString(d.payload)
+            if am.WhichOneof("payload_variant") == "get_owner_response":
+                owner_resp = (fr.packet, am)
+        client.close()
+
+        assert owner_resp is not None, "no get_owner_response from the replay device"
+        pkt, am = owner_resp
+        assert getattr(pkt, "from") == OBSERVER_NUM  # client keys the passkey on this
+        assert len(am.session_passkey) > 0
+        assert am.get_owner_response.id == f"!{OBSERVER_NUM:08x}"
+        assert pkt.decoded.request_id == 0xABCDEF  # echoes the request id
+    finally:
+        sess.stop()
+
+
 def test_sqlite_roundtrip_is_lossless(tmp_path):
     cap = sim.generate(nodes=30, days=1, seed=3, start=1_700_000_000)
     db = tmp_path / "rt.db"


### PR DESCRIPTION
## What

The simulated replay device only handled `want_config_id` — it's a one-way packet streamer. A client that blocks its post-NodeDB **seeding** step on an admin `get_owner_request` → owner + `session_passkey` round-trip drains config and the **full NodeDB**, then **times out**, because the device never answers.

This teaches the replay device to emulate that single firmware round-trip:

- On an `ADMIN_APP` `get_owner_request`, reply with a `get_owner_response` (the **Replay Observer** owner `User`) + an opaque 8-byte `session_passkey`, echoing the request id, `from = OBSERVER_NUM` (the node a client keys the passkey on).
- Everything else from the client is drained and ignored. **Read-only semantics are unchanged** — replay has tx disabled and does not honor mutating admin writes.

## Why

Real firmware answers `get_owner_request` as part of the phone handshake, so any strict client expects it. Without it, the simulator is faithful enough to drive a real client engine through config + NodeDB but can't get it to a ready/connected state. This closes that fidelity gap.

## Validation

Verified end-to-end against a strict third-party client: it now completes the handshake against the simulator and returns device info (`nodeCount`, owner) + a full node snapshot, instead of timing out at the seeding step.

Adds a regression test that drives the handshake + `get_owner_request` over a socket and asserts the response shape (owner id, non-empty passkey, `from == OBSERVER_NUM`, echoed request id).

- `ruff` + `ruff format` + `mypy` clean
- `tests/unit/test_replay.py`: 22 passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Replay sessions now answer owner/admin handshake requests so stricter clients can connect successfully without timing out.
  * Improved environment loading and tooling detection, reducing setup issues on Linux and with device-flashing tools.
  * Added clearer guidance when Linux USB permission issues are detected.

* **Documentation**
  * Updated release notes to reflect the latest replay behavior and supported read-only admin semantics.
  * Clarified tool and environment setup details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->