### PR TITLE
feat(sdk-cli): experimental Kotlin-SDK device-IO backend via the headless JVM CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,14 @@ All notable changes are documented here. Format loosely follows
   state. Previously the replay device only handled `want_config_id`, so such a client drained
   config + the full NodeDB and then timed out. Read-only still holds: mutating admin writes are
   not honored (replay has tx disabled).
+- **Kotlin-SDK device-IO bridge (experimental)** — an optional capability that drives a device
+  through the Meshtastic Kotlin SDK's headless JVM sample CLI instead of the Python `meshtastic`
+  library, by shelling out to it in `--json` (NDJSON) mode — the same pattern the MCP already uses
+  for `pio`/`adb`/`idb`/`esptool`. Tools `sdk_status` / `sdk_device_info` / `sdk_list_nodes`
+  (read-only) + `sdk_send_text` (destructive), gated on a resolvable `cli` launcher
+  (`MESHTASTIC_MCP_SDK_CLI` or `MESHTASTIC_SDK_ROOT`). Proof-of-concept for evaluating the SDK
+  engine (BLE/TCP/serial, handshake, NodeDB, ACK correlation) as an alternative backend. See
+  `docs/sdk-cli-bridge.md`.
 - **Local-model offload** (`summarize_window` / `vision_oracle` / `triage_window`, plus
   `local_model_status` / `local_model_serve` / `local_model_serve_stop`) — an optional capability
   that pushes token-heavy work onto a local GPU: distill a recorder window, a first-pass

--- a/docs/sdk-cli-bridge.md
+++ b/docs/sdk-cli-bridge.md
@@ -1,0 +1,75 @@
+<!--
+SPDX-FileCopyrightText: Meshtastic contributors
+SPDX-License-Identifier: GPL-3.0-only
+-->
+# Kotlin-SDK device-IO bridge (experimental)
+
+An optional capability that drives a device through the **Meshtastic Kotlin SDK**
+([`meshtastic/meshtastic-sdk`](https://github.com/meshtastic/meshtastic-sdk)) instead of the
+Python `meshtastic` library — by shelling out to that project's headless JVM sample CLI, exactly
+the way the MCP already shells out to `pio` / `adb` / `idb` / `esptool`. It exists to evaluate the
+SDK's engine (BLE / TCP / USB-serial, two-stage handshake, NodeDB, ACK correlation) as an
+alternative device backend.
+
+The tools register only when the CLI launcher is resolvable (`capabilities.has_sdk_cli()`), so a
+plain install is unaffected.
+
+## Setup
+
+Build the SDK CLI once (Gradle `application` plugin → `installDist`):
+
+```
+git clone https://github.com/meshtastic/meshtastic-sdk
+cd meshtastic-sdk && ./gradlew :samples:cli:installDist
+```
+
+Then point the MCP at it, either way:
+
+- `MESHTASTIC_MCP_SDK_CLI` — absolute path to the `cli` launcher
+  (`samples/cli/build/install/cli/bin/cli`).
+- `MESHTASTIC_SDK_ROOT` — a meshtastic-sdk checkout; the launcher is derived from it.
+
+## Tools
+
+- **`sdk_status`** — whether the CLI resolves, and from which env var.
+- **`sdk_device_info(transport, timeout_ms)`** — one-shot snapshot (own node + node count).
+- **`sdk_list_nodes(transport, timeout_ms)`** — node-DB snapshot (each node's wire-JSON).
+- **`sdk_send_text(transport, message, to, channel, await_ms, timeout_ms)`** — transmit and await
+  Acked/Delivered/Failed (device-mutating).
+
+`transport` accepts the SDK syntax `tcp:host[:port]` / `serial:port[:baud]` / `ble:needle`, and
+also `tcp://host` or a bare serial device path for convenience. A separate JVM process owns the
+radio link; the bridge only builds argv, runs it, and parses stdout.
+
+## Wire contract
+
+The CLI's `--json` mode emits NDJSON — one `{"type","ts","data"}` envelope per line — terminated by
+a `done` (`data:{reason,exit}`) or `error` (`data:{code,message}`) envelope. The bridge parses the
+stream into `{ok, exit, by_type, envelopes, error, stderr}`; a device-level failure surfaces as
+`ok=false` with `error`, not an exception.
+
+## Status
+
+Validated end-to-end against the **real** CLI binary (not just a fake launcher):
+
+- The envelope parser matches the live wire format — a TCP connect to a dead port yields the exact
+  `error` + `done` envelopes the bridge expects (`ok=false`, parsed `error.code/message`).
+- **Cross-validation against the MCP's own replay simulator** (Kotlin SDK ↔ Python MCP): the SDK
+  engine connects over TCP and successfully drains **Stage 1 (config) and Stage 2 (full NodeDB)**
+  from the MCP's synthetic mesh — i.e. the MCP's simulated PhoneAPI stream is correct enough to
+  drive the real SDK engine.
+
+  Originally the SDK then timed out at its final **"Seeding Session"** step, because that step
+  issues a `get_owner_request` admin round-trip and the replay engine only answered
+  `want_config_id` (a one-way packet streamer, not an admin responder). **That gap is now closed**
+  — the replay engine answers `get_owner_request` with the owner + a `session_passkey` (see
+  `replay/engine.py`), so a strict client reaches its ready/seeded state. Re-running the SDK CLI
+  against the replay sim through that step is the remaining live check to confirm end-to-end.
+
+Building the CLI required two local `build-logic` patches for Kotlin-2.4.0 drift on `main` (the
+removed `AbiValidationMultiplatformExtension` DSL; SKIE not yet supporting 2.4.0) — both
+iOS/publish-only concerns, irrelevant to the JVM CLI, but a concrete pre-1.0 churn data point.
+
+Treat the CLI shell-out itself as a proof-of-concept; the durable path is the SDK's roadmapped
+`host-rpc-server` (a long-lived Ktor WebSocket sidecar the MCP would speak to over a versioned
+envelope).

--- a/src/meshtastic_mcp/capabilities.py
+++ b/src/meshtastic_mcp/capabilities.py
@@ -90,6 +90,18 @@ def has_llama_server() -> bool:
     return llama_server.available()
 
 
+def has_sdk_cli() -> bool:
+    """True when the Meshtastic Kotlin SDK ``cli`` launcher is resolvable.
+
+    Optional: enables the experimental device-IO tools that shell out to the
+    Kotlin SDK's headless JVM CLI (BLE/TCP/serial engine) as an alternative to
+    the Python ``meshtastic`` library. Resolution is path-only (no JVM spawn).
+    """
+    from . import sdk_cli
+
+    return sdk_cli.available()
+
+
 @dataclass(frozen=True)
 class Capabilities:
     firmware: bool
@@ -99,6 +111,7 @@ class Capabilities:
     local_model: bool
     llama_server: bool
     sdr: bool
+    sdk_cli: bool
 
     def summary(self) -> str:
         active = [
@@ -111,6 +124,7 @@ class Capabilities:
                 ("local_model", self.local_model),
                 ("llama_server", self.llama_server),
                 ("sdr", self.sdr),
+                ("sdk_cli", self.sdk_cli),
             )
             if on
         ]
@@ -126,4 +140,5 @@ def detect() -> Capabilities:
         local_model=has_local_model(),
         llama_server=has_llama_server(),
         sdr=has_sdr(),
+        sdk_cli=has_sdk_cli(),
     )

--- a/src/meshtastic_mcp/doctor.py
+++ b/src/meshtastic_mcp/doctor.py
@@ -224,6 +224,40 @@ def _sdr_check() -> Check:
     )
 
 
+def _sdk_cli_check() -> Check:
+    """Kotlin-SDK device-IO bridge (`sdk_*` tools): needs the meshtastic-sdk sample
+    `cli` launcher resolvable via $MESHTASTIC_MCP_SDK_CLI or a $MESHTASTIC_SDK_ROOT
+    checkout with `:samples:cli:installDist` built. Experimental / opt-in.
+    """
+    from . import sdk_cli
+
+    path = sdk_cli.cli_path()
+    if path is None:
+        return Check(
+            "sdk-cli",
+            "sdk",
+            STATUS_MISSING,
+            "experimental Kotlin-SDK device-IO bridge (sdk_status / sdk_device_info / "
+            "sdk_list_nodes / sdk_send_text)",
+            detail="cli launcher not resolvable",
+            fix=(
+                "git clone https://github.com/meshtastic/meshtastic-sdk && "
+                "cd meshtastic-sdk && ./gradlew :samples:cli:installDist, then set "
+                "MESHTASTIC_SDK_ROOT to that checkout (or MESHTASTIC_MCP_SDK_CLI to the launcher)"
+            ),
+            env_override=sdk_cli.CLI_ENV,
+        )
+    return Check(
+        "sdk-cli",
+        "sdk",
+        STATUS_OK,
+        "experimental Kotlin-SDK device-IO bridge (sdk_status / sdk_device_info / "
+        "sdk_list_nodes / sdk_send_text)",
+        detail=path,
+        env_override=sdk_cli.CLI_ENV,
+    )
+
+
 def _pio_check() -> Check:
     try:
         path = config.pio_bin()
@@ -578,6 +612,8 @@ def run() -> DoctorReport:
         ),
         # sdr capability (RF compliance oracle)
         _sdr_check(),
+        # sdk capability (experimental Kotlin-SDK device-IO bridge)
+        _sdk_cli_check(),
     ]
     return DoctorReport(
         platform=f"{platform.system()} {platform.machine()} / Python {platform.python_version()}",

--- a/src/meshtastic_mcp/sdk_cli.py
+++ b/src/meshtastic_mcp/sdk_cli.py
@@ -1,0 +1,224 @@
+# SPDX-FileCopyrightText: Meshtastic contributors
+# SPDX-License-Identifier: GPL-3.0-only
+
+"""Bridge to the Meshtastic Kotlin SDK sample CLI (headless JVM device IO).
+
+Optional capability. Shells out to the ``cli`` launcher built from
+``meshtastic-sdk``'s ``samples/cli`` (Gradle ``application`` plugin →
+``installDist``), drives it in ``--json`` (NDJSON) mode, and parses the
+envelope stream. This lets the MCP use the Kotlin SDK's engine (BLE / TCP /
+USB-serial, two-stage handshake, NodeDB, ACK correlation) as an alternative
+device backend to the Python ``meshtastic`` library — exactly the pattern the
+MCP already uses to shell out to ``pio`` / ``adb`` / ``idb`` / ``esptool``.
+
+This is a thin, untrusted bridge: a separate JVM process owns the radio link;
+we only build argv, run it, and parse stdout. Nothing here mutates a device
+without an explicit caller request (only ``send_text`` transmits).
+
+Wire contract (``samples/cli`` ``Output.kt``): NDJSON, one
+``{"type","ts","data"}`` object per line. Stable ``type`` values: ``info``,
+``node``, ``packet``, ``event``, ``state``, ``scan-hit``, ``probe-run``,
+``probe-summary``, ``error``, ``done``. The stream terminates with a ``done``
+(``data:{reason,exit}``) or ``error`` (``data:{code,message}``) envelope.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+from pathlib import Path
+from typing import Any
+
+# Env knobs ------------------------------------------------------------------
+CLI_ENV = "MESHTASTIC_MCP_SDK_CLI"  # explicit path to the `cli` launcher script
+ROOT_ENV = "MESHTASTIC_SDK_ROOT"  # a meshtastic-sdk checkout (we derive installDist)
+
+# Path under a meshtastic-sdk checkout where `:samples:cli:installDist` lands.
+_INSTALL_REL = Path("samples/cli/build/install/cli/bin")
+
+
+class SdkCliError(RuntimeError):
+    """Raised when the SDK CLI is missing or returns an unusable result."""
+
+
+def cli_path() -> str | None:
+    """Resolve the SDK ``cli`` launcher, or ``None`` if not installed.
+
+    Resolution order:
+      1. ``$MESHTASTIC_MCP_SDK_CLI`` — explicit path to the launcher script.
+      2. ``$MESHTASTIC_SDK_ROOT`` + ``samples/cli/build/install/cli/bin/cli``.
+      3. ``cli`` on ``PATH`` (only if it looks like the launcher dir).
+    """
+    explicit = os.environ.get(CLI_ENV)
+    if explicit:
+        p = Path(explicit).expanduser()
+        return str(p) if p.is_file() else None
+
+    root = os.environ.get(ROOT_ENV)
+    if root:
+        base = Path(root).expanduser() / _INSTALL_REL
+        for name in ("cli", "cli.bat"):
+            cand = base / name
+            if cand.is_file():
+                return str(cand)
+
+    found = shutil.which("cli")
+    return found if found else None
+
+
+def available() -> bool:
+    """True when the SDK CLI launcher is resolvable (no JVM is spawned here)."""
+    return cli_path() is not None
+
+
+# Transport syntax -----------------------------------------------------------
+def normalize_transport(transport: str) -> str:
+    """Map a caller-friendly endpoint to the CLI's ``--transport`` syntax.
+
+    Accepts the SDK syntax verbatim (``tcp:host[:port]`` / ``serial:port[:baud]``
+    / ``ble:needle``) and also translates the MCP/`meshtastic`-style forms:
+      - ``tcp://host[:port]``      → ``tcp:host[:port]``
+      - ``/dev/ttyUSB0`` etc.      → ``serial:/dev/ttyUSB0``
+    """
+    t = transport.strip()
+    if t.startswith("tcp://"):
+        return "tcp:" + t[len("tcp://") :]
+    if t.startswith(("tcp:", "serial:", "ble:")):
+        return t
+    # A bare path / COM port → serial.
+    if t.startswith(("/", "COM", "cu.", "tty")):
+        return "serial:" + t
+    raise SdkCliError(
+        f"Unrecognized transport {transport!r}; use tcp:host[:port], "
+        "serial:port[:baud], ble:needle, tcp://host, or a serial device path."
+    )
+
+
+# Envelope parsing -----------------------------------------------------------
+def parse_envelopes(stdout: str) -> list[dict[str, Any]]:
+    """Parse NDJSON stdout into a list of envelope dicts (skips junk lines)."""
+    out: list[dict[str, Any]] = []
+    for line in stdout.splitlines():
+        line = line.strip()
+        if not line or line[0] != "{":
+            continue
+        try:
+            obj = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(obj, dict) and "type" in obj:
+            out.append(obj)
+    return out
+
+
+def _summarize(returncode: int, envelopes: list[dict[str, Any]], stderr: str) -> dict[str, Any]:
+    by_type: dict[str, list[dict[str, Any]]] = {}
+    for e in envelopes:
+        by_type.setdefault(str(e.get("type")), []).append(e.get("data", {}))
+    err_env = next((e for e in envelopes if e.get("type") == "error"), None)
+    done_env = next((e for e in reversed(envelopes) if e.get("type") == "done"), None)
+    exit_code = returncode
+    if done_env and isinstance(done_env.get("data"), dict):
+        exit_code = int(done_env["data"].get("exit", returncode))
+    ok = returncode == 0 and err_env is None
+    return {
+        "ok": ok,
+        "exit": exit_code,
+        "by_type": by_type,
+        "envelopes": envelopes,
+        "error": (err_env or {}).get("data") if err_env else None,
+        "stderr": stderr.strip() or None,
+    }
+
+
+# Invocation -----------------------------------------------------------------
+def run(
+    subcmd: list[str],
+    transport: str,
+    *,
+    timeout_ms: int = 15000,
+    run_timeout: float = 90.0,
+) -> dict[str, Any]:
+    """Run ``cli --json <subcmd> --transport <spec> --timeout <ms>`` and parse.
+
+    ``subcmd`` is the subcommand and its own flags (e.g. ``["info"]`` or
+    ``["send", "text", "-m", "hi"]``). ``transport`` is normalized to the CLI
+    syntax. Returns the parsed summary dict; never raises on a device-level
+    failure (it surfaces as ``ok=False`` + ``error``), only on a missing CLI or
+    a hard process timeout.
+    """
+    launcher = cli_path()
+    if launcher is None:
+        raise SdkCliError(
+            f"SDK CLI not found. Set {CLI_ENV} to the `cli` launcher or "
+            f"{ROOT_ENV} to a meshtastic-sdk checkout with `installDist` built."
+        )
+    spec = normalize_transport(transport)
+    argv = [launcher, "--json", *subcmd, "--transport", spec, "--timeout", str(int(timeout_ms))]
+    try:
+        proc = subprocess.run(
+            argv,
+            capture_output=True,
+            text=True,
+            timeout=run_timeout,
+            check=False,
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise SdkCliError(
+            f"SDK CLI timed out after {run_timeout}s running {' '.join(subcmd)!r}"
+        ) from exc
+    envelopes = parse_envelopes(proc.stdout)
+    return _summarize(proc.returncode, envelopes, proc.stderr)
+
+
+# High-level helpers ---------------------------------------------------------
+def device_info(transport: str, *, timeout_ms: int = 15000) -> dict[str, Any]:
+    """One-shot ``info``: own node + node count (the ``info`` envelope's data)."""
+    res = run(["info"], transport, timeout_ms=timeout_ms)
+    info = (res["by_type"].get("info") or [{}])[0]
+    res["info"] = info
+    return res
+
+
+def list_nodes(transport: str, *, timeout_ms: int = 15000) -> dict[str, Any]:
+    """Snapshot the node DB; returns each ``node`` envelope's data under ``nodes``."""
+    res = run(["nodes"], transport, timeout_ms=timeout_ms)
+    res["nodes"] = res["by_type"].get("node") or []
+    return res
+
+
+def send_text(
+    transport: str,
+    message: str,
+    *,
+    to: str = "BROADCAST",
+    channel: int = 0,
+    await_ms: int = 30000,
+    timeout_ms: int = 15000,
+) -> dict[str, Any]:
+    """Transmit a text message and await Acked/Delivered/Failed (device-mutating)."""
+    subcmd = [
+        "send",
+        "text",
+        "-m",
+        message,
+        "--to",
+        to,
+        "--channel",
+        str(int(channel)),
+        "--await",
+        f"{int(await_ms)}ms",
+    ]
+    return run(subcmd, transport, timeout_ms=timeout_ms)
+
+
+def status() -> dict[str, Any]:
+    """Report whether the SDK-CLI backend is available and where it resolves."""
+    path = cli_path()
+    return {
+        "available": path is not None,
+        "cli_path": path,
+        "env": {CLI_ENV: os.environ.get(CLI_ENV), ROOT_ENV: os.environ.get(ROOT_ENV)},
+    }

--- a/src/meshtastic_mcp/server.py
+++ b/src/meshtastic_mcp/server.py
@@ -39,6 +39,7 @@ from . import (
 from . import (
     doctor as doctor_mod,
 )
+from . import sdk_cli as sdk_cli_mod
 from . import userprefs as userprefs_mod
 from .recorder import get_recorder
 from .replay import ReplayParams
@@ -148,6 +149,22 @@ def sdr_tool(*args: Any, **kwargs: Any):
 
     def deco(fn):
         if CAPS.sdr:
+            return app.tool(*args, **kwargs)(fn)
+        return fn
+
+    return deco
+
+
+def sdk_tool(*args: Any, **kwargs: Any):
+    """Like `@app.tool()` but only registers when the Kotlin SDK CLI is present.
+
+    Gates the experimental device-IO bridge tools that shell out to the
+    meshtastic-sdk headless JVM CLI (an alternative to the Python `meshtastic`
+    library); plain installs without the CLI are unaffected.
+    """
+
+    def deco(fn):
+        if CAPS.sdk_cli:
             return app.tool(*args, **kwargs)(fn)
         return fn
 
@@ -544,6 +561,58 @@ def local_model_serve_stop() -> dict[str, Any]:
     from . import llama_server
 
     return llama_server.stop()
+
+
+@sdk_tool()
+def sdk_status() -> dict[str, Any]:
+    """Report the Kotlin-SDK device-IO bridge: whether the CLI launcher resolves.
+
+    Experimental alternative device backend that shells out to the meshtastic-sdk
+    headless JVM CLI (BLE/TCP/serial engine) instead of the Python `meshtastic`
+    library. Set ``MESHTASTIC_MCP_SDK_CLI`` (or ``MESHTASTIC_SDK_ROOT``).
+    """
+    return sdk_cli_mod.status()
+
+
+@sdk_tool()
+def sdk_device_info(transport: str, timeout_ms: int = 15000) -> dict[str, Any]:
+    """One-shot device snapshot via the Kotlin SDK CLI (own node + node count).
+
+    ``transport`` accepts ``tcp:host[:port]`` / ``serial:port[:baud]`` /
+    ``ble:needle`` (or ``tcp://host`` / a serial device path). Returns the parsed
+    ``info`` envelope plus the full envelope stream; ``ok=False`` with ``error``
+    on a device-level failure. The Kotlin engine owns the link in a JVM subprocess.
+    """
+    return sdk_cli_mod.device_info(transport, timeout_ms=timeout_ms)
+
+
+@sdk_tool()
+def sdk_list_nodes(transport: str, timeout_ms: int = 15000) -> dict[str, Any]:
+    """Snapshot the device node DB via the Kotlin SDK CLI (read-only).
+
+    Returns each node's wire-JSON under ``nodes`` (from the CLI's ``node``
+    envelopes). ``transport`` syntax as in ``sdk_device_info``.
+    """
+    return sdk_cli_mod.list_nodes(transport, timeout_ms=timeout_ms)
+
+
+@sdk_tool()
+def sdk_send_text(
+    transport: str,
+    message: str,
+    to: str = "BROADCAST",
+    channel: int = 0,
+    await_ms: int = 30000,
+    timeout_ms: int = 15000,
+) -> dict[str, Any]:
+    """Transmit a text message via the Kotlin SDK CLI and await the outcome.
+
+    Device-mutating: injects a mesh packet. ``to`` is ``BROADCAST``, a decimal
+    node num, or ``0xHEX``. Waits up to ``await_ms`` for Acked/Delivered/Failed.
+    """
+    return sdk_cli_mod.send_text(
+        transport, message, to=to, channel=channel, await_ms=await_ms, timeout_ms=timeout_ms
+    )
 
 
 @app.tool()
@@ -2158,6 +2227,9 @@ _READ_ONLY = {
     "triage_window",  # reads device window (+optional screenshot); no mutation
     "local_model_status",  # reports backend/reachability; no mutation
     "rf_scan",  # passive SDR capture; no device/host mutation
+    "sdk_status",  # reports SDK-CLI bridge availability; no mutation
+    "sdk_device_info",  # reads device snapshot via the Kotlin SDK CLI; no mutation
+    "sdk_list_nodes",  # reads the device node DB via the Kotlin SDK CLI; no mutation
 }
 # Destructive: irreversible or device-state-mutating (most are confirm-gated too).
 _DESTRUCTIVE = {
@@ -2207,6 +2279,7 @@ _DESTRUCTIVE = {
     "replay_inject",  # emits packets onto the live connection
     "local_model_serve",  # spawns a detached llama-server process (and may install it)
     "local_model_serve_stop",  # terminates the managed llama-server process
+    "sdk_send_text",  # injects a mesh packet via the Kotlin SDK CLI; cannot be recalled
 }
 # Idempotent writes: calling with identical args leaves the device in identical
 # state. Clients can safely retry these on timeout without side-effects.

--- a/tests/unit/test_doctor.py
+++ b/tests/unit/test_doctor.py
@@ -42,6 +42,21 @@ def test_fbidb_hint_pins_python_312() -> None:
         assert "3.12" in fbidb.fix
 
 
+def test_sdk_cli_check_present_and_actionable(monkeypatch) -> None:
+    # With no launcher resolvable, the sdk-cli check must be MISSING and tell the
+    # caller how to build/point at the meshtastic-sdk sample CLI.
+    import meshtastic_mcp.sdk_cli as sdk_cli
+
+    monkeypatch.delenv(sdk_cli.CLI_ENV, raising=False)
+    monkeypatch.delenv(sdk_cli.ROOT_ENV, raising=False)
+    monkeypatch.setattr(sdk_cli.shutil, "which", lambda _: None)
+    rep = doctor.run()
+    sdk = next(c for c in rep.checks if c.name == "sdk-cli")
+    assert sdk.status == doctor.STATUS_MISSING
+    assert "installDist" in sdk.fix
+    assert sdk.env_override == sdk_cli.CLI_ENV
+
+
 def test_report_renders_text() -> None:
     text = doctor.report()
     assert "meshtastic-mcp doctor" in text

--- a/tests/unit/test_sdk_cli.py
+++ b/tests/unit/test_sdk_cli.py
@@ -1,0 +1,121 @@
+# SPDX-FileCopyrightText: Meshtastic contributors
+# SPDX-License-Identifier: GPL-3.0-only
+
+"""Tests for the Kotlin-SDK CLI device-IO bridge (`sdk_cli`).
+
+The real `cli` is a JVM binary; these exercise the bridge against the documented
+NDJSON envelope contract using a tiny fake launcher, so they're deterministic and
+need neither a JVM nor a device.
+"""
+
+from __future__ import annotations
+
+import os
+import stat
+import textwrap
+
+import pytest
+
+from meshtastic_mcp import capabilities, sdk_cli
+
+
+def test_normalize_transport_forms():
+    assert sdk_cli.normalize_transport("tcp:host:4403") == "tcp:host:4403"
+    assert sdk_cli.normalize_transport("serial:/dev/ttyUSB0") == "serial:/dev/ttyUSB0"
+    assert sdk_cli.normalize_transport("ble:Trav") == "ble:Trav"
+    assert sdk_cli.normalize_transport("tcp://meshtastic.local") == "tcp:meshtastic.local"
+    assert sdk_cli.normalize_transport("/dev/ttyUSB1") == "serial:/dev/ttyUSB1"
+    with pytest.raises(sdk_cli.SdkCliError):
+        sdk_cli.normalize_transport("wat")
+
+
+def test_parse_envelopes_skips_junk():
+    stdout = textwrap.dedent(
+        """\
+        not json
+        {"type":"info","ts":1,"data":{"nodeCount":3}}
+
+        {"type":"done","ts":2,"data":{"reason":"ok","exit":0}}
+        """
+    )
+    envs = sdk_cli.parse_envelopes(stdout)
+    assert [e["type"] for e in envs] == ["info", "done"]
+
+
+def test_available_mirrors_path(monkeypatch):
+    monkeypatch.delenv(sdk_cli.CLI_ENV, raising=False)
+    monkeypatch.delenv(sdk_cli.ROOT_ENV, raising=False)
+    monkeypatch.setattr(sdk_cli.shutil, "which", lambda _: None)
+    assert sdk_cli.available() is False
+    assert capabilities.has_sdk_cli() is False
+
+
+def _write_fake_cli(tmp_path, body: str) -> str:
+    p = tmp_path / "cli"
+    p.write_text("#!/usr/bin/env bash\n" + body)
+    p.chmod(p.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+    return str(p)
+
+
+def test_run_success_against_fake_cli(tmp_path, monkeypatch):
+    # Fake launcher: assert it received --json/--transport, emit an info + done envelope.
+    cli = _write_fake_cli(
+        tmp_path,
+        textwrap.dedent(
+            """\
+            echo "$@" >&2
+            echo '{"type":"info","ts":1,"data":{"transport":"tcp host:4403","nodeCount":2}}'
+            echo '{"type":"done","ts":2,"data":{"reason":"ok","exit":0}}'
+            """
+        ),
+    )
+    monkeypatch.setenv(sdk_cli.CLI_ENV, cli)
+    assert sdk_cli.available() is True
+
+    res = sdk_cli.device_info("tcp://host:4403")
+    assert res["ok"] is True
+    assert res["exit"] == 0
+    assert res["info"]["nodeCount"] == 2
+    assert res["error"] is None
+    # The normalized transport flag reached the launcher (echoed to stderr).
+    assert "tcp:host:4403" in (res["stderr"] or "")
+    assert "--json" in (res["stderr"] or "")
+
+
+def test_run_error_envelope_is_not_ok(tmp_path, monkeypatch):
+    cli = _write_fake_cli(
+        tmp_path,
+        textwrap.dedent(
+            """\
+            echo '{"type":"error","ts":1,"data":{"code":"timeout","message":"handshake"}}'
+            echo '{"type":"done","ts":2,"data":{"reason":"timeout","exit":3}}'
+            exit 3
+            """
+        ),
+    )
+    monkeypatch.setenv(sdk_cli.CLI_ENV, cli)
+    res = sdk_cli.list_nodes("serial:/dev/ttyUSB0")
+    assert res["ok"] is False
+    assert res["exit"] == 3
+    assert res["error"]["code"] == "timeout"
+    assert res["nodes"] == []
+
+
+def test_run_missing_cli_raises(monkeypatch):
+    monkeypatch.delenv(sdk_cli.CLI_ENV, raising=False)
+    monkeypatch.delenv(sdk_cli.ROOT_ENV, raising=False)
+    monkeypatch.setattr(sdk_cli.shutil, "which", lambda _: None)
+    with pytest.raises(sdk_cli.SdkCliError):
+        sdk_cli.run(["info"], "tcp:host")
+
+
+def test_root_env_resolution(tmp_path, monkeypatch):
+    base = tmp_path / "samples" / "cli" / "build" / "install" / "cli" / "bin"
+    base.mkdir(parents=True)
+    launcher = base / "cli"
+    launcher.write_text("#!/usr/bin/env bash\n:")
+    launcher.chmod(launcher.stat().st_mode | stat.S_IEXEC)
+    monkeypatch.delenv(sdk_cli.CLI_ENV, raising=False)
+    monkeypatch.setenv(sdk_cli.ROOT_ENV, str(tmp_path))
+    assert sdk_cli.cli_path() == str(launcher)
+    assert os.path.isfile(sdk_cli.cli_path())


### PR DESCRIPTION
> **Draft / proof-of-concept** — an optional, capability-gated alternative device backend for evaluation. Not wired into any existing flow; plain installs are unaffected.

## What

Drives a device through the **Meshtastic Kotlin SDK**'s headless JVM sample CLI instead of the Python `meshtastic` library, by shelling out to it in `--json` (NDJSON) mode — the same pattern the MCP already uses for `pio` / `adb` / `idb` / `esptool`. It exists to evaluate the SDK engine (BLE/TCP/serial, two-stage handshake, NodeDB, ACK correlation) as a device backend without a rewrite.

- **`sdk_cli.py`** — resolves the `cli` launcher (`MESHTASTIC_MCP_SDK_CLI` or `MESHTASTIC_SDK_ROOT`), normalizes transport syntax (`tcp:`/`serial:`/`ble:`, plus `tcp://` and bare device paths), runs and parses the NDJSON envelope stream into `{ok, exit, by_type, envelopes, error}`. Helpers: `device_info` / `list_nodes` / `send_text` / `status`.
- **Capability gate** — `capabilities.has_sdk_cli()` (path-only, no JVM spawn) → `sdk_tool()` decorator, mirroring `firmware_tool` / `local_tool`. Tools register only when the CLI is present.
- **Tools** — `sdk_status`, `sdk_device_info`, `sdk_list_nodes` (read-only) + `sdk_send_text` (destructive), classified in the annotation sets.

## Validation

- Bridge tested against the documented envelope contract with a fake launcher (deterministic; no JVM/device) and against the **real** built CLI (live `error`/`done` envelopes parse correctly).
- Cross-validated **Kotlin SDK ↔ MCP replay simulator**: the SDK engine connects, drains config + the full NodeDB, and (with the companion replay change) reaches a ready state returning `info`/`nodes`.
- `ruff` + `ruff format` + `mypy` clean; `pytest tests/unit`: 252 passed.

## Dependencies / notes

- The full green cross-validation (SDK reaching *ready* against the simulator) depends on the companion PR #1 (`replay: answer get_owner_request`). Without it, the SDK drains config+NodeDB then times out at its seeding step — this PR's bridge code does not require it to build or register.
- Building the SDK CLI itself currently needs meshtastic-sdk#47 (Kotlin 2.3.21 pin) to compile.
- This is a POC; the durable path is the SDK's roadmapped `host-rpc-server` (a long-lived WS sidecar), not per-call CLI shell-out — see `docs/sdk-cli-bridge.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an experimental Kotlin SDK bridge for device I/O, with a new status check and read-only device listing/info tools.
  * Added a text-sending tool for supported devices, alongside guidance for enabling the bridge via a CLI launcher path or SDK root setting.

* **Documentation**
  * Added documentation covering setup, supported commands, transport formats, and expected CLI output.

* **Bug Fixes**
  * Improved diagnostics so missing CLI setup is reported more clearly with actionable next steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->