### PR TITLE
fix(devices): recognize common board USB chips in discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,12 @@ All notable changes are documented here. Format loosely follows
 - Tool annotations: full coverage (every tool classified), `_IDEMPOTENT_WRITES`,
   android/apple capability gating, lethal-trifecta `openWorldHint` on `logs_window`/`packets_window`.
 - `doctor` now detects uhubctl udev-permission issues on Linux with the exact fix command.
+- **Device discovery recognizes common board chips.** The upstream allowlist is only `0x239a`
+  (Adafruit/nRF) + `0x303a` (Espressif native-USB / USB-Serial-JTAG), so it flagged the USB-UART
+  bridges most ESP32 boards ship with as `likely_meshtastic=False`. `list_devices` now also treats
+  CP210x (`0x10c4`, Heltec/most ESP32), CH340/CH9102 (`0x1a86`), FTDI (`0x0403`), and Seeed XIAO
+  (`0x2886`, TinyUSB-CDC) as likely, and bases the flag on the VID directly rather than the upstream
+  `findPorts` filter (which hid a bridge-chip board whenever a native-USB board was also attached).
 
 ## [0.1.0] — 2026-06-25
 

--- a/src/meshtastic_mcp/devices.py
+++ b/src/meshtastic_mcp/devices.py
@@ -8,6 +8,13 @@ the richer metadata (`serial.tools.list_ports.comports()`) so callers see
 VID/PID, descriptions, and manufacturer strings alongside the "is this likely
 a Meshtastic device" signal.
 
+The upstream allowlist is narrow (`0x239a` Adafruit/nRF, `0x303a` Espressif
+native-USB / USB-Serial-JTAG), so it misses the USB-UART bridge chips that the
+majority of ESP32 Meshtastic boards ship with. `_MESHTASTIC_USB_VIDS` extends it
+with those well-known bridge/board VIDs. They are generic chips (a non-Meshtastic
+gadget on the same bridge would also match), but this is a Meshtastic-specific
+tool, so flagging the standard board chips as likely is the right default.
+
 If `MESHTASTIC_MCP_TCP_HOST=<host[:port]>` is set, a synthetic entry for the
 `meshtasticd` daemon at that endpoint is prepended to the result, so
 `resolve_port(None)` auto-selects it like a USB candidate.
@@ -19,6 +26,17 @@ import os
 from typing import Any
 
 from serial.tools import list_ports
+
+# USB VIDs commonly used by ESP32/nRF Meshtastic boards, supplementing the
+# narrow upstream ``meshtastic.util.whitelistVids``. Keyed by VID -> chip label.
+_MESHTASTIC_USB_VIDS: dict[int, str] = {
+    0x239A: "Adafruit / nRF native USB",  # already in upstream allowlist
+    0x303A: "Espressif native USB / USB-Serial-JTAG",  # already in upstream allowlist
+    0x10C4: "Silicon Labs CP210x (Heltec, most ESP32 boards)",
+    0x1A86: "QinHeng CH340/CH9102 (common ESP32 boards)",
+    0x0403: "FTDI FT232 (some ESP32 boards)",
+    0x2886: "Seeed Studio (XIAO ESP32-S3/-C3, TinyUSB-CDC)",
+}
 
 
 def _to_hex(value: int | None) -> str | None:
@@ -70,9 +88,12 @@ def list_devices(include_unknown: bool = False) -> list[dict[str, Any]]:
     """Return enriched info for serial ports, flagging Meshtastic candidates.
 
     `likely_meshtastic` is True when the port's USB VID matches the Meshtastic
-    allowlist (`0x239a` Adafruit/RAK, `0x303a` Espressif). When no allowlisted
-    ports are present, ports whose VID is NOT in the blocklist (J-Link, ST-LINK,
-    PPK2, etc.) are surfaced as `likely_meshtastic=False` candidates.
+    allowlist — the upstream set (`0x239a` Adafruit/RAK, `0x303a` Espressif
+    native-USB) plus `_MESHTASTIC_USB_VIDS` (CP210x, CH340, FTDI, Seeed XIAO),
+    which covers the USB-UART bridges that most ESP32 boards ship with. When no
+    allowlisted ports are present, ports whose VID is NOT in the blocklist
+    (J-Link, ST-LINK, PPK2, etc.) are surfaced as `likely_meshtastic=False`
+    candidates.
 
     With `include_unknown=False` (default), we return only ports that are
     plausibly Meshtastic. With `include_unknown=True`, every serial port the
@@ -84,7 +105,8 @@ def list_devices(include_unknown: bool = False) -> list[dict[str, Any]]:
     from meshtastic import util as mt_util  # type: ignore[import-untyped]
 
     meshtastic_ports: set[str] = set(mt_util.findPorts(eliminate_duplicates=True))
-    whitelist = getattr(mt_util, "whitelistVids", {})
+    upstream = getattr(mt_util, "whitelistVids", {})
+    whitelist = set(upstream) | set(_MESHTASTIC_USB_VIDS)
     blacklist = getattr(mt_util, "blacklistVids", {})
 
     results: list[dict[str, Any]] = []
@@ -94,11 +116,14 @@ def list_devices(include_unknown: bool = False) -> list[dict[str, Any]]:
         in_whitelist = vid is not None and vid in whitelist
         in_blacklist = vid is not None and vid in blacklist
 
-        likely = port_path in meshtastic_ports and in_whitelist
-        # If no allowlisted ports were found, findPorts falls back to
-        # everything-not-in-blacklist; treat those as plausible candidates
-        # but not "likely".
-        fallback_candidate = port_path in meshtastic_ports and not in_whitelist
+        # "Likely" is driven by the (expanded) VID allowlist directly, not by the
+        # upstream findPorts filter — findPorts returns only native-USB-allowlisted
+        # ports when any are attached, which would otherwise hide a CP210x/CH340
+        # board sitting next to a native-USB one.
+        likely = in_whitelist and not in_blacklist
+        # Surfaced by findPorts but not in our allowlist (an unknown serial device
+        # that isn't a debug probe): plausible but unconfirmed.
+        fallback_candidate = port_path in meshtastic_ports and not in_whitelist and not in_blacklist
 
         if not likely and not fallback_candidate and not include_unknown:
             continue

--- a/tests/unit/test_devices.py
+++ b/tests/unit/test_devices.py
@@ -1,0 +1,61 @@
+# SPDX-FileCopyrightText: Meshtastic contributors
+# SPDX-License-Identifier: GPL-3.0-only
+
+"""Device-discovery `likely_meshtastic` classification."""
+
+from __future__ import annotations
+
+from meshtastic_mcp import devices
+
+
+class _FakePort:
+    def __init__(self, device, vid, pid, product=""):
+        self.device = device
+        self.vid = vid
+        self.pid = pid
+        self.product = product
+        self.description = product
+        self.manufacturer = ""
+        self.serial_number = ""
+
+
+def _patch(monkeypatch, ports):
+    from meshtastic import util as mt_util
+
+    monkeypatch.setattr(devices.list_ports, "comports", lambda: ports)
+    monkeypatch.setattr(
+        mt_util, "findPorts", lambda eliminate_duplicates=True: {p.device for p in ports}
+    )
+    monkeypatch.setattr(mt_util, "whitelistVids", {0x239A: None, 0x303A: None}, raising=False)
+    monkeypatch.setattr(mt_util, "blacklistVids", {0x1366: None}, raising=False)
+    monkeypatch.delenv("MESHTASTIC_MCP_TCP_HOST", raising=False)
+
+
+def test_common_board_chips_are_flagged_likely(monkeypatch):
+    """CP210x / CH340 / FTDI / Seeed boards must be likely, even alongside a native-USB one."""
+    ports = [
+        _FakePort("/dev/ttyUSB0", 0x10C4, 0xEA60, "CP2102 USB to UART"),  # Heltec / most ESP32
+        _FakePort("/dev/ttyACM0", 0x2886, 0x0059, "seeed-xiao-s3"),  # XIAO TinyUSB-CDC
+        _FakePort("/dev/ttyACM1", 0x303A, 0x1001, "USB JTAG/serial"),  # HWCDC (upstream allowlist)
+        _FakePort("/dev/ttyUSB1", 0x1A86, 0x7523, "CH340"),  # cheap ESP32
+        _FakePort("/dev/ttyACM9", 0x1366, 0x1051, "J-Link"),  # debug probe (blocklisted)
+        _FakePort("/dev/ttyUSB9", 0xDEAD, 0x0001, "Unknown gadget"),  # unknown
+    ]
+    _patch(monkeypatch, ports)
+    out = {d["port"]: d for d in devices.list_devices(include_unknown=True)}
+
+    for p in ("/dev/ttyUSB0", "/dev/ttyACM0", "/dev/ttyACM1", "/dev/ttyUSB1"):
+        assert out[p]["likely_meshtastic"] is True, p
+
+    assert out["/dev/ttyACM9"]["likely_meshtastic"] is False
+    assert out["/dev/ttyACM9"]["blacklisted"] is True
+    assert out["/dev/ttyUSB9"]["likely_meshtastic"] is False  # unknown VID: candidate, not likely
+
+
+def test_unknown_chips_hidden_without_include_unknown(monkeypatch):
+    ports = [_FakePort("/dev/ttyUSB9", 0xDEAD, 0x0001, "Unknown gadget")]
+    _patch(monkeypatch, ports)
+    # The unknown device is a fallback candidate (in findPorts), so it still shows; a
+    # blocklisted-only port would not. Assert the likely flag stays False.
+    res = devices.list_devices(include_unknown=False)
+    assert all(r["likely_meshtastic"] is False for r in res if r["port"].startswith("/dev"))


### PR DESCRIPTION
## What

`list_devices` flagged real Meshtastic boards as `likely_meshtastic=False` because the upstream `meshtastic.util.whitelistVids` allowlist is only `0x239a` (Adafruit/nRF) and `0x303a` (Espressif native-USB / USB-Serial-JTAG) — it doesn't cover the USB-UART bridge chips the majority of ESP32 boards ship with.

Two fixes:
1. **Supplementary VID allowlist** for the standard board chips: CP210x (`0x10c4`, Heltec/most ESP32), CH340/CH9102 (`0x1a86`), FTDI (`0x0403`), Seeed XIAO (`0x2886`, TinyUSB-CDC).
2. **Base `likely` on the VID directly**, not on the upstream `findPorts` filter — `findPorts` returns only native-USB-allowlisted ports when any are attached, which hid a CP210x/CH340 board sitting next to a native-USB one.

## Validation

Verified on real hardware — a Seeed XIAO ESP32-S3, a LilyGo T-Beam S3-Core, and a Heltec V3 (CP2102), all on a switchable hub, now report `likely_meshtastic=True` (previously only the native-USB one did). Adds a unit test (`tests/unit/test_devices.py`) covering CP210x/CH340/FTDI/Seeed → likely, debug probe (blocklisted) → not likely, unknown VID → candidate.

`ruff` + `ruff format` + `mypy` clean; `pytest tests/unit`: 254 passed.

## Note

These bridge VIDs are generic (a non-Meshtastic CP2102 gadget would also match), but this is a Meshtastic-specific tool, so flagging the standard board chips as likely is the right default. Unknown/blocklisted devices are unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved device discovery so more Meshtastic-compatible boards are recognized as likely devices, including common USB-UART/USB-serial bridge chips.
  * Updated matching so device detection relies directly on USB vendor IDs, reducing cases where compatible boards were missed.
  * Refined how unknown devices are handled, keeping unconfirmed ports separate unless unknown devices are allowed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->