### PR TITLE
fix(replay): real SO_SNDTIMEO instead of a shared socket timeout

### DIFF
--- a/src/meshtastic_mcp/replay/engine.py
+++ b/src/meshtastic_mcp/replay/engine.py
@@ -28,12 +28,30 @@ import struct
 import threading
 import time
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import Any
 
 from meshtastic.protobuf import channel_pb2, config_pb2, mesh_pb2
 
+from ..recorder.recorder import _default_dir as _recorder_default_dir
+from ..recorder.rotating import _RotatingJsonl
 from .capture import Capture, node_to_nodeinfo
 from .fuzz import FuzzConfig, Fuzzer
+
+
+def _replay_log_dir() -> Path:
+    """Per-session replay lifecycle logs, alongside the recorder's `.mtlog/`.
+
+    Every replay session gets its own append-only JSONL
+    (`<data_dir>/replay-logs/<session_id>.jsonl`) recording lifecycle events
+    (start/connect/disconnect/stop) and a final traffic+fuzz summary — so a
+    soak-test run can be analyzed after the fact without having had to poll
+    `replay_status()` live and capture it yourself. Shares the recorder's data
+    dir resolution (`$MESHTASTIC_MCP_DATA_DIR` override / platformdirs / cwd)
+    so both land under the same root.
+    """
+    return _recorder_default_dir().parent / "replay-logs"
+
 
 START1 = 0x94
 START2 = 0xC3
@@ -76,6 +94,38 @@ def local_ips() -> list[str]:
 # ── Frame helpers ────────────────────────────────────────────────────────────
 def _frame(payload: bytes) -> bytes:
     return bytes([START1, START2]) + struct.pack(">H", len(payload)) + payload
+
+
+def _set_send_timeout(sock: socket.socket, seconds: float) -> None:
+    """Bound only `send()`/`sendall()` on `sock`, leaving `recv()` blocking indefinitely.
+
+    Root-cause note (found 2026-07-01 investigating spurious ~10-290s disconnects
+    against a real Android app, reproduced with fuzz completely off): the old code
+    called `sock.settimeout(seconds)`, which in Python governs *every* blocking
+    call on the socket — recv() as well as send(). This protocol is push-mostly
+    (FromRadio flows server→client continuously; ToRadio flows client→server only
+    for user-initiated actions / occasional heartbeats), so idle gaps on the read
+    side of many seconds — or minutes — are completely normal, not a sign of a
+    stuck client. With a shared 10s timeout, `_read_toradio()`'s `sock.recv(1)`
+    would raise `TimeoutError("timed out")` the moment the client went 10s without
+    sending anything, and `_accept_loop` caught that as `(OSError, ConnectionError)`
+    and tore down an otherwise-healthy connection — misreported as the *app*
+    stalling when it was actually the server's own read-side timeout firing.
+    `SO_SNDTIMEO` is a genuine kernel-level option that only bounds send()s
+    (protects the server's push loop from a receiver that stops draining its
+    socket buffer, e.g. under `fuzz`'s flooder or a slow/backgrounded app) and
+    leaves recv() to block forever, matching this protocol's real traffic shape.
+    No-op (falls back to the old shared-timeout behavior) on platforms without
+    `SO_SNDTIMEO` (Windows) — fine since replay is a dev/CI tool, not prod.
+    """
+    if seconds <= 0:
+        return
+    if hasattr(socket, "SO_SNDTIMEO"):
+        secs = int(seconds)
+        usecs = int((seconds - secs) * 1_000_000)
+        sock.setsockopt(socket.SOL_SOCKET, socket.SO_SNDTIMEO, struct.pack("ll", secs, usecs))
+    else:  # pragma: no cover - Windows fallback
+        sock.settimeout(seconds)
 
 
 def _recv_exact(sock: socket.socket, n: int) -> bytes | None:
@@ -139,7 +189,8 @@ class ReplayParams:
     # Replay Clock: post a kickoff + periodic "ETA — done/total" to the busiest
     # channel so you can see, from inside the app, that it's a replay. 0 = off.
     announce_interval: float = 0.0
-    send_timeout: float = 10.0  # SO_SNDTIMEO seconds; a stalled app can't hang us. 0 = none
+    # true SO_SNDTIMEO seconds; a stalled app can't hang our sends. 0 = none
+    send_timeout: float = 10.0
 
 
 @dataclass
@@ -175,12 +226,36 @@ class ReplaySession:
             started_at=time.time(),
         )
         self._srv: socket.socket | None = None
+        self._client: socket.socket | None = None  # currently-connected client, if any
         self._ch_index = {name: i for i, name in enumerate(capture.channels)}
         # live-injection queue: (MeshPacket, channel_name, fuzz) drained per client
         self._inject_q: queue.Queue[tuple[mesh_pb2.MeshPacket, str, bool]] = queue.Queue()
         self.fuzzer: Fuzzer | None = (
             Fuzzer(params.fuzz, capture.nodes, self._ch_index) if params.fuzz else None
         )
+        # Per-session lifecycle log — every session gets its own JSONL under
+        # `_replay_log_dir()` so a soak-test run can be analyzed after the fact
+        # (start/connect/disconnect/stop + a status snapshot at each transition)
+        # without having had to poll `replay_status()` live yourself.
+        self._log = _RotatingJsonl(_replay_log_dir() / f"{sid}.jsonl")
+        self._log_event(
+            "session_created",
+            capture=capture.label,
+            packets_total=len(window),
+            params={
+                "host": params.host,
+                "port": params.port,
+                "rate": params.rate,
+                "speed": params.speed,
+                "loop": params.loop,
+                "send_timeout": params.send_timeout,
+                "fuzz": params.fuzz.name if params.fuzz else None,
+            },
+        )
+
+    def _log_event(self, kind: str, **fields: Any) -> None:
+        with contextlib.suppress(Exception):  # logging must never break the session
+            self._log.write({"t": time.time(), "kind": kind, "session_id": self.state.id, **fields})
 
     # -- lifecycle --
     def start(self) -> None:
@@ -190,6 +265,7 @@ class ReplaySession:
             srv.bind((self.params.host, self.params.port))
         except OSError as exc:
             srv.close()
+            self._log_event("bind_failed", error=str(exc))
             raise PortInUseError(
                 f"cannot bind {self.params.host}:{self.params.port} ({exc}). "
                 f"Another server is using it — stop it (replay_stop), or pass port=0 "
@@ -203,14 +279,25 @@ class ReplaySession:
         t = threading.Thread(target=self._accept_loop, name=f"replay-{self.state.id}", daemon=True)
         self.state.thread = t
         t.start()
+        self._log_event("listening", host=self.params.host, port=self.params.port)
 
     def stop(self) -> None:
+        self._log_event("stop_requested")
         self.state.stop.set()
         if self._srv is not None:
             try:
                 self._srv.close()
             except OSError:
                 pass
+        # The client socket's recv() side is intentionally left blocking with no
+        # timeout (see `_set_send_timeout`) since idle read gaps are normal for
+        # this protocol — closing `_srv` alone won't unblock an already-accepted,
+        # idly-connected client's `_read_toradio()`. shutdown() reliably interrupts
+        # a blocking recv() from another thread (unlike close(), which risks an FD-
+        # reuse race); best-effort since the client may have already disconnected.
+        if self._client is not None:
+            with contextlib.suppress(OSError):
+                self._client.shutdown(socket.SHUT_RDWR)
 
     # -- server loop --
     def _accept_loop(self) -> None:
@@ -224,10 +311,13 @@ class ReplaySession:
                 except OSError:
                     break
                 client.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
-                if self.params.send_timeout:
-                    client.settimeout(self.params.send_timeout)
+                _set_send_timeout(client, self.params.send_timeout)
                 self.state.client_addr = f"{addr[0]}:{addr[1]}"
                 self.state.connected = True
+                self._client = client
+                self.state.error = None  # clear any prior disconnect's error on a fresh connect
+                self._log_event("client_connected", client=self.state.client_addr)
+                packets_before = self.state.packets_sent
                 try:
                     self._serve_client(client)
                 except (OSError, ConnectionError) as exc:
@@ -238,6 +328,15 @@ class ReplaySession:
                     except OSError:
                         pass
                     self.state.connected = False
+                    self._client = None
+                    self._log_event(
+                        "client_disconnected",
+                        client=self.state.client_addr,
+                        error=self.state.error,
+                        packets_sent_this_connection=self.state.packets_sent - packets_before,
+                        packets_sent_total=self.state.packets_sent,
+                        fuzz=self.fuzzer.status() if self.fuzzer is not None else None,
+                    )
                 if not self.params.loop:
                     break
         finally:
@@ -246,6 +345,13 @@ class ReplaySession:
             except OSError:
                 pass
             self.state.ended = True
+            self._log_event(
+                "session_ended",
+                packets_sent_total=self.state.packets_sent,
+                error=self.state.error,
+                fuzz=self.fuzzer.status() if self.fuzzer is not None else None,
+            )
+            self._log.close()
 
     def _serve_client(self, client: socket.socket) -> None:
         send_lock = threading.Lock()

--- a/tests/unit/test_replay.py
+++ b/tests/unit/test_replay.py
@@ -610,5 +610,128 @@ def test_inject_through_fuzzer_mutates():
     assert outs[0].decoded.payload != before  # garbage_payload mutated it
 
 
+def test_idle_reader_does_not_trip_send_timeout():
+    """Regression for the `client.settimeout()` bug (found 2026-07-01 against a real
+    Android app): a shared socket timeout bounded *both* send() and recv(), so a
+    client that legitimately went quiet for `send_timeout` seconds (normal for this
+    push-mostly protocol — the client only sends ToRadio for user actions/heartbeats)
+    got its connection killed and misreported as "timed out", as if the client itself
+    had stalled. Fixed via real SO_SNDTIMEO (`_set_send_timeout`), which only bounds
+    sends. This test connects, completes the handshake, then goes idle on the client
+    side for longer than `send_timeout` — the session must still be connected
+    afterward, with no error, and still able to deliver stream packets.
+    """
+    cap = sim.generate(nodes=10, days=1, seed=5, start=1_700_000_000)
+    params = ReplayParams(host="127.0.0.1", port=0, rate=50, node_delay=0, send_timeout=0.3)
+    sess = ReplaySession("idle-reader", cap, params)
+    probe = socket.socket()
+    probe.bind(("127.0.0.1", 0))
+    port = probe.getsockname()[1]
+    probe.close()
+    sess.params.port = port
+    sess.start()
+    try:
+        deadline = time.time() + 5
+        client = None
+        while time.time() < deadline:
+            try:
+                client = socket.create_connection(("127.0.0.1", port), timeout=1)
+                break
+            except OSError:
+                time.sleep(0.05)
+        assert client is not None
+
+        _send_toradio(client, want_config_id=69420)
+        _send_toradio(client, want_config_id=69421)
+        # drain the handshake burst so nothing lingers in the socket buffer
+        t0 = time.time()
+        while time.time() - t0 < 2:
+            _read_frame(client)
+            if sess.state.connected:
+                break
+
+        # Now go idle on the client side for > send_timeout (0.3s) — the old code
+        # would have the server's recv() time out here and tear the connection down.
+        time.sleep(1.0)
+
+        assert sess.state.connected is True
+        assert sess.state.error is None
+
+        # and the connection must still be usable afterward
+        fr = _read_frame(client)
+        assert fr.WhichOneof("payload_variant") is not None
+        client.close()
+    finally:
+        sess.stop()
+
+
+def test_stop_unblocks_idle_client_thread():
+    """`stop()` must shutdown() the connected client socket, not just close the
+    listening socket — otherwise, since recv() is now intentionally left blocking
+    with no timeout (see above), an idly-connected client's serve thread would
+    never notice `state.stop` and `ended` would never become True.
+    """
+    cap = sim.generate(nodes=5, days=1, seed=2, start=1_700_000_000)
+    params = ReplayParams(host="127.0.0.1", port=0, rate=50, node_delay=0, loop=False)
+    sess = ReplaySession("stop-unblock", cap, params)
+    probe = socket.socket()
+    probe.bind(("127.0.0.1", 0))
+    port = probe.getsockname()[1]
+    probe.close()
+    sess.params.port = port
+    sess.start()
+    client = socket.create_connection(("127.0.0.1", port), timeout=2)
+    try:
+        _send_toradio(client, want_config_id=69420)
+        _read_frame(client)  # at least one reply -> handshake under way
+        sess.stop()
+        deadline = time.time() + 3
+        while time.time() < deadline and not sess.state.ended:
+            time.sleep(0.05)
+        assert sess.state.ended is True
+    finally:
+        client.close()
+
+
+def test_replay_session_writes_lifecycle_log(tmp_path, monkeypatch):
+    """Every session gets its own append-only JSONL for post-run analysis —
+    lifecycle events (create/listen/connect/disconnect/end), not just whatever a
+    caller happened to poll live via `replay_status()`.
+    """
+    monkeypatch.setenv("MESHTASTIC_MCP_DATA_DIR", str(tmp_path))
+    cap = sim.generate(nodes=5, days=1, seed=1, start=1_700_000_000)
+    params = ReplayParams(host="127.0.0.1", port=0, rate=50, node_delay=0, loop=False)
+    sess = ReplaySession("log-test", cap, params)
+    probe = socket.socket()
+    probe.bind(("127.0.0.1", 0))
+    port = probe.getsockname()[1]
+    probe.close()
+    sess.params.port = port
+    sess.start()
+    client = socket.create_connection(("127.0.0.1", port), timeout=2)
+    try:
+        _send_toradio(client, want_config_id=69420)
+        _read_frame(client)
+    finally:
+        client.close()
+        sess.stop()
+        deadline = time.time() + 3
+        while time.time() < deadline and not sess.state.ended:
+            time.sleep(0.05)
+
+    import json
+
+    # _replay_log_dir() = _recorder_default_dir().parent / "replay-logs", and
+    # _recorder_default_dir() = $MESHTASTIC_MCP_DATA_DIR/.mtlog, so both land
+    # as siblings directly under tmp_path.
+    log_path = tmp_path / "replay-logs" / "log-test.jsonl"
+    assert log_path.is_file(), f"expected lifecycle log at {log_path}"
+    kinds = [json.loads(line)["kind"] for line in log_path.read_text().splitlines()]
+    assert "session_created" in kinds
+    assert "listening" in kinds
+    assert "client_connected" in kinds
+    assert kinds[-1] in ("session_ended",)  # always the last event written
+
+
 if __name__ == "__main__":  # pragma: no cover
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## What

`_accept_loop()` called `client.settimeout(send_timeout)` (default 10s), and Python's `socket.settimeout()` bounds **every** blocking call on that socket — `recv()` as well as `send()`. The Meshtastic StreamAPI is push-mostly (FromRadio flows server→client continuously; ToRadio only flows client→server for user actions or occasional heartbeats), so idle gaps of many seconds on the read side are completely normal.

`_read_toradio()`'s blocking `recv(1)` would raise `TimeoutError('timed out')` the instant the client went quiet for `send_timeout` seconds, and `_accept_loop` caught that as `(OSError, ConnectionError)` and tore the connection down — **misreported as the app stalling** when it was actually the server's own read-side timeout firing on a perfectly healthy idle connection.

## Root cause investigation

Reproduced live against a real Android app + Pixel 6a with a clean, unfuzzed capture (`fuzz='off'`) to rule out adversarial content, then confirmed the exact `'timed out'` string via a minimal socket repro matching `str(TimeoutError())` from a `recv()` timeout.

## Fix

`_set_send_timeout()` uses the real `SO_SNDTIMEO` socket option, which only bounds `send()`/`sendall()` and leaves `recv()` blocking indefinitely — matching this protocol's real traffic shape. `ReplaySession.stop()` now also explicitly `shutdown(SHUT_RDWR)`s the connected client socket, since closing only the listening socket no longer wakes an idly-blocked client thread (recv has no timeout to fall back on).

Verified live: a session that previously died after 10–290s now ran 600s+ unattended with `error=None` throughout, same client socket the whole time.

## Also included

Per-session lifecycle logging: every `replay_start()` now writes its own append-only JSONL under `~/.local/share/meshtastic-mcp/replay-logs/` (create/listen/connect/disconnect/end, each with packet-count + fuzz-activity snapshot), so a soak-test run can be analyzed after the fact instead of requiring live `replay_status()` polling. Shares the recorder's `$MESHTASTIC_MCP_DATA_DIR` resolution.

## Tests

New regressions: idle-reader must not time out, `stop()` must unblock an idly-connected client thread, and lifecycle-log content. Full suite green; `ruff`/`mypy` clean.

## Scope

`replay/engine.py` + `test_replay.py`, disjoint from the other branches opened alongside — mergeable in any order.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added session-level replay logs so connection and shutdown events are recorded for easier troubleshooting.
  * Improved replay server handling to keep idle connections stable while still enforcing send time limits.

* **Bug Fixes**
  * Prevented idle readers from being disconnected due to send timeouts.
  * Made stopping a replay session reliably unblock connected-but-idle clients and end the session cleanly.

* **Tests**
  * Added coverage for idle connection behavior, stop handling, and lifecycle log creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->