### PR TITLE
feat(emulator): connect the Android app via deep links, not UI taps

### DIFF
--- a/src/meshtastic_mcp/emulator/avd.py
+++ b/src/meshtastic_mcp/emulator/avd.py
@@ -39,6 +39,26 @@ from typing import Any
 EMULATOR_HOST_ALIAS = "10.0.2.2"
 DEFAULT_TCP_PORT = 4403
 
+# Known Meshtastic-Android applicationIds, most-specific first. The fdroid debug
+# build is preferred for e2e (no Play Services deps; TCP connect works everywhere).
+# See scripts/build_android_apk.sh's --variant default (assembleFdroidDebug).
+KNOWN_PACKAGES = (
+    "com.geeksville.mesh.fdroid.debug",
+    "com.geeksville.mesh.google.debug",
+    "com.geeksville.mesh",
+)
+
+# meshtastic://meshtastic/{path} and https://meshtastic.org/{path} both resolve
+# through the same in-app DeepLinkRouter (core/navigation). The custom scheme
+# needs no App Link verification and is the fastest way to drive navigation from
+# adb/automation. See docs/en/developer/navigation-and-deep-links.md.
+DEEPLINK_SCHEME = "meshtastic://meshtastic"
+
+# The app's internal "no device selected" sentinel — passing this as the
+# `?address=` value on the /connections deep link disconnects instead of
+# connecting (added alongside the connect-by-address deep link).
+NO_DEVICE_SELECTED = "n"
+
 
 class EmulatorError(RuntimeError):
     pass
@@ -306,6 +326,80 @@ def is_app_installed(package: str, serial: str | None = None) -> bool:
     return any(line.strip() == f"package:{package}" for line in out.splitlines())
 
 
+def resolve_package(serial: str | None = None) -> str | None:
+    """Find whichever Meshtastic-Android applicationId is installed on the device.
+
+    Tries `KNOWN_PACKAGES` in order (fdroid debug preferred). Returns None if
+    none are installed. Needed because the app ships under several
+    applicationIds depending on build variant/flavor (fdroid vs google, debug
+    vs release), and a single device may have more than one installed side by
+    side (they don't collide — different applicationIds).
+    """
+    for pkg in KNOWN_PACKAGES:
+        if is_app_installed(pkg, serial=serial):
+            return pkg
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Deep links (fast, version-resilient navigation — prefer over UI taps)
+# ---------------------------------------------------------------------------
+def deeplink(path: str, *, serial: str | None = None, package: str | None = None) -> None:
+    """Fire a Meshtastic-Android deep link via `am start -a VIEW`.
+
+    `path` is the part after the host, e.g. `connections?address=t192.168.1.1:4403`,
+    `nodes`, `map/3`, `settings/helpDocs`. See
+    docs/en/developer/navigation-and-deep-links.md (or `DeepLinkRouter.route()`
+    KDoc in the app source) for the full, current list of supported paths.
+
+    Targets the resolved package explicitly (`resolve_package()` if not given)
+    so the intent lands even when the app isn't already foregrounded. Safe to
+    call before the app has completed first-run onboarding: the app applies a
+    pending deep-link route once onboarding clears rather than dropping it
+    (verified live against 2.8.0 fdroid debug, 2026-07-01) — no need to dismiss
+    onboarding screens first.
+    """
+    pkg = package or resolve_package(serial=serial)
+    uri = f"{DEEPLINK_SCHEME}/{path.lstrip('/')}"
+    args = ["shell", "am", "start", "-a", "android.intent.action.VIEW", "-d", uri]
+    if pkg:
+        args.append(pkg)
+    adb(*args, serial=serial, check=False)
+
+
+def connect_app_via_deeplink(
+    address: str, *, serial: str | None = None, package: str | None = None
+) -> None:
+    """Connect the app to a device by address via the `/connections?address=` deep link.
+
+    `address` is the app's internal transport-prefixed format:
+      - `t<host>:<port>` — TCP, e.g. `t192.168.1.168:4403` or `t127.0.0.1:4403`
+      - `x<AA:BB:CC:DD:EE:FF>` — BLE MAC
+      - `s<path>` — serial/USB, e.g. `s/dev/ttyUSB0`
+
+    Requires Meshtastic-Android built from `main` @ 60119ce9d (2026-07-01,
+    meshtastic/Meshtastic-Android#6036) or later. Older builds ignore the
+    `address` param (deep link still opens the Connections screen, just
+    doesn't auto-connect) — `connect_app_to_tcp()` falls back to UI taps in
+    that case, so prefer that entry point unless you know the app is new
+    enough.
+
+    One shell call, no UI-tree parsing, no dependency on button positions/
+    labels — use this instead of `connect_app_to_tcp`'s UI-tap fallback
+    whenever the app build is known to include the address param.
+    """
+    deeplink(f"connections?address={address}", serial=serial, package=package)
+
+
+def disconnect_app_via_deeplink(*, serial: str | None = None, package: str | None = None) -> None:
+    """Disconnect the app's current device via `/connections?address=n`.
+
+    `n` is the app's internal "no device selected" sentinel (`NO_DEVICE_SELECTED`).
+    Same version requirement as `connect_app_via_deeplink`.
+    """
+    deeplink(f"connections?address={NO_DEVICE_SELECTED}", serial=serial, package=package)
+
+
 # ---------------------------------------------------------------------------
 # TCP connectivity
 # ---------------------------------------------------------------------------
@@ -399,6 +493,14 @@ def _ui_dump_physical(serial: str) -> list[dict[str, Any]]:
         xml_start = out.find("<hierarchy")
     if xml_start > 0:
         out = out[xml_start:]
+    # Some uiautomator versions (observed live on Pixel 6a / Android 17) also
+    # append the same status message *after* the closing tag on the same line,
+    # with no separating newline ("...</hierarchy>UI hierchary dumped to: ..."),
+    # which trips ET.fromstring with "junk after document element". Truncate at
+    # the true end of the XML document rather than trusting EOF.
+    xml_end = out.rfind("</hierarchy>")
+    if xml_end != -1:
+        out = out[: xml_end + len("</hierarchy>")]
     return _parse_uiautomator_xml(out)
 
 
@@ -604,21 +706,74 @@ def connect_app_to_tcp(
     *,
     serial: str | None = None,
     settle_s: float = 1.5,
+    confirm_timeout_s: float = 20.0,
+    prefer_deeplink: bool = True,
+    force_reconnect: bool = False,
 ) -> bool:
-    """Drive Meshtastic-Android's "Add device → IP" flow to connect to a TCP node.
+    """Connect the app to a TCP node at `host:port`.
 
     For emulators, pass host=EMULATOR_HOST_ALIAS (default).
     For physical devices, call tcp_dut_address(serial=serial) first to set up the
-    adb reverse tunnel, then pass host="127.0.0.1".
+    adb reverse tunnel, then pass host="127.0.0.1" (or any LAN-reachable host the
+    phone can already route to — the reverse tunnel is only needed when the phone
+    can't otherwise reach the host, e.g. no shared Wi-Fi).
 
-    Codifies the navigation validated live 2026-06-24 against Meshtastic-Android 2.8:
+    Fast path (`prefer_deeplink=True`, default): fires the `/connections?address=`
+    deep link (meshtastic/Meshtastic-Android#6036, merged 2026-07-01) — one `adb
+    shell am start`, no UI-tree parsing, works even mid-onboarding, version-
+    resilient to layout changes. Falls back to the legacy UI-tap flow below if the
+    "Not connected" label doesn't clear within `confirm_timeout_s` (covers app
+    builds predating the deep link, or a slow/failed connection where the fallback
+    won't help either — caller should still verify the final result via the
+    device-plane oracle, e.g. `replay_status().connected`, which is authoritative;
+    UI text is a best-effort signal only). `confirm_timeout_s` defaults generously
+    (20s) because a real handshake + full NodeDB download over TCP visibly takes
+    longer than a UI-animation settle — verified live: ~10-30s for a 20-40 node
+    capture on a Pixel 6a, occasionally longer. Don't shrink this to `settle_s`-ish
+    values; that just makes the (slower, less reliable) UI-tap fallback fire while
+    the deep-link connect is still in flight. Note: the Connections screen's
+    "Disconnect" button label is present regardless of connection state — don't
+    use it as a connected signal, use the absence of "Not connected" instead
+    (what this does).
+
+    **Sticky address / auto-reconnect** (verified live 2026-07-01): once the app
+    has an address configured, it keeps retrying that address indefinitely on its
+    own — a dropped TCP session (e.g. the DUT/replay session restarting) gets
+    silently reconnected with no further deep link needed. The converse: re-firing
+    `?address=` with the *same* value the app is already using/retrying may be a
+    Compose no-op (`LaunchedEffect(key.address)` doesn't restart for an unchanged
+    key) — you can't tell from that call alone whether it did anything. Only an
+    explicit `/connections?address=n` disconnect (`disconnect_app_via_deeplink`)
+    stops the retries. Pass `force_reconnect=True` to disconnect first, guaranteeing
+    a fresh, observable handshake even when reconnecting to the same address
+    (e.g. after swapping which DUT/replay session is listening on that port).
+
+    Legacy UI-tap flow (`prefer_deeplink=False`, or deep-link confirm timeout):
+    codifies the navigation validated live 2026-06-24 against Meshtastic-Android 2.8:
       onboarding Skip ×3 → Connection screen → ensure TCP transport on →
       "Add device manually…" → type address (Port defaults to 4403) → Add.
-
     Best-effort + UI-driven; layout can shift between app versions, so callers should
     verify the result (e.g. `poll_for_text("Disconnect")` or the node short name).
-    Returns True if the Add action was issued.
+
+    Returns True if a connect action was issued (deep link fired, or the UI Add
+    action was issued) — not a guarantee of an established connection either way.
     """
+    if prefer_deeplink:
+        if force_reconnect:
+            disconnect_app_via_deeplink(serial=serial)
+            time.sleep(settle_s)
+        connect_app_via_deeplink(f"t{host}:{port}", serial=serial)
+        deadline = time.monotonic() + confirm_timeout_s
+        while time.monotonic() < deadline:
+            try:
+                if not find_text("Not connected", serial=serial):
+                    return True
+            except EmulatorError:
+                pass  # transient dump failure (mid-animation) — keep polling
+            time.sleep(0.5)
+        # Fall through to the UI-tap flow — either an old app build ignoring
+        # `?address=`, or a still-in-flight/failed connection the caller must
+        # verify regardless. Cheap to attempt; a harmless no-op if already wired.
     # 1. Dismiss onboarding permission pages (BLE/Location/Notifications) — Skip up to 4x.
     for _ in range(4):
         if not _tap_text("Skip", serial=serial):

--- a/src/meshtastic_mcp/emulator/avd.py
+++ b/src/meshtastic_mcp/emulator/avd.py
@@ -32,6 +32,7 @@ import shutil
 import subprocess
 import time
 import xml.etree.ElementTree as ET
+from collections.abc import Sequence
 from pathlib import Path
 from typing import Any
 
@@ -58,6 +59,29 @@ DEEPLINK_SCHEME = "meshtastic://meshtastic"
 # `?address=` value on the /connections deep link disconnects instead of
 # connecting (added alongside the connect-by-address deep link).
 NO_DEVICE_SELECTED = "n"
+
+# Fully-qualified launcher activity — needed for `am start -n <pkg>/<activity>`
+# with intent extras (the onboarding-skip affordance below). Stable across the
+# applicationId variants in KNOWN_PACKAGES (they share one app module).
+MAIN_ACTIVITY = "org.meshtastic.app.MainActivity"
+
+# Debug-build intent extra that skips the first-run intro flow on a fresh install
+# (Meshtastic-Android#6044): `am start -n <pkg>/<activity> --ez skip_onboarding true`
+# calls onAppIntroCompleted() straight away. BuildConfig.DEBUG-gated in the app —
+# a no-op on release/Play builds. Pair with grant_runtime_permissions() to also
+# skip the permission dialogs. Requires an app built at or after that PR.
+EXTRA_SKIP_ONBOARDING = "skip_onboarding"
+
+# Runtime permissions the app requests during onboarding. Pre-granting them with
+# `pm grant` (native Android, no app code) pre-accepts the permission dialogs so a
+# fresh-install automation run lands straight on the main screen. POST_NOTIFICATIONS
+# is API 33+ (a no-op / error on older devices — grant is best-effort).
+ONBOARDING_PERMISSIONS = (
+    "android.permission.BLUETOOTH_SCAN",
+    "android.permission.BLUETOOTH_CONNECT",
+    "android.permission.ACCESS_FINE_LOCATION",
+    "android.permission.POST_NOTIFICATIONS",
+)
 
 
 class EmulatorError(RuntimeError):
@@ -339,6 +363,75 @@ def resolve_package(serial: str | None = None) -> str | None:
         if is_app_installed(pkg, serial=serial):
             return pkg
     return None
+
+
+# ---------------------------------------------------------------------------
+# Fresh-install launch (skip onboarding + pre-grant permissions)
+# ---------------------------------------------------------------------------
+def grant_runtime_permissions(
+    package: str | None = None,
+    *,
+    serial: str | None = None,
+    permissions: Sequence[str] = ONBOARDING_PERMISSIONS,
+) -> None:
+    """Pre-grant the app's runtime permissions via `pm grant` (native, no app code).
+
+    Pre-accepts the permission dialogs the app would otherwise raise during
+    onboarding, so a fresh-install automation run isn't blocked on them. Each
+    grant is best-effort (check=False): POST_NOTIFICATIONS only exists on API
+    33+, and a permission the manifest doesn't declare errors out — neither
+    should abort the rest. Pairs with `launch_app(skip_onboarding=True)`.
+    """
+    pkg = package or resolve_package(serial=serial)
+    if not pkg:
+        return
+    for perm in permissions:
+        adb("shell", "pm", "grant", pkg, perm, serial=serial, check=False)
+
+
+def launch_app(
+    package: str | None = None,
+    *,
+    serial: str | None = None,
+    skip_onboarding: bool = False,
+    activity: str = MAIN_ACTIVITY,
+) -> None:
+    """Launch the app's main activity via `am start -n <pkg>/<activity>`.
+
+    `skip_onboarding=True` adds the debug-only `--ez skip_onboarding true` extra
+    (Meshtastic-Android#6044), which calls onAppIntroCompleted() so a fresh
+    install lands straight on the main Connection screen instead of the intro
+    flow. That extra is BuildConfig.DEBUG-gated in the app — a harmless no-op on
+    release/Play builds or on app versions predating the PR (they just show the
+    intro, and the UI-tap 'Skip' fallback in connect_app_to_tcp still handles
+    it). Pre-grant the permission dialogs with grant_runtime_permissions() for a
+    fully hands-free fresh-install bring-up.
+    """
+    pkg = package or resolve_package(serial=serial)
+    if not pkg:
+        raise EmulatorError("no Meshtastic app installed to launch (see resolve_package)")
+    args = ["shell", "am", "start", "-n", f"{pkg}/{activity}"]
+    if skip_onboarding:
+        args += ["--ez", EXTRA_SKIP_ONBOARDING, "true"]
+    adb(*args, serial=serial, check=False)
+
+
+def prepare_fresh_install(
+    package: str | None = None,
+    *,
+    serial: str | None = None,
+) -> None:
+    """One call to make a freshly-installed app automation-ready.
+
+    Pre-grants runtime permissions, then launches skipping onboarding — the
+    hands-free equivalent of clicking through the intro + accepting every
+    permission dialog. After this, drive the app normally (e.g.
+    connect_app_to_tcp / deeplink). Both steps are best-effort and degrade
+    gracefully on app builds predating Meshtastic-Android#6044 (the UI-tap
+    onboarding-skip in connect_app_to_tcp remains the fallback).
+    """
+    grant_runtime_permissions(package, serial=serial)
+    launch_app(package, serial=serial, skip_onboarding=True)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_avd_physical.py
+++ b/tests/unit/test_avd_physical.py
@@ -54,6 +54,28 @@ def test_parse_uiautomator_malformed_raises():
         avd._parse_uiautomator_xml("<hierarchy><node bounds=")
 
 
+def test_ui_dump_physical_strips_trailing_status_line(monkeypatch):
+    # Regression (found live 2026-07-01 against a Pixel 6a / Android 17): some
+    # uiautomator versions append "UI hierchary dumped to: /dev/tty" *after*
+    # </hierarchy> on the same line with no separating newline, which used to
+    # blow up ET.fromstring with "junk after document element" and break every
+    # UI-tree-dependent helper on physical devices.
+    raw = (
+        '<?xml version="1.0" encoding="UTF-8"?><hierarchy rotation="0">'
+        '<node text="Disconnect" clickable="true" bounds="[0,0][200,60]"/>'
+        "</hierarchy>UI hierchary dumped to: /dev/tty\n"
+    )
+    monkeypatch.setattr(avd, "adb", lambda *a, **k: _cp_stdout(raw))
+    els = avd._ui_dump_physical("R5CT80ABCDE")
+    assert any(e["text"] == "Disconnect" for e in els)
+
+
+def _cp_stdout(stdout: str):
+    import subprocess
+
+    return subprocess.CompletedProcess(args=[], returncode=0, stdout=stdout, stderr="")
+
+
 def test_tcp_dut_address_emulator_uses_host_alias():
     assert avd.tcp_dut_address(4403, serial="emulator-5554") == "10.0.2.2:4403"
     assert avd.tcp_dut_address(4403) == "10.0.2.2:4403"  # no serial → emulator default

--- a/tests/unit/test_emulator_avd.py
+++ b/tests/unit/test_emulator_avd.py
@@ -52,3 +52,92 @@ def test_find_text(monkeypatch) -> None:
     monkeypatch.setattr(avd, "android", lambda *a, **k: _cp('[{"text": "E2E-123"}]'))
     assert avd.find_text("E2E-123") is True
     assert avd.find_text("nope") is False
+
+
+# ---------------------------------------------------------------------------
+# Deep links (meshtastic/Meshtastic-Android#6036, connect-by-address)
+# ---------------------------------------------------------------------------
+def test_resolve_package_prefers_fdroid_debug(monkeypatch) -> None:
+    installed = {"com.geeksville.mesh.fdroid.debug", "com.geeksville.mesh"}
+    monkeypatch.setattr(avd, "is_app_installed", lambda pkg, serial=None: pkg in installed)
+    assert avd.resolve_package() == "com.geeksville.mesh.fdroid.debug"
+
+
+def test_resolve_package_none_when_nothing_installed(monkeypatch) -> None:
+    monkeypatch.setattr(avd, "is_app_installed", lambda pkg, serial=None: False)
+    assert avd.resolve_package() is None
+
+
+def test_deeplink_fires_am_start_with_resolved_package(monkeypatch) -> None:
+    calls = []
+    monkeypatch.setattr(
+        avd, "resolve_package", lambda serial=None: "com.geeksville.mesh.fdroid.debug"
+    )
+    monkeypatch.setattr(avd, "adb", lambda *a, **k: calls.append(a) or _cp(""))
+    avd.deeplink("connections?address=t192.168.1.1:4403")
+    assert len(calls) == 1
+    args = calls[0]
+    assert args[0:4] == ("shell", "am", "start", "-a")
+    assert "android.intent.action.VIEW" in args
+    assert any(a == "meshtastic://meshtastic/connections?address=t192.168.1.1:4403" for a in args)
+    assert args[-1] == "com.geeksville.mesh.fdroid.debug"  # explicit package targets the intent
+
+
+def test_connect_app_via_deeplink_builds_correct_uri(monkeypatch) -> None:
+    seen = {}
+    monkeypatch.setattr(
+        avd, "deeplink", lambda path, serial=None, package=None: seen.update(path=path)
+    )
+    avd.connect_app_via_deeplink("t192.168.1.168:4403")
+    assert seen["path"] == "connections?address=t192.168.1.168:4403"
+
+
+def test_disconnect_app_via_deeplink_uses_sentinel(monkeypatch) -> None:
+    seen = {}
+    monkeypatch.setattr(
+        avd, "deeplink", lambda path, serial=None, package=None: seen.update(path=path)
+    )
+    avd.disconnect_app_via_deeplink()
+    assert seen["path"] == f"connections?address={avd.NO_DEVICE_SELECTED}"
+    assert avd.NO_DEVICE_SELECTED == "n"
+
+
+def test_connect_app_to_tcp_deeplink_fast_path_confirms(monkeypatch) -> None:
+    # "Not connected" is present for the first 2 polls, then clears -> success
+    # without ever falling through to the legacy UI-tap flow.
+    calls = {"deeplink": 0, "tap": 0, "find_text": 0}
+
+    def _find_text(token, serial=None):
+        calls["find_text"] += 1
+        return calls["find_text"] <= 2
+
+    monkeypatch.setattr(
+        avd,
+        "connect_app_via_deeplink",
+        lambda addr, serial=None: calls.__setitem__("deeplink", calls["deeplink"] + 1),
+    )
+    monkeypatch.setattr(avd, "find_text", _find_text)
+    monkeypatch.setattr(
+        avd, "_tap_text", lambda *a, **k: calls.__setitem__("tap", calls["tap"] + 1) or True
+    )
+    monkeypatch.setattr(avd.time, "sleep", lambda s: None)  # don't actually wait in a unit test
+
+    ok = avd.connect_app_to_tcp(host="192.168.1.168", port=4403, confirm_timeout_s=5.0)
+    assert ok is True
+    assert calls["deeplink"] == 1
+    assert calls["tap"] == 0  # never fell through to the UI-tap fallback
+
+
+def test_connect_app_to_tcp_falls_back_to_ui_taps_when_deeplink_never_confirms(monkeypatch) -> None:
+    # "Not connected" never clears within the confirm window -> falls through to
+    # the legacy UI-tap flow (covers app builds predating the deep link).
+    monkeypatch.setattr(avd, "connect_app_via_deeplink", lambda addr, serial=None: None)
+    monkeypatch.setattr(avd, "find_text", lambda token, serial=None: True)  # always "Not connected"
+    monkeypatch.setattr(avd, "_tap_text", lambda *a, **k: False)  # "Skip" not found -> loop exits
+    monkeypatch.setattr(
+        avd, "_find_center", lambda *a, **k: None
+    )  # "Add device manually" not found
+    monkeypatch.setattr(avd.time, "sleep", lambda s: None)
+
+    ok = avd.connect_app_to_tcp(host="192.168.1.168", port=4403, confirm_timeout_s=0.01)
+    assert ok is False  # UI-tap flow ran but "Add device manually" was never found

--- a/tests/unit/test_emulator_avd.py
+++ b/tests/unit/test_emulator_avd.py
@@ -7,6 +7,8 @@ from __future__ import annotations
 
 import subprocess
 
+import pytest
+
 from meshtastic_mcp.emulator import avd
 
 
@@ -52,6 +54,78 @@ def test_find_text(monkeypatch) -> None:
     monkeypatch.setattr(avd, "android", lambda *a, **k: _cp('[{"text": "E2E-123"}]'))
     assert avd.find_text("E2E-123") is True
     assert avd.find_text("nope") is False
+
+
+# ---------------------------------------------------------------------------
+# Fresh-install launch (meshtastic/Meshtastic-Android#6044, skip_onboarding)
+# ---------------------------------------------------------------------------
+def test_grant_runtime_permissions_grants_full_set(monkeypatch) -> None:
+    calls = []
+    monkeypatch.setattr(
+        avd, "resolve_package", lambda serial=None: "com.geeksville.mesh.fdroid.debug"
+    )
+    monkeypatch.setattr(avd, "adb", lambda *a, **k: calls.append(a) or _cp(""))
+    avd.grant_runtime_permissions()
+    granted = [a[-1] for a in calls]
+    assert granted == list(avd.ONBOARDING_PERMISSIONS)
+    assert all(a[0:3] == ("shell", "pm", "grant") for a in calls)
+    # package is the 4th token: pm grant <pkg> <perm>
+    assert all(a[3] == "com.geeksville.mesh.fdroid.debug" for a in calls)
+
+
+def test_grant_runtime_permissions_noop_when_no_package(monkeypatch) -> None:
+    calls = []
+    monkeypatch.setattr(avd, "resolve_package", lambda serial=None: None)
+    monkeypatch.setattr(avd, "adb", lambda *a, **k: calls.append(a) or _cp(""))
+    avd.grant_runtime_permissions()
+    assert calls == []  # nothing to grant against
+
+
+def test_launch_app_with_skip_onboarding_adds_extra(monkeypatch) -> None:
+    calls = []
+    monkeypatch.setattr(
+        avd, "resolve_package", lambda serial=None: "com.geeksville.mesh.fdroid.debug"
+    )
+    monkeypatch.setattr(avd, "adb", lambda *a, **k: calls.append(a) or _cp(""))
+    avd.launch_app(skip_onboarding=True)
+    assert len(calls) == 1
+    args = calls[0]
+    assert args[0:4] == ("shell", "am", "start", "-n")
+    assert args[4] == f"com.geeksville.mesh.fdroid.debug/{avd.MAIN_ACTIVITY}"
+    assert "--ez" in args
+    assert args[-2:] == (avd.EXTRA_SKIP_ONBOARDING, "true")
+
+
+def test_launch_app_without_skip_omits_extra(monkeypatch) -> None:
+    calls = []
+    monkeypatch.setattr(
+        avd, "resolve_package", lambda serial=None: "com.geeksville.mesh.fdroid.debug"
+    )
+    monkeypatch.setattr(avd, "adb", lambda *a, **k: calls.append(a) or _cp(""))
+    avd.launch_app()
+    assert avd.EXTRA_SKIP_ONBOARDING not in calls[0]
+
+
+def test_launch_app_raises_when_no_package(monkeypatch) -> None:
+    monkeypatch.setattr(avd, "resolve_package", lambda serial=None: None)
+    with pytest.raises(avd.EmulatorError):
+        avd.launch_app()
+
+
+def test_prepare_fresh_install_grants_then_launches(monkeypatch) -> None:
+    order = []
+    monkeypatch.setattr(
+        avd, "grant_runtime_permissions", lambda pkg=None, serial=None: order.append("grant")
+    )
+    monkeypatch.setattr(
+        avd,
+        "launch_app",
+        lambda pkg=None, serial=None, skip_onboarding=False, **k: order.append(
+            ("launch", skip_onboarding)
+        ),
+    )
+    avd.prepare_fresh_install()
+    assert order == ["grant", ("launch", True)]  # permissions first, then skip-onboarding launch
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

[meshtastic/Meshtastic-Android#6036](https://github.com/meshtastic/Meshtastic-Android/pull/6036) (merged 2026-07-01) added a `/connections?address=` deep link specifically so automation could trigger a device connection without walking the UI. This wires the MCP emulator helper to use it.

## Added

- `resolve_package()` — find whichever applicationId variant is installed (fdroid/google × debug/release)
- `deeplink()` — fire any `meshtastic://meshtastic/{path}` via `adb am start`
- `connect_app_via_deeplink()` / `disconnect_app_via_deeplink()` — the connect-by-address deep link and its `n` disconnect sentinel

`connect_app_to_tcp()` now tries the deep link first (`prefer_deeplink=True`, default): one `adb` call, no UI-tree parsing, works even mid-onboarding, version-resilient to layout churn. Falls back to the old UI-tap sequence only if the connect isn't confirmed within `confirm_timeout_s` (covers app builds predating the deep link).

## Notable behavior changes / findings (verified live on a Pixel 6a)

- Confirmation now polls for the **absence of "Not connected"** rather than the presence of "Disconnect" — the latter is a bad signal (that button label shows regardless of connection state).
- `confirm_timeout_s` defaults to a generous 20s, decoupled from the UI-animation-scale `settle_s`, since a real TCP handshake + NodeDB download visibly takes 10–30s+ on hardware.
- `force_reconnect` disconnect-then-connect for a guaranteed fresh handshake — the app retries a configured address indefinitely on its own, so re-firing `?address=` with the same value can be a Compose no-op (`LaunchedEffect(key.address)` doesn't restart for an unchanged key).

## Also fixes

`_ui_dump_physical()` crashed with `junk after document element` because some `uiautomator` versions (observed on a Pixel 6a / Android 17) append their status line **after** `</hierarchy>` on the same line with no separating newline. The old code only stripped a leading prefix before `<?xml>`/`<hierarchy>`; it never trimmed anything after the closing tag — silently breaking every UI-tree-dependent helper on affected physical devices. Fixed by truncating at the true end of the document before parsing.

## Tests

New coverage for `resolve_package`, the deep-link builders, the fast-path/fallback branches, and the trailing-junk XML fix. Full suite green; `ruff`/`mypy` clean.

## Scope

`emulator/avd.py` + its two test files, disjoint from the other branches opened alongside — mergeable in any order.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added deep-link based app connect/disconnect for Meshtastic addresses, including automatic package resolution for supported app variants.
  * Enhanced connection workflow with optional deep-link preference, confirmation polling, and reconnection controls.
  * Added helpers for launching apps with optional onboarding skipping and granting runtime permissions for a fresh install.
* **Bug Fixes**
  * Improved resilience of physical-device UI XML parsing by safely truncating trailing status text after the hierarchy ends.
* **Tests**
  * Added regression coverage for UI dump parsing and unit tests for deep-link, permission grant, app launch, and TCP connection control flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->