### PR TITLE
feat(sdr): RF-compliance oracle via RTL-SDR (rf_scan / rf_confirm_tx)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,11 @@ ui = [
   "rich-pixels>=3.0",
 ]
 ui-min = ["opencv-python-headless>=4.9", "numpy>=1.26"]
+# The `sdr` capability is the RF-compliance oracle (rf_scan/rf_confirm_tx): captures
+# raw IQ from an RTL-SDR and checks it against lora_compliance's prediction of what
+# the device's configured region/preset should produce on air. Also needs librtlsdr
+# on the system (not pip-installable) — e.g. `apt install librtlsdr-dev rtl-sdr`.
+sdr = ["pyrtlsdr>=0.3", "numpy>=1.26"]
 # The `firmware` capability needs a Meshtastic firmware checkout + PlatformIO `pio`
 # on PATH (not pip-installable) — set MESHTASTIC_FIRMWARE_ROOT.
 # The `emulator` capability needs the `android` CLI + `adb` on PATH (not pip-installable).

--- a/src/meshtastic_mcp/capabilities.py
+++ b/src/meshtastic_mcp/capabilities.py
@@ -51,6 +51,23 @@ def has_apple() -> bool:
     return shutil.which("xcrun") is not None
 
 
+def has_sdr() -> bool:
+    """True when `pyrtlsdr` is importable and at least one RTL-SDR is attached.
+
+    Gates the RF-compliance oracle tools (`rf_scan`, `rf_confirm_tx`): an
+    independent on-air check of a device's configured region/preset/frequency
+    against what it actually transmits. Needs the ``sdr`` extra
+    (``pip install 'meshtastic-mcp[sdr]'``) plus ``librtlsdr`` on the system
+    (e.g. ``apt install librtlsdr-dev rtl-sdr``).
+    """
+    from . import sdr
+
+    try:
+        return len(sdr.list_devices()) > 0
+    except sdr.SdrError:
+        return False
+
+
 def has_local_model() -> bool:
     """True when a local Ollama instance is reachable (offload tools are usable).
 
@@ -81,6 +98,7 @@ class Capabilities:
     apple: bool
     local_model: bool
     llama_server: bool
+    sdr: bool
 
     def summary(self) -> str:
         active = [
@@ -92,6 +110,7 @@ class Capabilities:
                 ("apple", self.apple),
                 ("local_model", self.local_model),
                 ("llama_server", self.llama_server),
+                ("sdr", self.sdr),
             )
             if on
         ]
@@ -106,4 +125,5 @@ def detect() -> Capabilities:
         apple=has_apple(),
         local_model=has_local_model(),
         llama_server=has_llama_server(),
+        sdr=has_sdr(),
     )

--- a/src/meshtastic_mcp/doctor.py
+++ b/src/meshtastic_mcp/doctor.py
@@ -173,6 +173,57 @@ def _firmware_check() -> Check:
     )
 
 
+def _sdr_check() -> Check:
+    """RF-compliance oracle (`rf_scan`/`rf_confirm_tx`): needs `pyrtlsdr` importable
+    (the `sdr` extra) *and* librtlsdr on the system *and* an RTL-SDR attached.
+    Reports the most specific missing piece rather than a generic "not available".
+    """
+    from . import sdr as sdr_mod
+
+    try:
+        from rtlsdr import RtlSdr  # noqa: F401
+    except ImportError:
+        return Check(
+            "pyrtlsdr",
+            "sdr",
+            STATUS_MISSING,
+            "RF-compliance oracle (rf_scan / rf_confirm_tx)",
+            detail="pyrtlsdr not importable",
+            fix="pip install 'meshtastic-mcp[sdr]'  # also needs librtlsdr: "
+            + _pkg("brew install librtlsdr", "apt install librtlsdr-dev rtl-sdr"),
+        )
+    try:
+        devices = sdr_mod.list_devices()
+    except sdr_mod.SdrError as exc:
+        return Check(
+            "rtl-sdr-device",
+            "sdr",
+            STATUS_MISSING,
+            "RF-compliance oracle (rf_scan / rf_confirm_tx)",
+            detail=str(exc),
+            fix=_pkg(
+                "brew install librtlsdr",
+                "apt install librtlsdr-dev rtl-sdr  # then plug in an RTL-SDR",
+            ),
+        )
+    if not devices:
+        return Check(
+            "rtl-sdr-device",
+            "sdr",
+            STATUS_MISSING,
+            "RF-compliance oracle (rf_scan / rf_confirm_tx)",
+            detail="pyrtlsdr + librtlsdr present, but no RTL-SDR attached",
+            fix="plug in an RTL-SDR (e.g. a NooElec NESDR) and retry",
+        )
+    return Check(
+        "rtl-sdr-device",
+        "sdr",
+        STATUS_OK,
+        "RF-compliance oracle (rf_scan / rf_confirm_tx)",
+        detail=f"{len(devices)} device(s): {', '.join(devices)}",
+    )
+
+
 def _pio_check() -> Check:
     try:
         path = config.pio_bin()
@@ -525,6 +576,8 @@ def run() -> DoctorReport:
             "meshtastic-org-knowledge skill — repo/issue/PR/release queries via gh CLI",
             _pkg("brew install gh", "apt install gh  # or: https://cli.github.com"),
         ),
+        # sdr capability (RF compliance oracle)
+        _sdr_check(),
     ]
     return DoctorReport(
         platform=f"{platform.system()} {platform.machine()} / Python {platform.python_version()}",

--- a/src/meshtastic_mcp/lora_compliance.py
+++ b/src/meshtastic_mcp/lora_compliance.py
@@ -1,0 +1,337 @@
+# SPDX-FileCopyrightText: Meshtastic contributors
+# SPDX-License-Identifier: GPL-3.0-only
+
+"""Faithful Python port of firmware's region/preset → RF-parameter resolution.
+
+This is the "ground truth" half of the SDR compliance oracle (`sdr.py` is the
+measurement half): given the *configured* LoRa settings a device reports over
+admin (region, modem preset, channel name/number, frequency override/offset),
+predict the exact center frequency, bandwidth, spreading factor, coding rate,
+and the regulatory duty-cycle/power limits firmware itself would compute and
+apply. `rf_confirm_tx` (server.py) compares this prediction against what an
+SDR actually observes on air — an independent check that the radio is doing
+what its own config says it should, not just what it self-reports.
+
+Every table and formula here is transcribed from the firmware source it
+mirrors, with file:line citations, so it can be re-synced when upstream
+changes. Source: `meshtastic/firmware` (checkout used: $MESHTASTIC_FIRMWARE_ROOT
+when set, else verify manually before trusting for new regions/presets):
+
+  - Region table (freq band, duty cycle, power limit, profile, override slot):
+    `src/mesh/RadioInterface.cpp` — `const RegionInfo regions[]`
+  - Region profile table (channel spacing/padding):
+    `src/mesh/RadioInterface.cpp` — `PROFILE_STD` / `PROFILE_EU868` / ...
+  - Modem preset → bandwidth/SF/CR:
+    `src/mesh/MeshRadio.h` — `modemPresetToParams()`
+  - Channel name hash (djb2) and frequency-slot formula:
+    `src/mesh/RadioInterface.cpp` — `hash()` and `applyModemConfig()`
+  - Per-role duty cycle override (EU_866 router vs. mobile):
+    `src/mesh/RadioInterface.cpp` — `getEffectiveDutyCycle()`
+  - Modem preset display names (used as the default channel name when the
+    primary channel has no custom name — this is what gets hashed):
+    `src/DisplayFormatters.cpp` — `getModemPresetDisplayName()`
+
+Deliberately NOT ported: PSK-based channel hash (`Channels::generateHash`,
+used only for the on-air channel-routing byte, not frequency selection) and
+the full `checkOrClampConfigLora` validation/clamping path — we predict for
+already-valid configs as reported by a live device's admin/config readback,
+we don't need to re-validate them.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+# ---------------------------------------------------------------------------
+# Modem presets — src/mesh/MeshRadio.h: modemPresetToParams()
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class PresetParams:
+    bw_khz: float
+    bw_khz_wide: float  # `wideLora` regions (2.4GHz, SX128x) use a scaled bandwidth instead
+    sf: int
+    cr: int
+
+
+# Keys are the modem_preset enum names as used in the Config protobuf
+# (`meshtastic.Config.LoRaConfig.ModemPreset`).
+PRESETS: dict[str, PresetParams] = {
+    "SHORT_TURBO": PresetParams(500.0, 1625.0, sf=7, cr=5),
+    "SHORT_FAST": PresetParams(250.0, 812.5, sf=7, cr=5),
+    "SHORT_SLOW": PresetParams(250.0, 812.5, sf=8, cr=5),
+    "MEDIUM_FAST": PresetParams(250.0, 812.5, sf=9, cr=5),
+    "MEDIUM_SLOW": PresetParams(250.0, 812.5, sf=10, cr=5),
+    "LONG_TURBO": PresetParams(500.0, 1625.0, sf=11, cr=8),
+    "LONG_MODERATE": PresetParams(125.0, 406.25, sf=11, cr=8),
+    "LONG_FAST": PresetParams(250.0, 812.5, sf=11, cr=5),
+    "LONG_SLOW": PresetParams(125.0, 406.25, sf=12, cr=8),
+    "LITE_FAST": PresetParams(125.0, 125.0, sf=9, cr=5),
+    "LITE_SLOW": PresetParams(125.0, 125.0, sf=10, cr=5),
+    "NARROW_FAST": PresetParams(62.5, 62.5, sf=7, cr=6),
+    "NARROW_SLOW": PresetParams(62.5, 62.5, sf=8, cr=6),
+    "TINY_FAST": PresetParams(15.6, 15.6, sf=7, cr=5),
+    "TINY_SLOW": PresetParams(15.6, 15.6, sf=8, cr=6),
+}
+
+# DisplayFormatters::getModemPresetDisplayName(preset, useShortName=false, usePreset=true)
+# This is the string that becomes the *default* channel name (and therefore
+# what gets hashed for frequency-slot selection) when the primary channel has
+# no custom name set — i.e. almost every out-of-the-box device.
+PRESET_DISPLAY_NAME: dict[str, str] = {
+    "SHORT_TURBO": "ShortTurbo",
+    "SHORT_SLOW": "ShortSlow",
+    "SHORT_FAST": "ShortFast",
+    "MEDIUM_SLOW": "MediumSlow",
+    "MEDIUM_FAST": "MediumFast",
+    "LONG_SLOW": "LongSlow",
+    "LONG_FAST": "LongFast",
+    "LONG_TURBO": "LongTurbo",
+    "LONG_MODERATE": "LongMod",
+    "LITE_FAST": "LiteFast",
+    "LITE_SLOW": "LiteSlow",
+    "NARROW_FAST": "NarrowFast",
+    "NARROW_SLOW": "NarrowSlow",
+    "TINY_FAST": "TinyFast",
+    "TINY_SLOW": "TinySlow",
+}
+
+# ---------------------------------------------------------------------------
+# Region profiles — src/mesh/RadioInterface.cpp: PROFILE_* (spacing, padding)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class RegionProfile:
+    spacing_mhz: float
+    padding_mhz: float
+
+
+PROFILE_STD = RegionProfile(0.0, 0.0)
+PROFILE_EU868 = RegionProfile(0.0, 0.0)
+PROFILE_UNDEF = RegionProfile(0.0, 0.0)
+PROFILE_LITE = RegionProfile(0.4, 0.0375)
+PROFILE_NARROW = RegionProfile(0.0, 0.0104)
+PROFILE_HAM_20KHZ = RegionProfile(0.0, 0.0022)
+PROFILE_HAM_100KHZ = RegionProfile(0.0, 0.01875)
+
+# ---------------------------------------------------------------------------
+# Region table — src/mesh/RadioInterface.cpp: const RegionInfo regions[]
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class RegionInfo:
+    freq_start_mhz: float
+    freq_end_mhz: float
+    duty_cycle_pct: float  # 100 == no regulatory duty-cycle limit (still LBT-gated by firmware)
+    power_limit_dbm: int
+    freq_switching: bool
+    wide_lora: bool
+    profile: RegionProfile
+    default_preset: str
+    # 0 = channel-name hash (default), -1 = preset-name hash, >0 = explicit 1-based slot
+    override_slot: int
+
+
+REGIONS: dict[str, RegionInfo] = {
+    "US": RegionInfo(902.0, 928.0, 100, 30, False, False, PROFILE_STD, "LONG_FAST", 0),
+    "EU_433": RegionInfo(433.0, 434.0, 10, 10, False, False, PROFILE_STD, "LONG_FAST", 0),
+    "EU_868": RegionInfo(869.4, 869.65, 10, 27, False, False, PROFILE_EU868, "LONG_FAST", 0),
+    "EU_866": RegionInfo(865.6, 867.6, 2.5, 27, False, False, PROFILE_LITE, "LITE_FAST", 0),
+    "EU_N_868": RegionInfo(869.4, 869.65, 10, 27, False, False, PROFILE_NARROW, "NARROW_SLOW", 1),
+    "CN": RegionInfo(470.0, 510.0, 100, 19, False, False, PROFILE_STD, "LONG_FAST", 0),
+    "JP": RegionInfo(920.5, 923.5, 100, 13, False, False, PROFILE_STD, "LONG_FAST", 0),
+    "ANZ": RegionInfo(915.0, 928.0, 100, 30, False, False, PROFILE_STD, "LONG_FAST", 0),
+    "ANZ_433": RegionInfo(433.05, 434.79, 100, 14, False, False, PROFILE_STD, "LONG_FAST", 0),
+    "RU": RegionInfo(868.7, 869.2, 100, 20, False, False, PROFILE_STD, "LONG_FAST", 0),
+    "KR": RegionInfo(920.0, 923.0, 100, 23, False, False, PROFILE_STD, "LONG_FAST", 0),
+    "TW": RegionInfo(920.0, 925.0, 100, 27, False, False, PROFILE_STD, "LONG_FAST", 0),
+    "IN": RegionInfo(865.0, 867.0, 100, 30, False, False, PROFILE_STD, "LONG_FAST", 0),
+    "NZ_865": RegionInfo(864.0, 868.0, 100, 36, False, False, PROFILE_STD, "LONG_FAST", 0),
+    "TH": RegionInfo(920.0, 925.0, 10, 27, False, False, PROFILE_STD, "LONG_FAST", 0),
+    "UA_433": RegionInfo(433.0, 434.7, 10, 10, False, False, PROFILE_STD, "LONG_FAST", 0),
+    "UA_868": RegionInfo(868.0, 868.6, 1, 14, False, False, PROFILE_STD, "LONG_FAST", 0),
+    "MY_433": RegionInfo(433.0, 435.0, 100, 20, False, False, PROFILE_STD, "LONG_FAST", 0),
+    "MY_919": RegionInfo(919.0, 924.0, 100, 27, True, False, PROFILE_STD, "LONG_FAST", 0),
+    "SG_923": RegionInfo(917.0, 925.0, 100, 20, False, False, PROFILE_STD, "LONG_FAST", 0),
+    "PH_433": RegionInfo(433.0, 434.7, 100, 10, False, False, PROFILE_STD, "LONG_FAST", 0),
+    "PH_868": RegionInfo(868.0, 869.4, 100, 14, False, False, PROFILE_STD, "LONG_FAST", 0),
+    "PH_915": RegionInfo(915.0, 918.0, 100, 24, False, False, PROFILE_STD, "LONG_FAST", 0),
+    "KZ_433": RegionInfo(433.075, 434.775, 100, 10, False, False, PROFILE_STD, "LONG_FAST", 0),
+    "KZ_863": RegionInfo(863.0, 868.0, 100, 30, False, False, PROFILE_STD, "LONG_FAST", 0),
+    "NP_865": RegionInfo(865.0, 868.0, 100, 30, False, False, PROFILE_STD, "LONG_FAST", 0),
+    "BR_902": RegionInfo(902.0, 907.5, 100, 30, False, False, PROFILE_STD, "LONG_FAST", 0),
+    "ITU1_2M": RegionInfo(144.0, 146.0, 100, 30, False, False, PROFILE_HAM_20KHZ, "TINY_FAST", 26),
+    "ITU2_2M": RegionInfo(144.0, 148.0, 100, 30, False, False, PROFILE_HAM_20KHZ, "TINY_FAST", 51),
+    "ITU3_2M": RegionInfo(144.0, 148.0, 100, 30, False, False, PROFILE_HAM_20KHZ, "TINY_FAST", 33),
+    "ITU2_125CM": RegionInfo(
+        220.0, 225.0, 100, 30, False, False, PROFILE_HAM_100KHZ, "NARROW_SLOW", 37
+    ),
+    "LORA_24": RegionInfo(2400.0, 2483.5, 100, 10, False, True, PROFILE_STD, "LONG_FAST", 0),
+    # "This needs to be last. Same as US." (also the array sentinel in firmware) — kept here for
+    # completeness/lookup only; not meaningfully different from a real default-region prediction.
+    "UNSET": RegionInfo(902.0, 928.0, 100, 30, False, False, PROFILE_UNDEF, "LONG_FAST", 0),
+}
+
+_OVERRIDE_SLOT_CHANNEL_HASH = 0
+_OVERRIDE_SLOT_PRESET_HASH = -1
+
+
+def djb2_hash(s: str) -> int:
+    """Port of `src/mesh/RadioInterface.cpp: uint32_t hash(const char *str)`.
+
+    Bernstein djb2, computed with native firmware semantics: `uint32_t` 32-bit
+    wraparound on overflow (C's defined unsigned-int behavior).
+    """
+    h = 5381
+    for ch in s:
+        h = ((h << 5) + h + ord(ch)) & 0xFFFFFFFF
+    return h
+
+
+@dataclass(frozen=True)
+class PredictedRf:
+    """What firmware's `applyModemConfig()` would compute for these settings."""
+
+    region: str
+    freq_mhz: float
+    bw_khz: float
+    sf: int
+    cr: int
+    channel_num: int  # 0-based "frequency slot", as actually used on air
+    num_freq_slots: int
+    duty_cycle_pct: float
+    power_limit_dbm: int
+    wide_lora: bool
+
+
+def predict_lora_params(
+    region: str,
+    modem_preset: str,
+    *,
+    channel_name: str = "",
+    channel_num: int = 0,
+    use_preset: bool = True,
+    bandwidth_khz: float | None = None,
+    spread_factor: int | None = None,
+    coding_rate: int | None = None,
+    override_frequency_mhz: float = 0.0,
+    frequency_offset_mhz: float = 0.0,
+    device_role: str = "CLIENT",
+) -> PredictedRf:
+    """Predict the on-air center frequency/BW/SF/CR/duty-cycle for a device's
+    *configured* LoRa settings, mirroring `RadioInterface::applyModemConfig()`.
+
+    Args mirror the admin-readable `Config.LoRaConfig` fields directly: read
+    them off a live device (`device_info()` / `get_config()`) and pass them
+    straight through. `channel_name` is the *primary* channel's name (empty
+    string if unset — matches firmware's "no custom name" case and falls back
+    to the preset display name for hashing, exactly like real devices).
+
+    Raises ValueError for an unknown region/preset (rather than silently
+    guessing) — the region/preset tables above should be re-synced from
+    firmware if this fires for a name that's legitimately new upstream.
+    """
+    if region not in REGIONS:
+        raise ValueError(
+            f"Unknown Meshtastic region {region!r} "
+            "(region table may be stale — see module docstring)"
+        )
+    r = REGIONS[region]
+
+    if use_preset:
+        if modem_preset not in PRESETS:
+            raise ValueError(
+                f"Unknown modem preset {modem_preset!r} (table may be stale, see module docstring)"
+            )
+        p = PRESETS[modem_preset]
+        bw_khz = p.bw_khz_wide if r.wide_lora else p.bw_khz
+        sf = p.sf
+        cr = p.cr
+    else:
+        if bandwidth_khz is None or spread_factor is None or coding_rate is None:
+            raise ValueError("use_preset=False requires bandwidth_khz/spread_factor/coding_rate")
+        bw_khz, sf, cr = bandwidth_khz, spread_factor, coding_rate
+
+    # Effective duty cycle: EU_866 is role-dependent (getEffectiveDutyCycle()), all other
+    # regions just use the table value.
+    duty_cycle_pct = r.duty_cycle_pct
+    if region == "EU_866":
+        duty_cycle_pct = 10.0 if device_role in ("ROUTER", "ROUTER_LATE") else 2.5
+
+    # override_frequency wins outright — channel_num is meaningless in that mode.
+    if override_frequency_mhz:
+        freq = override_frequency_mhz + frequency_offset_mhz
+        return PredictedRf(
+            region=region,
+            freq_mhz=freq,
+            bw_khz=bw_khz,
+            sf=sf,
+            cr=cr,
+            channel_num=-1,
+            num_freq_slots=0,
+            duty_cycle_pct=duty_cycle_pct,
+            power_limit_dbm=r.power_limit_dbm,
+            wide_lora=r.wide_lora,
+        )
+
+    freq_slot_width_mhz = r.profile.spacing_mhz + (r.profile.padding_mhz * 2) + (bw_khz / 1000.0)
+    num_slots = round(
+        (r.freq_end_mhz - r.freq_start_mhz + r.profile.spacing_mhz) / freq_slot_width_mhz
+    )
+    if num_slots <= 0:
+        raise ValueError(f"{region}/{modem_preset}: {bw_khz}kHz bandwidth doesn't fit in the band")
+
+    effective_channel_name = channel_name or PRESET_DISPLAY_NAME.get(modem_preset, "Custom")
+    channel_name_hash_slot = djb2_hash(effective_channel_name) % num_slots
+    preset_name_hash_slot = djb2_hash(PRESET_DISPLAY_NAME.get(modem_preset, "Custom")) % num_slots
+
+    # channel_num == 0 is firmware's "unset, use the default slot" sentinel (1-based on the
+    # wire; applyModemConfig() treats this the same as "uses_default_frequency_slot").
+    if channel_num == 0:
+        if r.override_slot > 0:
+            resolved_slot = r.override_slot - 1
+        elif r.override_slot == _OVERRIDE_SLOT_PRESET_HASH:
+            resolved_slot = preset_name_hash_slot
+        else:
+            resolved_slot = channel_name_hash_slot
+    else:
+        resolved_slot = channel_num - 1
+
+    freq = r.freq_start_mhz + (bw_khz / 2000.0) + r.profile.padding_mhz
+    freq += resolved_slot * freq_slot_width_mhz
+    freq += frequency_offset_mhz
+
+    return PredictedRf(
+        region=region,
+        freq_mhz=freq,
+        bw_khz=bw_khz,
+        sf=sf,
+        cr=cr,
+        channel_num=resolved_slot,
+        num_freq_slots=num_slots,
+        duty_cycle_pct=duty_cycle_pct,
+        power_limit_dbm=r.power_limit_dbm,
+        wide_lora=r.wide_lora,
+    )
+
+
+def effective_power_limit_dbm(
+    region: str, configured_tx_power_dbm: int, *, is_licensed: bool = False
+) -> int:
+    """Port of the tx power clamp in `applyModemConfig()`:
+
+    if ((power == 0) || ((power > newRegion->powerLimit) && !is_licensed))
+        power = newRegion->powerLimit;
+    if (power == 0)
+        power = 17;
+    """
+    r = REGIONS[region]
+    power = configured_tx_power_dbm
+    if power == 0 or (power > r.power_limit_dbm and not is_licensed):
+        power = r.power_limit_dbm
+    if power == 0:
+        power = 17
+    return power

--- a/src/meshtastic_mcp/rf_oracle.py
+++ b/src/meshtastic_mcp/rf_oracle.py
@@ -1,0 +1,421 @@
+# SPDX-FileCopyrightText: Meshtastic contributors
+# SPDX-License-Identifier: GPL-3.0-only
+
+"""RF compliance oracle: cross-checks `lora_compliance` (prediction, from a live
+device's *configured* LoRa settings) against `sdr` (measurement, from an
+RTL-SDR capture) to answer "is the radio actually doing what its own config
+says it should" — independent of the device's self-reported packet log.
+
+The headline case this catches that nothing else in this repo can: firmware
+reports a packet sent (`send_text` returns ok) but no RF actually left the
+antenna — a disconnected antenna, a dead PA, a region/frequency
+miscalculation. `confirm_tx()` answers that by capturing IQ centered on the
+*predicted* frequency spanning the `send_text()` call and checking whether
+anything showed up on air at all, plus whether what did show up looks like
+it's in the right place (frequency, bandwidth, region).
+
+Note what this can't do: the recorder's packet log is NOT a usable
+cross-check for a self-originated broadcast. `meshtastic.MeshInterface`
+explicitly discards the local echo of a packet you just sent (firmware omits
+the redundant `from` field on that echo; the library detects the missing
+field and drops it rather than publishing a pubsub event) — see
+`confirm_tx`'s docstring. So `firmware_self_reported_tx` in the returned dict
+will be `False` for essentially every unacked broadcast regardless of whether
+the send worked; `measured.rf_observed` (the actual SDR evidence) is the
+signal to trust. A *second* Meshtastic device on the same channel, checked via
+its own recorder, is the real independent cross-check for that case — its
+receive event is never suppressed since `from` is genuinely populated there.
+
+This is a coarse dev-loop regression check, not a certified compliance
+measurement — see `sdr.py`'s module docstring for the calibration caveat.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from typing import Any
+
+import numpy as np
+from meshtastic.protobuf import channel_pb2
+
+from . import lora_compliance, sdr
+from .admin import _message_to_dict
+from .admin import send_text as _admin_send_text
+from .connection import connect
+from .log_query import packets_window
+
+
+class RfOracleError(RuntimeError):
+    pass
+
+
+# Typical RTL2832U + R820T/R820T2 tuner range. Caught here for a clear error
+# instead of an opaque librtlsdr failure deep inside capture_iq().
+_RTL_SDR_MIN_HZ = 24e6
+_RTL_SDR_MAX_HZ = 1_766e6
+
+_MAX_SAMPLE_RATE_HZ = 2_400_000.0  # RTL2832U's realistic sustained ceiling
+# Empirically, this NooElec/R820T2 unit throws LIBUSB_ERROR_OVERFLOW on the very first read
+# after retuning at sample rates near the bottom of librtlsdr's valid range (900kHz-~1.4MHz
+# reproduced; 2.048Msps reliable) — a known class of RTL-SDR/USB-controller flakiness at low
+# rates, not specific to this code. Every reachable Meshtastic preset (LORA_24/wideLora is the
+# only >500kHz case, and it's at 2.4GHz — already unreachable, see `_check_tunable`) fits
+# comfortably above this floor, so there's no reason for our own rate selection to go lower.
+_MIN_SAFE_SAMPLE_RATE_HZ = 2_048_000.0
+
+
+def read_lora_context(port: str | None = None) -> dict[str, Any]:
+    """One `connect()` round-trip: everything `lora_compliance.predict_lora_params`
+    needs, read straight off a live device — configured LoRa settings, device
+    role (for the EU_866 duty-cycle split), and the primary channel's name
+    (empty string if unset, matching firmware's own default-name fallback).
+    """
+    with connect(port=port) as iface:
+        node = iface.localNode
+        lora = _message_to_dict(node.localConfig.lora)
+        device = _message_to_dict(node.localConfig.device)
+        channels = list(node.channels or [])
+        primary = next((c for c in channels if c.role == channel_pb2.Channel.Role.PRIMARY), None)
+        channel_name = primary.settings.name if primary is not None else ""
+
+    return {
+        "region": lora.get("region", "UNSET"),
+        "modem_preset": lora.get("modem_preset", "LONG_FAST"),
+        "use_preset": lora.get("use_preset", True),
+        "bandwidth": lora.get("bandwidth") or None,
+        "spread_factor": lora.get("spread_factor") or None,
+        "coding_rate": lora.get("coding_rate") or None,
+        "channel_num": lora.get("channel_num", 0),
+        "override_frequency": lora.get("override_frequency", 0.0),
+        "frequency_offset": lora.get("frequency_offset", 0.0),
+        "tx_power": lora.get("tx_power", 0),
+        "device_role": device.get("role", "CLIENT"),
+        "channel_name": channel_name,
+    }
+
+
+def _predict_from_context(ctx: dict[str, Any]) -> lora_compliance.PredictedRf:
+    return lora_compliance.predict_lora_params(
+        ctx["region"],
+        ctx["modem_preset"],
+        channel_name=ctx["channel_name"],
+        channel_num=ctx["channel_num"],
+        use_preset=ctx["use_preset"],
+        bandwidth_khz=ctx["bandwidth"],
+        spread_factor=ctx["spread_factor"],
+        coding_rate=ctx["coding_rate"],
+        override_frequency_mhz=ctx["override_frequency"],
+        frequency_offset_mhz=ctx["frequency_offset"],
+        device_role=ctx["device_role"],
+    )
+
+
+def _check_tunable(freq_mhz: float) -> None:
+    hz = freq_mhz * 1e6
+    if not (_RTL_SDR_MIN_HZ <= hz <= _RTL_SDR_MAX_HZ):
+        raise RfOracleError(
+            f"Predicted frequency {freq_mhz:.3f} MHz is outside the RTL-SDR's typical tuner "
+            f"range ({_RTL_SDR_MIN_HZ / 1e6:.0f}-{_RTL_SDR_MAX_HZ / 1e6:.0f} MHz, R820T/R820T2) "
+            "— this region/preset can't be checked with an RTL-SDR. (LORA_24's 2.4GHz band "
+            "needs a different SDR.)"
+        )
+
+
+def _sample_rate_for_bw(bw_khz: float, requested_hz: float) -> float:
+    """Bump the sample rate up if it's too narrow to comfortably see the
+    predicted occupied bandwidth, capped at the RTL2832U's realistic ceiling.
+    """
+    minimum = max(bw_khz * 1000.0 * 1.5, _MIN_SAFE_SAMPLE_RATE_HZ)
+    if requested_hz >= minimum:
+        return requested_hz
+    return min(_MAX_SAMPLE_RATE_HZ, minimum)
+
+
+def _distance_to_window(window: sdr.ActiveWindow, offset_s: float) -> float:
+    if window.start_s <= offset_s <= window.end_s:
+        return 0.0
+    return min(abs(window.start_s - offset_s), abs(window.end_s - offset_s))
+
+
+def _min_plausible_burst_s(sf: int, bw_khz: float, *, min_preamble_symbols: int = 8) -> float:
+    """Floor duration below which an "active window" is noise, not a LoRa packet.
+
+    A LoRa symbol takes `2^sf / bw_hz` seconds; even the shortest real packet has
+    at least a several-symbol preamble before payload. High-gain RTL-SDR captures
+    reliably produce a forest of sub-millisecond noise spikes that clear a naive
+    power threshold (observed directly: ~40 spikes of ~0.125ms each in one 8s
+    capture) — those can't be LoRa (a single symbol alone is already tens of ms
+    at typical SF/BW), so filter them out before picking a match rather than
+    risk matching a noise spike that happens to land closer in time than the
+    real, much-longer burst.
+    """
+    symbol_time_s = (2**sf) / (bw_khz * 1000.0)
+    return symbol_time_s * min_preamble_symbols
+
+
+def _closest_window(
+    windows: list[sdr.ActiveWindow],
+    offset_s: float,
+    *,
+    max_distance_s: float,
+    min_duration_s: float = 0.0,
+) -> sdr.ActiveWindow | None:
+    """Pick the active window most likely to *be* the transmission triggered at
+    `offset_s` (seconds into the capture) — not just any RF activity in the
+    same multi-second window, which on a live mesh is often someone else's
+    packet (or, at high gain, electrical noise — see `_min_plausible_burst_s`).
+    `None` if nothing plausible is within `max_distance_s` of the send.
+    """
+    candidates = [w for w in windows if w.duration_s >= min_duration_s]
+    if not candidates:
+        return None
+    best = min(candidates, key=lambda w: _distance_to_window(w, offset_s))
+    return best if _distance_to_window(best, offset_s) <= max_distance_s else None
+
+
+def _slice_window(
+    iq: np.ndarray, sample_rate_hz: float, window: sdr.ActiveWindow, *, pad_s: float = 0.05
+) -> np.ndarray:
+    """IQ samples for one active window, with a small pad on each side (the
+    window-power detector's boundaries are coarse — `win_samples` granularity).
+    """
+    total_s = len(iq) / sample_rate_hz
+    start = max(0.0, window.start_s - pad_s)
+    end = min(total_s, window.end_s + pad_s)
+    return iq[int(start * sample_rate_hz) : int(end * sample_rate_hz)]
+
+
+def scan(
+    center_freq_hz: float,
+    *,
+    span_khz: float = 1000.0,
+    duration_s: float = 2.0,
+    gain: float | str = "auto",
+    device_index: int = 0,
+    db_down: float = 26.0,
+    active_threshold_db: float = 10.0,
+) -> dict[str, Any]:
+    """Capture and characterize RF activity at a frequency — no Meshtastic
+    device involved. Useful for a pre-test "is this channel already busy"
+    occupancy check, or just probing a frequency by hand.
+    """
+    requested_rate_hz = min(
+        _MAX_SAMPLE_RATE_HZ, max(span_khz * 1000.0 * 1.5, _MIN_SAFE_SAMPLE_RATE_HZ)
+    )
+    iq, _t_start, _t_end, sample_rate_hz = sdr.capture_iq_timed(
+        center_freq_hz, requested_rate_hz, duration_s, gain=gain, device_index=device_index
+    )
+
+    _freqs, psd_db = sdr.power_spectrum_db(iq, sample_rate_hz)
+    windows = sdr.active_windows(iq, sample_rate_hz, threshold_db=active_threshold_db)
+    ob = sdr.occupied_bandwidth(iq, sample_rate_hz, db_down=db_down) if windows else None
+
+    return {
+        "center_hz": center_freq_hz,
+        "sample_rate_hz": sample_rate_hz,
+        "duration_s": duration_s,
+        "active_windows": [{"start_s": w.start_s, "duration_s": w.duration_s} for w in windows],
+        "duty_cycle_pct_in_capture": round(sdr.duty_cycle_pct(windows, duration_s), 3),
+        "occupied_bandwidth_hz": ob.bw_hz if ob else None,
+        "peak_freq_offset_hz": ob.peak_freq_hz if ob else None,
+        "peak_power_db": float(np.max(psd_db)),
+        "noise_floor_db_estimate": float(np.median(psd_db)),
+    }
+
+
+def confirm_tx(
+    text: str,
+    *,
+    channel_index: int = 0,
+    port: str | None = None,
+    window_s: float = 5.0,
+    pre_delay_s: float = 0.4,
+    sample_rate_hz: float = 2_048_000.0,
+    gain: float | str = "auto",
+    device_index: int = 0,
+    db_down: float = 26.0,
+    active_threshold_db: float = 10.0,
+    band_guard_khz: float = 100.0,
+    tx_confirm_lookback_s: float = 60.0,
+) -> dict[str, Any]:
+    """Send a text message while an RTL-SDR captures the predicted frequency,
+    and cross-check what actually showed up on air against the firmware's own
+    configured LoRa settings (via `lora_compliance`).
+
+    Timing is loose (capture starts in a background thread, `pre_delay_s`
+    later `send_text` fires on the main thread) — fine for "did energy show up
+    somewhere in this multi-second window", not for measuring a single
+    packet's exact airtime. Capture window must comfortably exceed the
+    preset's expected on-air time (a LONG_SLOW packet can take several
+    seconds) or the transmission may start before/finish after the window.
+
+    **Queued-but-delayed TX is real and can look identical to a dropped send.**
+    Firmware enforces its own channel-utilization/airtime budget: under heavy
+    recent traffic (including your own rapid-fire test calls saturating that
+    budget), a queued packet can sit for tens of seconds before actually being
+    keyed — empirically observed here as a 40-70s delay after back-to-back test
+    sends on a single node. Neither this function's SDR capture (bounded by
+    `window_s`, since holding the SDR open is the expensive part) nor a naive
+    short recorder poll will see a transmission that happens after they've
+    already stopped watching. `ok=False`/`silent_tx_suspected=True` from a
+    *single* short-window call is NOT conclusive evidence of a real failure if
+    you've been calling `send_text`/`confirm_tx` repeatedly in quick
+    succession — space calls out, or re-check with `rf_scan` a bit later,
+    before concluding TX is actually broken.
+
+    `ok`/`measured.rf_observed` (independent SDR evidence, bounded by
+    `window_s`) is the primary verdict here, with the delayed-TX caveat above.
+    `firmware_self_reported_tx` is a secondary, best-effort signal with its own
+    limitation: `meshtastic.MeshInterface._handlePacketFromRadio` explicitly
+    discards and never publishes a pubsub event for a packet that echoes back
+    your own node's send (firmware omits the now-redundant `from` field to
+    save bytes on that echo; the library detects the missing field and drops
+    it — "Device returned a packet we sent, ignoring"). So for a plain
+    broadcast with `want_ack=False`, `firmware_self_reported_tx` will be
+    `False` almost always regardless of whether the send worked — it only has
+    a chance of being `True` if some other node relays/ACKs the packet back to
+    us with the relay's own `from` populated. To make this check actually
+    useful despite the delayed-TX behavior above, its packet-log lookback
+    (`tx_confirm_lookback_s`, default 60s) is intentionally decoupled from and
+    much longer than the live SDR `window_s` — checking the log is cheap, so
+    there's no reason to bound it as tightly as the RF capture. For a real
+    independent cross-node oracle, have a *second* Meshtastic device on the
+    same channel and check its recorder for a genuine receive event instead
+    (see the `meshtastic-e2e` skill's closed-loop pattern) — that receive
+    event is never suppressed since `from` is legitimately populated on a
+    genuinely different node's receive, and the same delayed-TX caveat still
+    applies (watch long enough).
+    """
+    ctx = read_lora_context(port=port)
+    pred = _predict_from_context(ctx)
+    _check_tunable(pred.freq_mhz)
+
+    center_hz = pred.freq_mhz * 1e6
+    requested_rate_hz = _sample_rate_for_bw(pred.bw_khz, sample_rate_hz)
+
+    capture_result: dict[str, Any] = {}
+
+    def _capture() -> None:
+        try:
+            iq, t_start, t_end, actual_rate = sdr.capture_iq_timed(
+                center_hz, requested_rate_hz, window_s, gain=gain, device_index=device_index
+            )
+            capture_result["iq"] = iq
+            capture_result["t_start"] = t_start
+            capture_result["t_end"] = t_end
+            capture_result["sample_rate_hz"] = actual_rate
+        except sdr.SdrError as exc:
+            capture_result["error"] = str(exc)
+
+    capture_thread = threading.Thread(target=_capture, daemon=True)
+    capture_thread.start()
+    time.sleep(pre_delay_s)
+
+    t_send = time.monotonic()
+    send_result = _admin_send_text(text=text, channel_index=channel_index, port=port)
+
+    capture_thread.join(timeout=window_s + 15.0)
+    if capture_thread.is_alive():
+        raise RfOracleError("SDR capture thread did not finish in time — device may be wedged")
+    if "error" in capture_result:
+        raise RfOracleError(f"SDR capture failed: {capture_result['error']}")
+    iq = capture_result.get("iq")
+    if iq is None:
+        raise RfOracleError("SDR capture produced no samples")
+    t_start = capture_result["t_start"]
+    sample_rate_hz = capture_result["sample_rate_hz"]
+    send_offset_s = t_send - t_start
+
+    # All RF activity seen in the capture (ambient mesh traffic included) — useful context,
+    # but NOT what "rf_observed" means below: that's specifically the window matched to our send.
+    windows = sdr.active_windows(iq, sample_rate_hz, threshold_db=active_threshold_db)
+    duty_pct = sdr.duty_cycle_pct(windows, observation_window_s=window_s)
+
+    # Match the window closest to our actual send_text() call — analyzing only that slice
+    # instead of averaging the whole capture avoids blurring our packet together with any
+    # other traffic sharing the channel during the window. Tolerance is generous (LoRa
+    # packets can take seconds of airtime at high SF) but capped so an unrelated burst much
+    # later/earlier in the capture doesn't get misattributed to this send.
+    match_tolerance_s = max(1.0, min(window_s / 2.0, 3.0))
+    min_burst_s = _min_plausible_burst_s(pred.sf, pred.bw_khz)
+    matched = _closest_window(
+        windows, send_offset_s, max_distance_s=match_tolerance_s, min_duration_s=min_burst_s
+    )
+
+    region_info = lora_compliance.REGIONS[ctx["region"]]
+    guard_hz = band_guard_khz * 1000.0
+    ob = None
+    in_band_frac = None
+    if matched is not None:
+        matched_iq = _slice_window(iq, sample_rate_hz, matched)
+        ob = sdr.occupied_bandwidth(matched_iq, sample_rate_hz, db_down=db_down)
+        in_band_frac = sdr.in_band_fraction(
+            matched_iq,
+            sample_rate_hz,
+            capture_center_hz=center_hz,
+            band_start_hz=region_info.freq_start_mhz * 1e6 - guard_hz,
+            band_end_hz=region_info.freq_end_mhz * 1e6 + guard_hz,
+        )
+
+    # Best-effort only — see docstring. This is `False` for essentially every unacked
+    # broadcast regardless of whether the send worked (the library discards the local echo
+    # of your own packet before it ever reaches the recorder), so it can only ever go `True`
+    # via some other node's relay/ACK bouncing the packet_id back to us. Not the primary signal.
+    # Lookback is deliberately much longer than `window_s` — queued packets under airtime
+    # pressure can transmit tens of seconds late (see docstring); checking the log further
+    # back costs nothing, unlike extending the live SDR capture would.
+    pkt_window = packets_window(
+        start=f"-{tx_confirm_lookback_s:.0f}s", portnum="TEXT_MESSAGE_APP", max=20
+    )
+    packet_id = send_result.get("packet_id")
+    firmware_self_reported_tx = any(
+        packet_id is not None and pkt.get("id") == packet_id
+        for pkt in pkt_window.get("packets", [])
+    )
+
+    rf_observed = matched is not None
+    # The actual "silent TX" signal: firmware said the send was queued OK, but no RF showed up
+    # anywhere near the predicted frequency during the capture window.
+    silent_tx_suspected = bool(send_result.get("ok")) and not rf_observed
+
+    return {
+        "ok": rf_observed,
+        "silent_tx_suspected": silent_tx_suspected,
+        "predicted": {
+            "region": pred.region,
+            "freq_mhz": round(pred.freq_mhz, 4),
+            "bw_khz": pred.bw_khz,
+            "sf": pred.sf,
+            "cr": pred.cr,
+            "duty_cycle_limit_pct": pred.duty_cycle_pct,
+            "power_limit_dbm": pred.power_limit_dbm,
+        },
+        "measured": {
+            "rf_observed": rf_observed,
+            "matched_window": (
+                {"start_s": matched.start_s, "duration_s": matched.duration_s} if matched else None
+            ),
+            "occupied_bandwidth_hz": ob.bw_hz if ob else None,
+            "freq_offset_from_predicted_hz": ob.peak_freq_hz if ob else None,
+            "in_region_band_fraction": round(in_band_frac, 4) if in_band_frac is not None else None,
+            "all_active_windows_in_capture": [
+                {"start_s": w.start_s, "duration_s": w.duration_s} for w in windows
+            ],
+            "duty_cycle_pct_in_capture": round(duty_pct, 3),
+        },
+        "firmware_self_reported_tx": firmware_self_reported_tx,
+        "send_result": send_result,
+        "capture": {
+            "center_hz": center_hz,
+            "sample_rate_hz": sample_rate_hz,
+            "window_s": window_s,
+            "pre_delay_s": pre_delay_s,
+            "send_offset_s": round(send_offset_s, 4),
+            "tx_confirm_lookback_s": tx_confirm_lookback_s,
+        },
+        "caveat": (
+            "RTL-SDR dev-loop regression check, uncalibrated power reference — "
+            "not a substitute for certified EMC-lab compliance testing."
+        ),
+    }

--- a/src/meshtastic_mcp/sdr.py
+++ b/src/meshtastic_mcp/sdr.py
@@ -1,0 +1,353 @@
+# SPDX-FileCopyrightText: Meshtastic contributors
+# SPDX-License-Identifier: GPL-3.0-only
+
+"""RTL-SDR capture + spectral analysis — the measurement half of the RF
+compliance oracle (`lora_compliance.py` is the prediction half).
+
+Deliberately does **not** attempt LoRa chirp demodulation — that's a hard,
+narrow problem other tools (meshtastic-sniffer, gr-lora_sdr, MeshRF, the
+SDRangel Meshtastic plugins) already solve well. What we need for compliance
+testing is coarser and more tractable: where is the energy, how wide is it,
+how long is it on, and does that match what `lora_compliance.predict_lora_params`
+says the device should be doing. All analysis below operates on raw IQ with
+plain `numpy` — no SDR access needed to unit test it (see
+`tests/unit/test_sdr.py`, which feeds synthetic IQ).
+
+Hardware access is via `pyrtlsdr` (the `sdr` extra: `pip install
+'meshtastic-mcp[sdr]'`), which wraps `librtlsdr` directly — chosen over
+shelling out to `rtl_power`/`rtl_sdr` so capture timing can be controlled
+precisely (start capturing *before* triggering `send_text()`, stop right
+after) rather than parsing another process's periodic text output.
+
+Caveat that matters: a ~$25 RTL-SDR has no calibrated power reference, no
+oven-stabilized clock, and a noisy front end. Treat every measurement here as
+a **dev-loop regression check** ("did this change shift behavior"), not a
+certified compliance measurement for regulatory sign-off — that requires a
+calibrated EMC lab.
+"""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Sequence
+from dataclasses import dataclass
+
+import numpy as np
+
+
+class SdrError(RuntimeError):
+    """Raised for missing `pyrtlsdr`/`librtlsdr`, no device, or capture failure."""
+
+
+def _require_rtlsdr():
+    try:
+        from rtlsdr import RtlSdr  # type: ignore[import-not-found]
+    except ImportError as exc:
+        raise SdrError(
+            "pyrtlsdr is not installed. Install the 'sdr' extra: pip install 'meshtastic-mcp[sdr]' "
+            "(also requires librtlsdr — e.g. `apt install librtlsdr-dev rtl-sdr`)."
+        ) from exc
+    return RtlSdr
+
+
+def list_devices() -> list[str]:
+    """List serial numbers of attached RTL-SDR devices (does not open any of them)."""
+    RtlSdr = _require_rtlsdr()
+    try:
+        return list(RtlSdr.get_device_serial_addresses())
+    except Exception as exc:
+        raise SdrError(f"Could not enumerate RTL-SDR devices: {exc}") from exc
+
+
+# RTL2832U hardware sample-rate limits (librtlsdr's rtlsdr_set_sample_rate): valid ranges are
+# roughly 225.001-300kHz and 900.001kHz-3.2Msps. Everything in [300k, 900k) is rejected by the
+# tuner/ADC and raises a LibUSBError -22 ("invalid argument") if requested directly.
+_RTLSDR_VALID_RATE_RANGES: tuple[tuple[float, float], ...] = (
+    (225_001.0, 300_000.0),
+    (900_001.0, 3_200_000.0),
+)
+
+
+def snap_sample_rate(hz: float) -> float:
+    """Snap a requested sample rate to the nearest value the RTL2832U will accept.
+
+    Below the lowest valid range -> floor of that range. Inside the forbidden
+    300k-900k gap -> floor of the next (high) range. Above the highest valid
+    range -> ceiling of that range. Already-valid values pass through unchanged.
+    """
+    for lo, hi in _RTLSDR_VALID_RATE_RANGES:
+        if lo <= hz <= hi:
+            return hz
+    lowest_floor = _RTLSDR_VALID_RATE_RANGES[0][0]
+    if hz < lowest_floor:
+        return lowest_floor
+    highest_floor, highest_ceiling = _RTLSDR_VALID_RATE_RANGES[-1]
+    if hz < highest_floor:
+        return highest_floor
+    return highest_ceiling
+
+
+def capture_iq(
+    center_freq_hz: float,
+    sample_rate_hz: float,
+    duration_s: float,
+    *,
+    gain: float | str = "auto",
+    device_index: int = 0,
+    settle_s: float = 0.05,
+    chunk_samples: int = 256 * 1024,
+) -> np.ndarray:
+    """Tune to `center_freq_hz` and capture `duration_s` seconds of IQ.
+
+    Thin wrapper around `capture_iq_timed()` for callers that don't need
+    precise wall-clock correlation against an external event (e.g. `rf_scan`).
+    """
+    iq, _t_start, _t_end, _actual_rate = capture_iq_timed(
+        center_freq_hz,
+        sample_rate_hz,
+        duration_s,
+        gain=gain,
+        device_index=device_index,
+        settle_s=settle_s,
+        chunk_samples=chunk_samples,
+    )
+    return iq
+
+
+def capture_iq_timed(
+    center_freq_hz: float,
+    sample_rate_hz: float,
+    duration_s: float,
+    *,
+    gain: float | str = "auto",
+    device_index: int = 0,
+    settle_s: float = 0.05,
+    chunk_samples: int = 256 * 1024,
+) -> tuple[np.ndarray, float, float, float]:
+    """Like `capture_iq`, but also returns `(iq, t_start, t_end, actual_sample_rate_hz)`.
+
+    `t_start`/`t_end` are `time.monotonic()` timestamps bracketing the *timed*
+    capture window (after the `settle_s` discard, which absorbs PLL-lock/AGC
+    jitter). This is what makes precise correlation against an external event
+    possible: a caller that records `time.monotonic()` right before
+    triggering that event (e.g. `send_text()`) can compute
+    `event_offset_s = t_event - t_start` and know exactly where in the
+    returned IQ array the event should appear, instead of averaging the whole
+    capture window and blurring together unrelated RF activity captured in
+    the same window (see `rf_oracle.confirm_tx`, which uses this to isolate
+    one transmission from ambient mesh traffic).
+
+    `actual_sample_rate_hz` is read back from the hardware after configuring
+    it — `sample_rate_hz` is silently snapped to a valid value
+    (`snap_sample_rate`) before being applied, AND the RTL2832U's internal
+    rational-divider PLL only hits *exact* rates at certain values, so the
+    achieved rate can differ from what was requested either way. Use the
+    returned rate (not the one you passed in) for any frequency-axis math on
+    the returned samples.
+
+    Returns a complex64 ndarray of `round(duration_s * actual_sample_rate_hz)`
+    samples, normalized to [-1, 1] (pyrtlsdr's convention). Reads in
+    `chunk_samples`-sized calls and concatenates — single huge
+    `read_samples()` calls can exceed librtlsdr's internal transfer-size
+    comfort zone on some platforms.
+    """
+    RtlSdr = _require_rtlsdr()
+    try:
+        sdr = RtlSdr(device_index=device_index)
+    except Exception as exc:
+        raise SdrError(f"Could not open RTL-SDR device_index={device_index}: {exc}") from exc
+
+    try:
+        sdr.sample_rate = snap_sample_rate(sample_rate_hz)
+        actual_rate = float(sdr.sample_rate)
+        sdr.center_freq = center_freq_hz
+        sdr.gain = gain
+
+        if settle_s > 0:
+            sdr.read_samples(int(settle_s * actual_rate))
+
+        total_needed = round(duration_s * actual_rate)
+        chunks: list[np.ndarray] = []
+        remaining = total_needed
+        t_start = time.monotonic()
+        while remaining > 0:
+            n = min(chunk_samples, remaining)
+            chunks.append(np.asarray(sdr.read_samples(n), dtype=np.complex64))
+            remaining -= n
+        t_end = time.monotonic()
+        iq = np.concatenate(chunks) if len(chunks) > 1 else chunks[0]
+        return iq, t_start, t_end, actual_rate
+    except SdrError:
+        raise
+    except Exception as exc:
+        raise SdrError(f"RTL-SDR capture failed: {exc}") from exc
+    finally:
+        sdr.close()
+
+
+# ---------------------------------------------------------------------------
+# Pure-numpy analysis — no hardware required, fully unit-testable.
+# ---------------------------------------------------------------------------
+
+
+def power_spectrum_db(
+    iq: np.ndarray, sample_rate_hz: float, nfft: int = 4096
+) -> tuple[np.ndarray, np.ndarray]:
+    """Welch-averaged power spectral density.
+
+    Returns `(freqs_hz, psd_db)`, `freqs_hz` centered on 0 (i.e. relative to
+    whatever the capture's `center_freq_hz` was), fftshift-ordered ascending.
+    Averaging across non-overlapping `nfft`-sample segments trades time
+    resolution for a less noisy spectral estimate — appropriate here since we
+    care about where the energy sits, not catching a single symbol.
+    """
+    n = len(iq)
+    if n < nfft:
+        # fall back to a smaller power-of-2 for short captures
+        nfft = max(8, 1 << (n.bit_length() - 1))
+    usable = (n // nfft) * nfft
+    if usable == 0:
+        raise SdrError(f"capture too short ({n} samples) for nfft={nfft}")
+    segments = iq[:usable].reshape(-1, nfft)
+    window = np.hanning(nfft)
+    spectra = np.fft.fftshift(np.fft.fft(segments * window, axis=1), axes=1)
+    psd = np.mean(np.abs(spectra) ** 2, axis=0)
+    psd_db = 10.0 * np.log10(psd + 1e-20)
+    freqs = np.fft.fftshift(np.fft.fftfreq(nfft, d=1.0 / sample_rate_hz))
+    return freqs, psd_db
+
+
+@dataclass(frozen=True)
+class OccupiedBandwidth:
+    low_hz: float  # relative to capture center
+    high_hz: float
+    bw_hz: float
+    peak_freq_hz: float  # relative to capture center — the freq_offset estimate
+
+
+def occupied_bandwidth(
+    iq: np.ndarray, sample_rate_hz: float, *, db_down: float = 26.0, nfft: int = 4096
+) -> OccupiedBandwidth:
+    """ "N dB down" occupied bandwidth — the regulatory-style method (commonly
+    20-26 dB down is used for LoRa/CSS signals; FCC/ETSI occupied-bandwidth
+    methods are conceptually the same idea applied with their own thresholds).
+
+    Finds the peak bin, then walks outward in both directions until the PSD
+    drops more than `db_down` below the peak, contiguously. This is a coarse
+    bandwidth estimate, not a certified regulatory measurement (see module
+    docstring) — use it for regression ("did this preset change widen the
+    occupied bandwidth"), not for compliance sign-off.
+    """
+    freqs, psd_db = power_spectrum_db(iq, sample_rate_hz, nfft=nfft)
+    peak_idx = int(np.argmax(psd_db))
+    peak_db = psd_db[peak_idx]
+    threshold = peak_db - db_down
+
+    low_idx = peak_idx
+    while low_idx > 0 and psd_db[low_idx - 1] >= threshold:
+        low_idx -= 1
+    high_idx = peak_idx
+    while high_idx < len(psd_db) - 1 and psd_db[high_idx + 1] >= threshold:
+        high_idx += 1
+
+    return OccupiedBandwidth(
+        low_hz=float(freqs[low_idx]),
+        high_hz=float(freqs[high_idx]),
+        bw_hz=float(freqs[high_idx] - freqs[low_idx]),
+        peak_freq_hz=float(freqs[peak_idx]),
+    )
+
+
+def in_band_fraction(
+    iq: np.ndarray,
+    sample_rate_hz: float,
+    *,
+    capture_center_hz: float,
+    band_start_hz: float,
+    band_end_hz: float,
+    nfft: int = 4096,
+) -> float:
+    """Fraction (0..1) of total spectral power that falls within an absolute
+    frequency band (e.g. a region's `[freq_start_mhz, freq_end_mhz]`).
+
+    Use this for the "did the device emit anything outside its allocated
+    region" check: capture wide enough to see both the expected channel and
+    some guard band beyond the region's edges, then confirm this fraction is
+    ~1.0. A low fraction with a confirmed-active capture means energy leaked
+    outside the configured region.
+    """
+    freqs, psd_db = power_spectrum_db(iq, sample_rate_hz, nfft=nfft)
+    psd_linear = 10.0 ** (psd_db / 10.0)
+    abs_freqs = capture_center_hz + freqs
+    in_band = (abs_freqs >= band_start_hz) & (abs_freqs <= band_end_hz)
+    total = float(np.sum(psd_linear))
+    if total <= 0:
+        return 0.0
+    return float(np.sum(psd_linear[in_band]) / total)
+
+
+@dataclass(frozen=True)
+class ActiveWindow:
+    start_s: float
+    end_s: float
+
+    @property
+    def duration_s(self) -> float:
+        return self.end_s - self.start_s
+
+
+def active_windows(
+    iq: np.ndarray,
+    sample_rate_hz: float,
+    *,
+    threshold_db: float = 10.0,
+    win_samples: int = 256,
+    min_gap_s: float = 0.002,
+) -> list[ActiveWindow]:
+    """Detect RF-active time segments via a sliding-window power envelope.
+
+    Computes mean power per `win_samples`-sample window, estimates the noise
+    floor as the median window power, and flags windows more than
+    `threshold_db` above it as active. Adjacent active windows separated by a
+    gap shorter than `min_gap_s` are merged (avoids splitting one transmission
+    into many segments across a brief envelope dip). This is the input to
+    `duty_cycle_pct` — it does not require demodulating the signal, only
+    detecting "is the radio transmitting right now."
+    """
+    n = len(iq)
+    n_windows = n // win_samples
+    if n_windows == 0:
+        return []
+    power = np.abs(iq[: n_windows * win_samples].reshape(n_windows, win_samples)) ** 2
+    win_power_db = 10.0 * np.log10(np.mean(power, axis=1) + 1e-20)
+    noise_floor_db = float(np.median(win_power_db))
+    active_mask = win_power_db >= (noise_floor_db + threshold_db)
+
+    win_duration_s = win_samples / sample_rate_hz
+    windows: list[ActiveWindow] = []
+    start_idx: int | None = None
+    for i, is_active in enumerate(active_mask):
+        if is_active and start_idx is None:
+            start_idx = i
+        elif not is_active and start_idx is not None:
+            windows.append(ActiveWindow(start_idx * win_duration_s, i * win_duration_s))
+            start_idx = None
+    if start_idx is not None:
+        windows.append(ActiveWindow(start_idx * win_duration_s, n_windows * win_duration_s))
+
+    # Merge windows separated by a gap shorter than min_gap_s.
+    merged: list[ActiveWindow] = []
+    for w in windows:
+        if merged and (w.start_s - merged[-1].end_s) < min_gap_s:
+            merged[-1] = ActiveWindow(merged[-1].start_s, w.end_s)
+        else:
+            merged.append(w)
+    return merged
+
+
+def duty_cycle_pct(windows: Sequence[ActiveWindow], observation_window_s: float) -> float:
+    """Percent of `observation_window_s` spent RF-active, from `active_windows()` output."""
+    if observation_window_s <= 0:
+        return 0.0
+    active_s = sum(w.duration_s for w in windows)
+    return 100.0 * active_s / observation_window_s

--- a/src/meshtastic_mcp/server.py
+++ b/src/meshtastic_mcp/server.py
@@ -30,6 +30,7 @@ from . import (
     info,
     log_query,
     registry,
+    rf_oracle,
     serial_session,
 )
 from . import (
@@ -138,6 +139,21 @@ def local_serve_tool(*args: Any, **kwargs: Any):
     return deco
 
 
+def sdr_tool(*args: Any, **kwargs: Any):
+    """Like `@app.tool()` but only registers when the sdr capability is active.
+
+    Without `pyrtlsdr` + an attached RTL-SDR, the RF-compliance oracle tools
+    (`rf_scan`, `rf_confirm_tx`) are not advertised. See `doctor` for what's missing.
+    """
+
+    def deco(fn):
+        if CAPS.sdr:
+            return app.tool(*args, **kwargs)(fn)
+        return fn
+
+    return deco
+
+
 def _start_recorder() -> None:
     # Persistent device-log capture. Starts on first import — pubsub fan-out
     # is process-global, so subscribing here captures every active interface
@@ -160,6 +176,12 @@ _ANDROID_TOOLS = (
     "android_docs_fetch",
     "android_version_lookup",
     "android_render_compose_preview",
+)
+
+# SDR-coupled tools, gated by `sdr_tool` on the sdr capability.
+_SDR_TOOLS = (
+    "rf_scan",
+    "rf_confirm_tx",
 )
 
 # Firmware-coupled tools, gated by `firmware_tool` on the firmware capability.
@@ -199,6 +221,13 @@ def _log_capabilities() -> None:
                 "(set MESHTASTIC_FIRMWARE_ROOT to enable): %s",
                 len(_FIRMWARE_TOOLS),
                 ", ".join(_FIRMWARE_TOOLS),
+            )
+        if not CAPS.sdr:
+            log.info(
+                "sdr capability inactive: %d RF-compliance tools not registered "
+                "(install the 'sdr' extra + librtlsdr + an RTL-SDR to enable): %s",
+                len(_SDR_TOOLS),
+                ", ".join(_SDR_TOOLS),
             )
     except Exception as exc:  # never fail startup over a capability probe
         log.warning("capability detection failed: %s", exc)
@@ -1253,6 +1282,107 @@ def reboot(port: str | None = None, confirm: bool = False, seconds: int = 10) ->
     return admin.reboot(port=port, confirm=confirm, seconds=seconds)
 
 
+# ---------- RF compliance oracle (RTL-SDR) ---------------------------------
+
+
+@sdr_tool()
+def rf_scan(
+    center_freq_hz: float,
+    span_khz: float = 1000.0,
+    duration_s: float = 2.0,
+    gain: float | str = "auto",
+    device_index: int = 0,
+) -> dict[str, Any]:
+    """Capture and characterize RF activity at a frequency with an RTL-SDR. No
+    Meshtastic device involved — use for a pre-test channel-occupancy check
+    ("is this band already busy") or to probe a frequency by hand. See
+    `rf_confirm_tx` for cross-checking a live device's actual TX against its
+    own configured region/preset.
+
+    Returns:
+        {center_hz, sample_rate_hz, duration_s, active_windows: [{start_s, duration_s}],
+         duty_cycle_pct_in_capture, occupied_bandwidth_hz, peak_freq_offset_hz,
+         peak_power_db, noise_floor_db_estimate}
+    """
+    return rf_oracle.scan(
+        center_freq_hz,
+        span_khz=span_khz,
+        duration_s=duration_s,
+        gain=gain,
+        device_index=device_index,
+    )
+
+
+@sdr_tool()
+def rf_confirm_tx(
+    text: str,
+    channel_index: int = 0,
+    port: str | None = None,
+    window_s: float = 5.0,
+    gain: float | str = "auto",
+    device_index: int = 0,
+    tx_confirm_lookback_s: float = 60.0,
+) -> dict[str, Any]:
+    """Send a text message while an RTL-SDR captures the frequency the device's
+    *own configured* region/preset/channel predict it should transmit on —
+    independent ground truth, not the device's self-reported packet log.
+
+    Catches the class of bug firmware can never self-report: TX reported as
+    queued OK (`send_result.ok`) but no RF actually left the antenna (dead PA,
+    disconnected antenna, a region/frequency miscalculation). Also flags
+    off-frequency or off-region emission and reports the measured occupied
+    bandwidth alongside the regulatory duty-cycle/power limit for the
+    device's region.
+
+    **Delayed TX under airtime pressure looks identical to a dropped send.**
+    Firmware enforces its own channel-utilization budget; a queued packet can
+    sit for tens of seconds before actually transmitting if you (or the mesh)
+    have been generating a lot of recent traffic — empirically observed here
+    as 40-70s delays after back-to-back test calls. A single `ok=False` /
+    `silent_tx_suspected=True` result right after a burst of test sends is NOT
+    conclusive; space calls out, or re-check with `rf_scan` shortly after,
+    before concluding TX is actually broken.
+
+    `firmware_self_reported_tx` in the result is best-effort only, NOT a
+    reliable cross-check: the `meshtastic` library discards the local echo of
+    a packet you just sent (firmware omits the redundant `from` field on that
+    echo, and the library drops anything missing it rather than publishing a
+    pubsub event) — so for a plain broadcast this is `False` almost always,
+    regardless of whether the send worked. `ok` / `measured.rf_observed` (the
+    SDR evidence) is what `silent_tx_suspected` is actually based on.
+    `tx_confirm_lookback_s` (default 60s) controls how far back this best-
+    effort check searches the packet log — deliberately much longer than
+    `window_s` since checking the log is cheap, unlike extending the live SDR
+    capture. For a real independent cross-node check, use a second Meshtastic
+    device on the same channel and inspect its own recorder — that receive
+    event is never suppressed since `from` is genuinely populated there (same
+    delayed-TX caveat still applies: watch long enough).
+
+    Needs an RTL-SDR (`doctor` shows whether the sdr capability is active).
+    Coverage is limited to ~24MHz-1766MHz (R820T/R820T2 tuner range) —
+    LORA_24 (2.4GHz) can't be checked with an RTL-SDR. This is a dev-loop
+    regression check with an uncalibrated power reference, not a substitute
+    for certified EMC-lab compliance testing.
+
+    Returns:
+        {ok: bool, silent_tx_suspected: bool, predicted: {region, freq_mhz, bw_khz,
+         sf, cr, duty_cycle_limit_pct, power_limit_dbm}, measured: {rf_observed,
+         matched_window, occupied_bandwidth_hz, freq_offset_from_predicted_hz,
+         in_region_band_fraction, all_active_windows_in_capture,
+         duty_cycle_pct_in_capture}, firmware_self_reported_tx (best-effort,
+         see above), send_result, capture, caveat}
+    """
+    return rf_oracle.confirm_tx(
+        text,
+        channel_index=channel_index,
+        port=port,
+        window_s=window_s,
+        gain=gain,
+        device_index=device_index,
+        tx_confirm_lookback_s=tx_confirm_lookback_s,
+    )
+
+
 @app.tool()
 def shutdown(port: str | None = None, confirm: bool = False, seconds: int = 10) -> dict[str, Any]:
     """Shut down the connected node in `seconds` seconds. Requires confirm=True.
@@ -2027,6 +2157,7 @@ _READ_ONLY = {
     "vision_oracle",  # reads a screenshot, asks the local model; no mutation
     "triage_window",  # reads device window (+optional screenshot); no mutation
     "local_model_status",  # reports backend/reachability; no mutation
+    "rf_scan",  # passive SDR capture; no device/host mutation
 }
 # Destructive: irreversible or device-state-mutating (most are confirm-gated too).
 _DESTRUCTIVE = {
@@ -2043,6 +2174,7 @@ _DESTRUCTIVE = {
     "set_channel_url",
     "set_debug_log_api",
     "send_text",  # injects a mesh packet; cannot be recalled
+    "rf_confirm_tx",  # calls send_text internally; injects a mesh packet
     "send_input_event",  # drives device button/GPIO; side-effect on hardware
     "reboot",
     "shutdown",

--- a/tests/unit/test_lora_compliance.py
+++ b/tests/unit/test_lora_compliance.py
@@ -1,0 +1,120 @@
+# SPDX-FileCopyrightText: Meshtastic contributors
+# SPDX-License-Identifier: GPL-3.0-only
+
+"""Correctness of the firmware region/preset → RF-parameter port.
+
+No hardware, no firmware checkout needed — these pin the pure-Python port in
+`lora_compliance.py` against hand-derived values from the firmware source it
+mirrors (see that module's docstring for file:line citations), so a future
+re-sync with upstream has a regression net.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from meshtastic_mcp import lora_compliance as lc
+
+
+def test_djb2_hash_matches_known_vectors() -> None:
+    # djb2 with the firmware's exact recurrence (hash*33 + c, 32-bit wraparound).
+    # Hand-computed for short, easily-verified strings.
+    assert lc.djb2_hash("") == 5381
+    assert lc.djb2_hash("a") == 5381 * 33 + ord("a")
+    # "LongFast" — the default channel name hashed for the default US LongFast slot.
+    h = 5381
+    for ch in "LongFast":
+        h = ((h << 5) + h + ord(ch)) & 0xFFFFFFFF
+    assert lc.djb2_hash("LongFast") == h
+
+
+def test_us_default_long_fast_in_band_and_250khz() -> None:
+    pred = lc.predict_lora_params("US", "LONG_FAST")
+    assert 902.0 <= pred.freq_mhz <= 928.0
+    assert pred.bw_khz == 250.0
+    assert pred.sf == 11
+    assert pred.cr == 5
+    assert pred.duty_cycle_pct == 100
+    assert pred.power_limit_dbm == 30
+    assert 0 <= pred.channel_num < pred.num_freq_slots
+
+
+def test_eu_868_narrow_band_and_duty_cycle() -> None:
+    pred = lc.predict_lora_params("EU_868", "LONG_FAST")
+    assert 869.4 <= pred.freq_mhz <= 869.65
+    assert pred.duty_cycle_pct == 10
+    assert pred.power_limit_dbm == 27
+
+
+def test_eu_866_duty_cycle_is_role_dependent() -> None:
+    mobile = lc.predict_lora_params("EU_866", "LITE_FAST", device_role="CLIENT")
+    router = lc.predict_lora_params("EU_866", "LITE_FAST", device_role="ROUTER")
+    assert mobile.duty_cycle_pct == 2.5
+    assert router.duty_cycle_pct == 10.0
+
+
+def test_override_frequency_wins_outright() -> None:
+    pred = lc.predict_lora_params(
+        "US", "LONG_FAST", override_frequency_mhz=906.875, frequency_offset_mhz=0.5
+    )
+    assert pred.freq_mhz == pytest.approx(907.375)
+    assert pred.channel_num == -1
+
+
+def test_frequency_offset_is_additive() -> None:
+    base = lc.predict_lora_params("US", "LONG_FAST", channel_num=1)
+    offset = lc.predict_lora_params("US", "LONG_FAST", channel_num=1, frequency_offset_mhz=1.0)
+    assert offset.freq_mhz == pytest.approx(base.freq_mhz + 1.0)
+
+
+def test_explicit_channel_num_resolves_slot_deterministically() -> None:
+    # channel_num is 1-based on the wire; slot 1 -> resolved channel_num 0 -> band edge + half BW.
+    pred = lc.predict_lora_params("US", "LONG_FAST", channel_num=1)
+    assert pred.channel_num == 0
+    assert pred.freq_mhz == pytest.approx(902.0 + 250.0 / 2000.0)
+
+
+def test_wide_lora_region_uses_wide_bandwidth_table() -> None:
+    pred = lc.predict_lora_params("LORA_24", "LONG_FAST")
+    assert pred.wide_lora is True
+    assert pred.bw_khz == 812.5  # wideLora variant, not the 250kHz sub-GHz figure
+    assert 2400.0 <= pred.freq_mhz <= 2483.5
+
+
+def test_ham_region_explicit_override_slot() -> None:
+    # ITU1_2M hardcodes slot 26 regardless of channel name hash.
+    pred = lc.predict_lora_params("ITU1_2M", "TINY_FAST")
+    assert pred.channel_num == 25  # 1-based 26 -> 0-based 25
+
+
+def test_unknown_region_raises() -> None:
+    with pytest.raises(ValueError):
+        lc.predict_lora_params("ATLANTIS", "LONG_FAST")
+
+
+def test_unknown_preset_raises() -> None:
+    with pytest.raises(ValueError):
+        lc.predict_lora_params("US", "ULTRA_FAST")
+
+
+def test_effective_power_limit_clamps_to_region() -> None:
+    assert lc.effective_power_limit_dbm("US", configured_tx_power_dbm=99) == 30
+    assert lc.effective_power_limit_dbm("US", configured_tx_power_dbm=10) == 10
+    assert lc.effective_power_limit_dbm("US", configured_tx_power_dbm=0) == 30
+
+
+def test_effective_power_limit_licensed_bypasses_clamp() -> None:
+    assert lc.effective_power_limit_dbm("US", configured_tx_power_dbm=33, is_licensed=True) == 33
+
+
+@pytest.mark.parametrize("region", list(lc.REGIONS.keys()))
+def test_every_region_default_preset_predicts_in_band(region: str) -> None:
+    """Every region's own default preset should resolve to a frequency inside
+    [freq_start, freq_end] — a basic self-consistency check across the whole
+    table (catches transcription typos like a swapped start/end)."""
+    info = lc.REGIONS[region]
+    pred = lc.predict_lora_params(region, info.default_preset)
+    assert info.freq_start_mhz <= pred.freq_mhz <= info.freq_end_mhz, (
+        f"{region}/{info.default_preset}: predicted {pred.freq_mhz} MHz outside "
+        f"[{info.freq_start_mhz}, {info.freq_end_mhz}]"
+    )

--- a/tests/unit/test_rf_oracle.py
+++ b/tests/unit/test_rf_oracle.py
@@ -1,0 +1,65 @@
+# SPDX-FileCopyrightText: Meshtastic contributors
+# SPDX-License-Identifier: GPL-3.0-only
+
+"""Correctness of `rf_oracle`'s window-matching helpers — no hardware needed.
+
+Regression test for a real bug found via live-hardware testing: a high-gain
+RTL-SDR capture produced ~40 sub-millisecond noise spikes alongside one
+genuine ~1s LoRa burst, and naive nearest-by-time matching picked a noise
+spike (closer in raw time to the send offset) over the real, much longer
+burst. `_min_plausible_burst_s` + `_closest_window`'s `min_duration_s` filter
+fixes this by rejecting anything shorter than a LoRa preamble could be before
+considering a window a candidate match.
+"""
+
+from __future__ import annotations
+
+from meshtastic_mcp import rf_oracle
+from meshtastic_mcp.sdr import ActiveWindow
+
+
+def test_min_plausible_burst_s_scales_with_symbol_time() -> None:
+    # SF11/250kHz (LONG_FAST): symbol time = 2^11/250000 = 8.192ms; 8 symbols ~= 65.5ms.
+    assert rf_oracle._min_plausible_burst_s(sf=11, bw_khz=250.0) > 0.06
+    # Higher SF (slower, e.g. LONG_SLOW SF12) means longer symbols, so a higher floor.
+    slow = rf_oracle._min_plausible_burst_s(sf=12, bw_khz=125.0)
+    fast = rf_oracle._min_plausible_burst_s(sf=7, bw_khz=500.0)
+    assert slow > fast
+
+
+def test_closest_window_ignores_noise_spikes_shorter_than_min_duration() -> None:
+    # Reproduces the exact real-world shape: many ~0.125ms noise spikes plus one
+    # genuine ~1s burst about 1.17s after the (simulated) send offset — closer in
+    # time is a spike, but only the long burst is a plausible LoRa packet.
+    windows = [
+        ActiveWindow(0.000875, 0.001),
+        ActiveWindow(0.128875, 0.129),
+        ActiveWindow(0.256875, 0.257),  # nearest by raw time to offset_s=0.2163
+        ActiveWindow(1.3875, 2.375),  # the real ~1s burst
+    ]
+    offset_s = 0.2163
+    min_duration_s = rf_oracle._min_plausible_burst_s(sf=11, bw_khz=250.0)
+
+    naive = rf_oracle._closest_window(windows, offset_s, max_distance_s=3.0)
+    assert naive is not None
+    assert naive.start_s == 0.256875, "sanity check: naive nearest-by-time picks the noise spike"
+
+    filtered = rf_oracle._closest_window(
+        windows, offset_s, max_distance_s=3.0, min_duration_s=min_duration_s
+    )
+    assert filtered is not None
+    assert filtered.start_s == 1.3875, "with the noise filter, the real burst should win instead"
+
+
+def test_closest_window_returns_none_when_only_noise_present() -> None:
+    windows = [ActiveWindow(0.1, 0.1001), ActiveWindow(0.2, 0.2001)]
+    result = rf_oracle._closest_window(windows, 0.15, max_distance_s=3.0, min_duration_s=0.05)
+    assert result is None
+
+
+def test_closest_window_respects_max_distance_even_with_duration_filter() -> None:
+    # A plausible-duration window that's just too far away from the send should
+    # still be rejected — min_duration_s narrows candidates, it doesn't widen tolerance.
+    windows = [ActiveWindow(10.0, 11.0)]
+    result = rf_oracle._closest_window(windows, 0.2, max_distance_s=3.0, min_duration_s=0.05)
+    assert result is None

--- a/tests/unit/test_sdr.py
+++ b/tests/unit/test_sdr.py
@@ -1,0 +1,157 @@
+# SPDX-FileCopyrightText: Meshtastic contributors
+# SPDX-License-Identifier: GPL-3.0-only
+
+"""Pure-numpy analysis correctness for `sdr.py`, against synthetic IQ.
+
+No RTL-SDR hardware needed — every function here operates on an in-memory
+ndarray, so we can build a known signal (a tone, or a tone burst with known
+on/off timing) and assert the analysis recovers its known parameters. This is
+the regression net for the compliance oracle's measurement half; `lora_compliance`
+tests are the prediction half.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from meshtastic_mcp import sdr
+
+
+def _tone(
+    freq_hz: float, sample_rate_hz: float, duration_s: float, amplitude: float = 1.0
+) -> np.ndarray:
+    n = int(duration_s * sample_rate_hz)
+    t = np.arange(n) / sample_rate_hz
+    return (amplitude * np.exp(2j * np.pi * freq_hz * t)).astype(np.complex64)
+
+
+def _noise(n: int, amplitude: float = 0.01, seed: int = 0) -> np.ndarray:
+    rng = np.random.default_rng(seed)
+    return (amplitude * (rng.standard_normal(n) + 1j * rng.standard_normal(n))).astype(np.complex64)
+
+
+def test_power_spectrum_peak_at_tone_frequency() -> None:
+    sample_rate = 2_000_000.0
+    tone_freq = 250_000.0  # offset from "center" (0 Hz in this relative-frequency convention)
+    iq = _tone(tone_freq, sample_rate, 0.01) + _noise(int(0.01 * sample_rate))
+
+    freqs, psd_db = sdr.power_spectrum_db(iq, sample_rate, nfft=2048)
+    peak_freq = freqs[int(np.argmax(psd_db))]
+    # nfft=2048 @ 2Msps -> ~977 Hz/bin resolution; allow a couple bins of slack.
+    assert abs(peak_freq - tone_freq) < 5 * (sample_rate / 2048)
+
+
+def test_occupied_bandwidth_narrow_for_pure_tone() -> None:
+    sample_rate = 2_000_000.0
+    iq = _tone(0.0, sample_rate, 0.01) + _noise(int(0.01 * sample_rate))
+    ob = sdr.occupied_bandwidth(iq, sample_rate, db_down=20.0, nfft=2048)
+    # A pure tone's energy should be tightly concentrated — well under 1% of the sample rate.
+    assert ob.bw_hz < sample_rate * 0.01
+    assert abs(ob.peak_freq_hz) < 5 * (sample_rate / 2048)
+
+
+def test_occupied_bandwidth_wider_for_wideband_signal() -> None:
+    sample_rate = 2_000_000.0
+    n = int(0.01 * sample_rate)
+    # A wideband chirp-ish signal (linear FM sweep) occupies much more spectrum than a tone.
+    t = np.arange(n) / sample_rate
+    sweep_bw = 500_000.0
+    chirp = np.exp(2j * np.pi * (-sweep_bw / 2 * t + (sweep_bw / (2 * t[-1])) * t**2)).astype(
+        np.complex64
+    )
+    iq = chirp + _noise(n)
+
+    ob_tone = sdr.occupied_bandwidth(
+        _tone(0.0, sample_rate, 0.01) + _noise(n), sample_rate, nfft=2048
+    )
+    ob_chirp = sdr.occupied_bandwidth(iq, sample_rate, nfft=2048)
+    assert ob_chirp.bw_hz > ob_tone.bw_hz * 10
+
+
+def test_in_band_fraction_high_when_tone_inside_band() -> None:
+    sample_rate = 2_000_000.0
+    capture_center = 915_000_000.0
+    tone_offset = 100_000.0  # 915.1 MHz absolute
+    iq = _tone(tone_offset, sample_rate, 0.01) + _noise(int(0.01 * sample_rate))
+
+    frac_in = sdr.in_band_fraction(
+        iq,
+        sample_rate,
+        capture_center_hz=capture_center,
+        band_start_hz=902_000_000.0,
+        band_end_hz=928_000_000.0,
+    )
+    assert frac_in > 0.95
+
+
+def test_in_band_fraction_low_when_tone_outside_band() -> None:
+    sample_rate = 2_000_000.0
+    capture_center = 915_000_000.0
+    tone_offset = 800_000.0  # 915.8 MHz absolute — outside a narrow allowed band below
+    iq = _tone(tone_offset, sample_rate, 0.01) + _noise(int(0.01 * sample_rate))
+
+    frac_in = sdr.in_band_fraction(
+        iq,
+        sample_rate,
+        capture_center_hz=capture_center,
+        band_start_hz=914_000_000.0,
+        band_end_hz=915_200_000.0,  # excludes the 915.8MHz tone
+    )
+    assert frac_in < 0.3
+
+
+def test_active_windows_detects_burst_timing() -> None:
+    sample_rate = 1_000_000.0
+    # 20ms silence, 5ms tone burst, 20ms silence — burst is a minority of windows so
+    # the median-based noise floor lands on the silence level, not the burst.
+    silence_a = _noise(int(0.020 * sample_rate), amplitude=0.005)
+    burst = _tone(50_000.0, sample_rate, 0.005, amplitude=1.0)
+    silence_b = _noise(int(0.020 * sample_rate), amplitude=0.005)
+    iq = np.concatenate([silence_a, burst, silence_b])
+
+    windows = sdr.active_windows(iq, sample_rate, threshold_db=15.0, win_samples=64)
+    assert len(windows) == 1
+    w = windows[0]
+    assert abs(w.start_s - 0.020) < 0.001
+    assert abs(w.duration_s - 0.005) < 0.001
+
+
+def test_duty_cycle_pct_matches_active_fraction() -> None:
+    windows = [sdr.ActiveWindow(0.0, 1.0), sdr.ActiveWindow(2.0, 2.5)]
+    assert sdr.duty_cycle_pct(windows, observation_window_s=10.0) == pytest.approx(15.0)
+
+
+def test_duty_cycle_pct_zero_for_empty_observation() -> None:
+    assert sdr.duty_cycle_pct([], observation_window_s=0.0) == 0.0
+
+
+def test_snap_sample_rate_passes_through_valid_values() -> None:
+    assert sdr.snap_sample_rate(250_000.0) == 250_000.0
+    assert sdr.snap_sample_rate(2_048_000.0) == 2_048_000.0
+
+
+def test_snap_sample_rate_avoids_the_forbidden_gap() -> None:
+    # 750kHz (e.g. a naive span_khz*1.5 calc for a 500kHz span) falls in the RTL2832U's
+    # unsupported [300k, 900k) gap and must be snapped up to the next valid tier's floor.
+    assert sdr.snap_sample_rate(750_000.0) == 900_001.0
+
+
+def test_snap_sample_rate_clamps_below_and_above_range() -> None:
+    assert sdr.snap_sample_rate(1_000.0) == 225_001.0
+    assert sdr.snap_sample_rate(10_000_000.0) == 3_200_000.0
+
+
+def test_require_rtlsdr_raises_sdr_error_when_missing(monkeypatch: pytest.MonkeyPatch) -> None:
+    import builtins
+
+    real_import = builtins.__import__
+
+    def fake_import(name: str, *args: object, **kwargs: object) -> object:
+        if name == "rtlsdr":
+            raise ImportError("no module named rtlsdr")
+        return real_import(name, *args, **kwargs)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    with pytest.raises(sdr.SdrError, match="pyrtlsdr is not installed"):
+        sdr.list_devices()


### PR DESCRIPTION
## What

An independent, on-air cross-check that a device's actual RF emission matches what its own configured region/preset/channel say it should be — catching the class of bug firmware can never self-report: TX reported as queued OK (`send_result.ok`) but nothing actually left the antenna (dead PA, disconnected antenna, region/frequency miscalculation).

## Three new modules (prediction split from measurement, each unit-testable without hardware)

- **`lora_compliance.py`** — faithful Python port of firmware's region/preset → RF-parameter resolution (center frequency, bandwidth, SF, CR, duty-cycle/power limits). Every table transcribed from firmware source with file:line citations for re-syncing when upstream changes.
- **`sdr.py`** — RTL-SDR capture + spectral analysis via `pyrtlsdr`. Deliberately does **not** attempt LoRa chirp demodulation (narrow, hard problem other tools already solve) — answers the coarser, tractable question of where the energy is, how wide, how long it's on, via plain `numpy` over raw IQ. Unit-testable with synthetic IQ, no hardware.
- **`rf_oracle.py`** — cross-checks the two: predicted vs. measured frequency/bandwidth/timing, flags a silent-TX suspicion when nothing shows up on the predicted frequency during a live `send_text()`.

## New MCP tools (gated by the `sdr` capability — all optional)

- `rf_scan` — passive channel-occupancy capture at a frequency, no device involved (read-only)
- `rf_confirm_tx` — `send_text()` while capturing the predicted frequency; returns `ok`/`silent_tx_suspected` plus predicted vs. measured RF params (destructive: injects a real mesh packet)

Requires `pyrtlsdr` + `librtlsdr` + an attached RTL-SDR. Wired into `capabilities.py` (`has_sdr()`), `doctor.py` (reports the most specific missing piece), and a new `sdr` pyproject extra.

## Scope / caveats

Explicitly a **dev-loop regression check** ("did this change shift behavior"), not a certified compliance measurement — an RTL-SDR has no calibrated power reference or oven-stabilized clock. Documents a real gotcha found live: delayed TX under airtime pressure (40–70s observed after back-to-back sends) looks identical to a dropped send, so a single `silent_tx_suspected=True` right after a burst isn't conclusive.

## Tests

67 passing across the three modules, synthetic-IQ-only (no hardware required) plus doctor-check coverage for each missing-dependency state. `ruff`/`mypy` clean.

## Merge note

Files are fully disjoint from the three other open PRs (only this branch touches `server.py`/`capabilities.py`/`doctor.py`/`pyproject.toml` + the new modules), so it merges cleanly in any order relative to them.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional SDR support for RF compliance checks.
  * Added new RF scan and transmission-confirmation tools for inspecting LoRa activity with an RTL-SDR device.
  * Expanded capability detection and status reporting to show when SDR features are available.

* **Bug Fixes**
  * Improved RF measurement handling so active transmissions and bandwidth estimates are identified more reliably.

* **Tests**
  * Added coverage for LoRa parameter prediction and SDR signal-analysis behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->