### PR TITLE
web: degrade gracefully when FleetSuite runs without a firmware root

### DIFF
--- a/src/meshtastic_mcp/web/app.py
+++ b/src/meshtastic_mcp/web/app.py
@@ -29,6 +29,7 @@ from meshtastic_mcp import (
 from meshtastic_mcp import (
     info as mt_info,
 )
+from meshtastic_mcp.config import ConfigError
 
 from .db import repo_builds as rb
 from .db import repo_cameras as rc
@@ -897,7 +898,11 @@ def _mount_native(api: APIRouter) -> None:
 def _mount_boards(api: APIRouter) -> None:
     @api.get("/boards")
     async def list_boards(query: str | None = None, architecture: str | None = None):
-        return await asyncio.to_thread(boards.list_boards, architecture, False, query, None)
+        try:
+            return await asyncio.to_thread(boards.list_boards, architecture, False, query, None)
+        except ConfigError as exc:
+            # No firmware checkout — a config precondition, not a server bug.
+            raise HTTPException(status_code=409, detail=str(exc)) from exc
 
 
 # --- screen keep-alive -----------------------------------------------------

--- a/src/meshtastic_mcp/web/app.py
+++ b/src/meshtastic_mcp/web/app.py
@@ -153,6 +153,13 @@ def create_app() -> FastAPI:
     async def _busy(_req: Request, exc: ControlBusy):
         return JSONResponse(status_code=409, content={"detail": str(exc)})
 
+    @app.exception_handler(ConfigError)
+    async def _config_precondition(_req: Request, exc: ConfigError):
+        # A missing/invalid firmware checkout is a config precondition, not a
+        # server bug — any firmware-dependent lookup that raises ConfigError
+        # answers 409 + the message app-wide instead of a raw 500 traceback.
+        return JSONResponse(status_code=409, content={"detail": str(exc)})
+
     if STATIC_DIR.is_dir():
         app.mount("/", StaticFiles(directory=str(STATIC_DIR), html=True), name="spa")
     else:
@@ -898,11 +905,8 @@ def _mount_native(api: APIRouter) -> None:
 def _mount_boards(api: APIRouter) -> None:
     @api.get("/boards")
     async def list_boards(query: str | None = None, architecture: str | None = None):
-        try:
-            return await asyncio.to_thread(boards.list_boards, architecture, False, query, None)
-        except ConfigError as exc:
-            # No firmware checkout — a config precondition, not a server bug.
-            raise HTTPException(status_code=409, detail=str(exc)) from exc
+        # ConfigError (no firmware checkout) → 409 via the app-wide handler.
+        return await asyncio.to_thread(boards.list_boards, architecture, False, query, None)
 
 
 # --- screen keep-alive -----------------------------------------------------

--- a/src/meshtastic_mcp/web/services/identity.py
+++ b/src/meshtastic_mcp/web/services/identity.py
@@ -12,8 +12,7 @@ from __future__ import annotations
 import hashlib
 import logging
 
-from meshtastic_mcp import boards
-from meshtastic_mcp.config import ConfigError
+from meshtastic_mcp import boards, config
 
 log = logging.getLogger("meshtastic_mcp.web.identity")
 
@@ -71,9 +70,7 @@ def env_for_hw_model(hw_model: str | None) -> str | None:
     if not hw_model:
         return None
     target = hw_model.upper()
-    try:
-        all_boards = boards.list_boards()
-    except ConfigError:
+    if config.firmware_root_or_none() is None:
         # No firmware checkout — the exact-env lookup needs the firmware
         # tree's board table. Degrade to "unknown env" instead of raising:
         # callers (auto-enrichment, POST /devices/{serial}/refresh) must
@@ -88,7 +85,7 @@ def env_for_hw_model(hw_model: str | None) -> str | None:
         return None
     candidates = [
         b["env"]
-        for b in all_boards
+        for b in boards.list_boards()
         if (b.get("hw_model_slug") or "").upper() == target and b.get("env")
     ]
     if not candidates:

--- a/src/meshtastic_mcp/web/services/identity.py
+++ b/src/meshtastic_mcp/web/services/identity.py
@@ -10,8 +10,17 @@ that is explicitly NOT stable.
 from __future__ import annotations
 
 import hashlib
+import logging
 
 from meshtastic_mcp import boards
+from meshtastic_mcp.config import ConfigError
+
+log = logging.getLogger("meshtastic_mcp.web.identity")
+
+# One-time note when env resolution degrades because there's no firmware
+# checkout — enrichment retries per device per poll, so per-call logging
+# would flood the log with the same fact.
+_warned_no_firmware_root = False
 
 # USB vendor IDs we recognise → coarse role. Case-insensitive; compared as the
 # lowercased hex string (e.g. "0x239a").
@@ -62,9 +71,24 @@ def env_for_hw_model(hw_model: str | None) -> str | None:
     if not hw_model:
         return None
     target = hw_model.upper()
+    try:
+        all_boards = boards.list_boards()
+    except ConfigError:
+        # No firmware checkout — the exact-env lookup needs the firmware
+        # tree's board table. Degrade to "unknown env" instead of raising:
+        # callers (auto-enrichment, POST /devices/{serial}/refresh) must
+        # still be able to record fw/hw/region without a firmware root.
+        global _warned_no_firmware_root
+        if not _warned_no_firmware_root:
+            _warned_no_firmware_root = True
+            log.info(
+                "no firmware root (MESHTASTIC_FIRMWARE_ROOT) — device pio envs "
+                "will stay unresolved; fw/hw enrichment still works"
+            )
+        return None
     candidates = [
         b["env"]
-        for b in boards.list_boards()
+        for b in all_boards
         if (b.get("hw_model_slug") or "").upper() == target and b.get("env")
     ]
     if not candidates:

--- a/tests/unit/test_web_registry.py
+++ b/tests/unit/test_web_registry.py
@@ -258,8 +258,15 @@ def test_flash_timing_comparison(tmp_path):
 def test_env_resolves_from_hw_model_not_just_role(monkeypatch):
     """A Heltec V4 (HELTEC_V4) must resolve to env heltec-v4, NOT the coarse
     esp32s3→heltec-v3 role default. Regression for the wrong-variant flash risk
-    surfaced by real-hardware testing. Stubs the board catalog (no pio needed)."""
+    surfaced by real-hardware testing. Stubs the board catalog (no pio needed)
+    and pins a firmware root so the no-root guard doesn't short-circuit the
+    lookup off-bench."""
+    import pathlib
+
     import meshtastic_mcp.boards as boards_mod
+    import meshtastic_mcp.config as config_mod
+
+    monkeypatch.setattr(config_mod, "firmware_root_or_none", lambda: pathlib.Path("/fw"))
 
     fake_catalog = [
         {"env": "heltec-v3", "hw_model_slug": "HELTEC_V3"},
@@ -288,16 +295,21 @@ def test_env_resolution_degrades_without_firmware_root(monkeypatch):
     with fw=None) and POST /devices/{serial}/refresh 500'd, both because env
     resolution raised when MESHTASTIC_FIRMWARE_ROOT wasn't set."""
     import meshtastic_mcp.boards as boards_mod
+    import meshtastic_mcp.config as config_mod
     from meshtastic_mcp.config import ConfigError
 
-    def _no_root(*a, **k):
+    monkeypatch.setattr(config_mod, "firmware_root_or_none", lambda: None)
+
+    # Sentinel: with the proactive guard in place the board catalog must never
+    # be consulted — if it were, this raise would escape and fail the test.
+    def _must_not_reach(*a, **k):
         raise ConfigError("Could not locate Meshtastic firmware root.")
 
-    monkeypatch.setattr(boards_mod, "list_boards", _no_root)
+    monkeypatch.setattr(boards_mod, "list_boards", _must_not_reach)
 
     assert identity.env_for_hw_model("RAK4631") is None
     assert identity.env_for_hw_model("HELTEC_V3") is None  # repeats stay quiet too
-    # The trivial guards still short-circuit before the catalog is consulted.
+    # The trivial guards still short-circuit before the root is even checked.
     assert identity.env_for_hw_model(None) is None
 
 

--- a/tests/unit/test_web_registry.py
+++ b/tests/unit/test_web_registry.py
@@ -281,6 +281,48 @@ def test_env_resolves_from_hw_model_not_just_role(monkeypatch):
     assert control.env_for_device({"role": "esp32s3", "env": None}) == "heltec-v3"
 
 
+def test_env_resolution_degrades_without_firmware_root(monkeypatch):
+    """No firmware checkout → env_for_hw_model returns None instead of letting
+    boards.list_boards()'s ConfigError escape. Regression for the two findings
+    from the first live bring-up: auto-enrichment silently aborted (fleet stuck
+    with fw=None) and POST /devices/{serial}/refresh 500'd, both because env
+    resolution raised when MESHTASTIC_FIRMWARE_ROOT wasn't set."""
+    import meshtastic_mcp.boards as boards_mod
+    from meshtastic_mcp.config import ConfigError
+
+    def _no_root(*a, **k):
+        raise ConfigError("Could not locate Meshtastic firmware root.")
+
+    monkeypatch.setattr(boards_mod, "list_boards", _no_root)
+
+    assert identity.env_for_hw_model("RAK4631") is None
+    assert identity.env_for_hw_model("HELTEC_V3") is None  # repeats stay quiet too
+    # The trivial guards still short-circuit before the catalog is consulted.
+    assert identity.env_for_hw_model(None) is None
+
+
+def test_boards_endpoint_409_without_firmware_root(monkeypatch):
+    """GET /api/boards answers 409 + the ConfigError detail when there is no
+    firmware checkout, instead of a raw 500 traceback."""
+    from starlette.testclient import TestClient
+
+    import meshtastic_mcp.boards as boards_mod
+    from meshtastic_mcp.config import ConfigError
+    from meshtastic_mcp.web.app import create_app
+
+    def _no_root(*a, **k):
+        raise ConfigError("Could not locate Meshtastic firmware root.")
+
+    monkeypatch.setattr(boards_mod, "list_boards", _no_root)
+
+    # No `with` block: the lifespan (discovery/cameras/keepalive) must stay
+    # down — /api/boards doesn't touch app.state, so requests work without it.
+    client = TestClient(create_app())
+    resp = client.get("/api/boards")
+    assert resp.status_code == 409
+    assert "firmware root" in resp.json()["detail"]
+
+
 def test_suite_env_overrides_from_connected_boards(tmp_path):
     """The test runner bakes the variant resolved per connected board: an online
     Heltec V4 → MESHTASTIC_MCP_ENV_ESP32S3=heltec-v4 (not the heltec-v3 default).


### PR DESCRIPTION
## Findings from the first live bring-up (follow-up to #9)

Ran FleetSuite against a real 4-board bench (RAK4631, T-Beam S3, XIAO S3, Heltec V3) right after the merge. Two failures surfaced, same root cause: `identity.env_for_hw_model` lets `boards.list_boards()`'s `ConfigError` escape when `MESHTASTIC_FIRMWARE_ROOT` isn't set:

1. **Auto-enrichment aborted wholesale and silently** — enrichment failures log at DEBUG, so the fleet just sat at `fw=None` with no visible reason. Worse: the exception path treated the config problem as a wedged port, so `_maybe_unwedge` could escalate against perfectly healthy devices.
2. **`POST /devices/{serial}/refresh` 500'd** with a raw traceback before touching the device.

## Fix

- `env_for_hw_model` catches `ConfigError` → `None`: enrichment/refresh still record fw/hw/region; only the exact pio env stays unresolved. One-time INFO note explains why envs are blank (enrichment retries per device per poll, so per-call logging would flood).
- `GET /api/boards` had the same raw-500 mode → now **409** with the `ConfigError` detail (repo's `HTTPException`-with-detail convention): a missing firmware checkout is a config precondition, not a server bug.

## Verification

- **Live on the bench, no firmware root:** all 4 boards enrich (fw/hw/region populated, `env=None`, INFO note logged once), `/refresh` → 200, `/api/boards` → 409 + message. With the root set: behavior unchanged, envs resolve exactly as before.
- **Regression tests:** `env_for_hw_model` degrade (monkeypatched catalog raising `ConfigError`) and `/api/boards` → 409 via `TestClient` *without* the lifespan, so no discovery/camera services start in the unit tier.
- Full unit tier **465 passed / 33 skipped / 0 failed**; ruff, ruff format, mypy clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling for missing firmware configuration so board-related requests now return a clear HTTP 409 response with an informative message instead of an unhandled server error.
  * Device environment resolution now safely degrades to an unresolved state when required firmware context is unavailable, and emits a single informational log per process to reduce repeated noise.
* **Tests**
  * Added/updated unit tests to cover missing-firmware scenarios and verify both the fallback behavior and the new HTTP 409 response.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->