### PR TITLE
feat(replay): support injecting raw FromRadio messages (FileInfo)

### DIFF
--- a/src/meshtastic_mcp/replay/build.py
+++ b/src/meshtastic_mcp/replay/build.py
@@ -372,3 +372,23 @@ def from_kind(
             channel_idx=channel_idx,
         )
     raise ValueError(f"unknown inject kind: {kind!r}")
+
+
+def fromradio_from_kind(kind: str, args: dict[str, Any]) -> mesh_pb2.FromRadio:
+    """Build a raw top-level FromRadio message from a high-level ``kind`` + ``args``.
+
+    Counterpart to `from_kind()` for the handshake-only oneofs that have no MeshPacket
+    envelope (nothing to route/channel/from-node -- these aren't mesh traffic). Pair with
+    `ReplaySession.inject_fromradio()` / `ReplayManager.inject_fromradio()`.
+
+    kinds: ``fileinfo`` (file_name, size_bytes) -- exercises a client's file-manifest
+    handler (STATE_SEND_FILEMANIFEST) outside the initial handshake window, e.g. to fuzz-
+    test unbounded accumulation or malformed entries under a long-running session.
+    """
+    a = args or {}
+    if kind == "fileinfo":
+        fr = mesh_pb2.FromRadio()
+        fr.fileInfo.file_name = a.get("file_name", "")
+        fr.fileInfo.size_bytes = int(a.get("size_bytes", 0))
+        return fr
+    raise ValueError(f"unknown fromradio inject kind: {kind!r}")

--- a/src/meshtastic_mcp/replay/build.py
+++ b/src/meshtastic_mcp/replay/build.py
@@ -389,6 +389,9 @@ def fromradio_from_kind(kind: str, args: dict[str, Any]) -> mesh_pb2.FromRadio:
     if kind == "fileinfo":
         fr = mesh_pb2.FromRadio()
         fr.fileInfo.file_name = a.get("file_name", "")
-        fr.fileInfo.size_bytes = int(a.get("size_bytes", 0))
+        # size_bytes is a uint32 on the wire; protobuf rejects a raw negative int.
+        # Mask into the unsigned representation so adversarial/negative fuzz values
+        # (advertised by replay_inject_fileinfo) still encode instead of raising.
+        fr.fileInfo.size_bytes = int(a.get("size_bytes", 0)) & 0xFFFFFFFF
         return fr
     raise ValueError(f"unknown fromradio inject kind: {kind!r}")

--- a/src/meshtastic_mcp/replay/engine.py
+++ b/src/meshtastic_mcp/replay/engine.py
@@ -237,6 +237,13 @@ class ReplaySession:
         self._ch_index = {name: i for i, name in enumerate(capture.channels)}
         # live-injection queue: (MeshPacket, channel_name, fuzz) drained per client
         self._inject_q: queue.Queue[tuple[mesh_pb2.MeshPacket, str, bool]] = queue.Queue()
+        # live-injection queue for top-level FromRadio messages (FileInfo, MyInfo, Config,
+        # ModuleConfig, Channel, ...) -- the handshake-phase counterpart to _inject_q. These
+        # oneofs are only ever sent during _send_config_phase/_send_db_phase today, so there was
+        # no way to exercise a handler for them (e.g. handleFileInfo) outside the initial
+        # handshake window. Most app-side handlers don't gate on handshake state, so injecting
+        # one mid-session is a legitimate way to fuzz/exercise that code path on demand.
+        self._inject_fr_q: queue.Queue[mesh_pb2.FromRadio] = queue.Queue()
         self.fuzzer: Fuzzer | None = (
             Fuzzer(params.fuzz, capture.nodes, self._ch_index) if params.fuzz else None
         )
@@ -378,6 +385,13 @@ class ReplaySession:
             args=(send,),
             daemon=True,
             name=f"replay-inject-{self.state.id}",
+        ).start()
+        # same, for raw top-level FromRadio injection (inject_fromradio()).
+        threading.Thread(
+            target=self._inject_fromradio_loop,
+            args=(send,),
+            daemon=True,
+            name=f"replay-inject-fr-{self.state.id}",
         ).start()
 
         while not self.state.stop.is_set():
@@ -641,6 +655,33 @@ class ReplaySession:
         send(fr)
 
     # -- live injection --
+    def inject_fromradio(self, messages: list[mesh_pb2.FromRadio]) -> int:
+        """Queue raw top-level FromRadio messages to emit onto the live connection.
+
+        Unlike `inject()` (which wraps a MeshPacket for normal mesh traffic), this sends
+        the FromRadio as-is -- for handshake-only oneofs like `fileInfo`, `my_info`,
+        `config`, `moduleConfig`, `channel` that have no MeshPacket envelope. Still goes
+        through the same `send()` path as everything else, so frame-level fuzz corruption
+        (`maybe_corrupt_frame`) still applies if the session has `fuzz` configured.
+        """
+        for fr in messages:
+            self._inject_fr_q.put(fr)
+        return len(messages)
+
+    def _inject_fromradio_loop(self, send: Any) -> None:
+        stop = self.state.stop
+        while not stop.is_set():
+            try:
+                fr = self._inject_fr_q.get(timeout=0.5)
+            except queue.Empty:
+                continue
+            try:
+                send(fr)
+            except (OSError, ConnectionError):
+                return
+            self.state.packets_sent += 1
+            self.state.injected += 1
+
     def inject(
         self, packets: list[mesh_pb2.MeshPacket], *, channel: str = "LongFast", fuzz: bool = False
     ) -> int:
@@ -798,6 +839,14 @@ class ReplayManager:
         if sess is None:
             return {"error": f"no session {sid}"}
         n = sess.inject(packets, channel=channel, fuzz=fuzz)
+        return {"id": sid, "queued": n, "connected": sess.state.connected}
+
+    def inject_fromradio(self, sid: str, messages: list[mesh_pb2.FromRadio]) -> dict[str, Any]:
+        with self._lock:
+            sess = self._sessions.get(sid)
+        if sess is None:
+            return {"error": f"no session {sid}"}
+        n = sess.inject_fromradio(messages)
         return {"id": sid, "queued": n, "connected": sess.state.connected}
 
     def stop(self, sid: str | None = None) -> dict[str, Any]:

--- a/src/meshtastic_mcp/replay/engine.py
+++ b/src/meshtastic_mcp/replay/engine.py
@@ -358,7 +358,9 @@ class ReplaySession:
                 self._srv.close()
             except OSError:
                 pass
-            self.state.ended = True
+            # Write the terminal log line *before* flipping `ended` so any
+            # observer polling `state.ended` is guaranteed to see `session_ended`
+            # already on disk (avoids a stop_requested-is-last race).
             self._log_event(
                 "session_ended",
                 packets_sent_total=self.state.packets_sent,
@@ -366,6 +368,7 @@ class ReplaySession:
                 fuzz=self.fuzzer.status() if self.fuzzer is not None else None,
             )
             self._log.close()
+            self.state.ended = True
 
     def _serve_client(self, client: socket.socket) -> None:
         send_lock = threading.Lock()

--- a/src/meshtastic_mcp/server.py
+++ b/src/meshtastic_mcp/server.py
@@ -2465,6 +2465,7 @@ _DESTRUCTIVE = {
     "replay_stop",
     "replay_inject",  # emits packets onto the live connection
     "replay_inject_beacon",  # emits a MESH_BEACON_APP packet
+    "replay_inject_fileinfo",  # emits a FileInfo FromRadio onto the live connection
     "replay_inject_traceroute",  # emits a TRACEROUTE_APP RouteDiscovery packet
     "replay_inject_waypoint",  # emits a WAYPOINT_APP packet (with optional geofence)
     "local_model_serve",  # spawns a detached llama-server process (and may install it)

--- a/src/meshtastic_mcp/server.py
+++ b/src/meshtastic_mcp/server.py
@@ -2124,6 +2124,39 @@ def replay_inject_beacon(
 
 
 @app.tool()
+def replay_inject_fileinfo(
+    session_id: str,
+    file_name: str,
+    size_bytes: int = 0,
+    count: int = 1,
+) -> dict[str, Any]:
+    """Inject a raw FileInfo FromRadio message into a running replay session.
+
+    Unlike `replay_inject` (which wraps a MeshPacket for mesh traffic), FileInfo is a
+    handshake-only FromRadio oneof (STATE_SEND_FILEMANIFEST) with no MeshPacket envelope --
+    real firmware only ever sends it during the initial config handshake. Most app-side
+    handlers don't gate on handshake state though, so this lets you exercise that code path
+    on demand, e.g. to fuzz-test unbounded accumulation (send many with `count`) or
+    malformed/adversarial entries (huge `file_name`, negative `size_bytes`) in a
+    long-running session rather than only at connect time.
+
+    `count` repeats the inject (each with a distinct file_name suffix so entries don't
+    collide) -- useful for probing whether a client caps its file manifest.
+    """
+    msgs = [
+        replay_build.fromradio_from_kind(
+            "fileinfo",
+            {
+                "file_name": file_name if count == 1 else f"{file_name}.{i}",
+                "size_bytes": size_bytes,
+            },
+        )
+        for i in range(max(1, count))
+    ]
+    return get_replay_manager().inject_fromradio(session_id, msgs)
+
+
+@app.tool()
 def replay_inject_traceroute(
     session_id: str,
     destination_node: int,

--- a/tests/unit/test_replay.py
+++ b/tests/unit/test_replay.py
@@ -579,6 +579,17 @@ def test_from_kind_builds_each_packet_type():
         build.from_kind("bogus", {}, from_node=1)
 
 
+def test_fromradio_from_kind_builds_fileinfo():
+    from meshtastic_mcp.replay import build
+
+    fr = build.fromradio_from_kind("fileinfo", {"file_name": "log.bin", "size_bytes": 4096})
+    assert fr.WhichOneof("payload_variant") == "fileInfo"
+    assert fr.fileInfo.file_name == "log.bin"
+    assert fr.fileInfo.size_bytes == 4096
+    with pytest.raises(ValueError):
+        build.fromradio_from_kind("bogus", {})
+
+
 def test_from_events_builds_scenario_capture():
     cap = capture.from_events(
         [
@@ -640,6 +651,58 @@ def test_live_inject_reaches_client():
                     found = True
         client.close()
         assert found  # injected waypoint reached the live client
+        assert mgr.status(sid)["injected"] >= 1
+    finally:
+        mgr.stop(sid)
+
+
+def test_live_inject_fromradio_reaches_client():
+    """inject_fromradio() is the handshake-only counterpart to inject(): a raw FromRadio
+    (e.g. fileInfo) with no MeshPacket envelope, delivered outside the initial handshake
+    window. Regression coverage for the gap found while adversarial-fuzz-testing
+    Meshtastic-Android: there was no way to exercise a client's FileInfo handler
+    (STATE_SEND_FILEMANIFEST) mid-session, only at connect time.
+    """
+    from meshtastic_mcp.replay import build, get_manager
+
+    cap = sim.generate(nodes=5, days=1, seed=1, start=1_700_000_000)
+    mgr = get_manager()
+    probe = socket.socket()
+    probe.bind(("127.0.0.1", 0))
+    port = probe.getsockname()[1]
+    probe.close()
+    st = mgr.start(cap, ReplayParams(host="127.0.0.1", port=port, rate=600, node_delay=0))
+    sid = st["id"]
+    try:
+        client = None
+        deadline = time.time() + 5
+        while time.time() < deadline:
+            try:
+                client = socket.create_connection(("127.0.0.1", port), timeout=1)
+                break
+            except OSError:
+                time.sleep(0.05)
+        assert client is not None
+        _send_toradio(client, want_config_id=69420)
+        _send_toradio(client, want_config_id=69421)
+        time.sleep(0.3)
+
+        fr_in = build.fromradio_from_kind(
+            "fileinfo", {"file_name": "evil.bin", "size_bytes": 999999999}
+        )
+        res = mgr.inject_fromradio(sid, [fr_in])
+        assert res["queued"] == 1
+        found = False
+        t0 = time.time()
+        while time.time() - t0 < 3 and not found:
+            fr = _read_frame(client)
+            if (
+                fr.WhichOneof("payload_variant") == "fileInfo"
+                and fr.fileInfo.file_name == "evil.bin"
+            ):
+                found = True
+        client.close()
+        assert found  # injected FileInfo reached the live client
         assert mgr.status(sid)["injected"] >= 1
     finally:
         mgr.stop(sid)

--- a/tests/unit/test_replay.py
+++ b/tests/unit/test_replay.py
@@ -586,6 +586,10 @@ def test_fromradio_from_kind_builds_fileinfo():
     assert fr.WhichOneof("payload_variant") == "fileInfo"
     assert fr.fileInfo.file_name == "log.bin"
     assert fr.fileInfo.size_bytes == 4096
+    # Adversarial negative size_bytes must still encode (masked into uint32) rather
+    # than raising -- replay_inject_fileinfo advertises negative values as a fuzz case.
+    neg = build.fromradio_from_kind("fileinfo", {"file_name": "x", "size_bytes": -1})
+    assert neg.fileInfo.size_bytes == 0xFFFFFFFF
     with pytest.raises(ValueError):
         build.fromradio_from_kind("bogus", {})
 


### PR DESCRIPTION
While adversarially fuzz-testing Meshtastic-Android with this server's replay engine ([Meshtastic-Android#6093](https://github.com/meshtastic/Meshtastic-Android/pull/6093)), I found a real bug — `RadioConfigRepositoryImpl.addFileInfo` grew its in-memory file-manifest accumulator unbounded — but only by reading the app's source. There was no way to reproduce it live: `replay_inject` only builds `MeshPacket`-wrapped mesh traffic (`waypoint`/`position`/`text`/`nodeinfo`/`beacon`/`traceroute`/`raw`). `FileInfo` is a handshake-only `FromRadio` oneof (`STATE_SEND_FILEMANIFEST`) with no `MeshPacket` envelope, so it was completely outside the injectable surface.

## What's added

A parallel injection path for raw top-level `FromRadio` messages, alongside the existing `MeshPacket` one:

- `ReplaySession.inject_fromradio()` / `_inject_fromradio_loop()` — a second queue + drain loop next to the existing `inject()`/`_inject_loop()`, reusing the same `send()` path so frame-level fuzz corruption (`maybe_corrupt_frame`) still applies.
- `ReplayManager.inject_fromradio()` — manager-level wrapper, mirrors `inject()`.
- `build.fromradio_from_kind()` — builds a `FromRadio` from a high-level `kind` + `args`; only `fileinfo` (`file_name`, `size_bytes`) for now, easy to extend to `my_info`/`config`/`moduleConfig`/`channel` later for testing other handshake-phase decode paths.
- `replay_inject_fileinfo` MCP tool — the caller-facing entry point, with a `count` param specifically for probing unbounded-accumulation bugs (send a burst past a client's expected cap).

Since most app-side handlers for these oneofs don't gate on handshake state, injecting one mid-session (not just at connect time) is a legitimate way to exercise/fuzz that code path on demand.

## Testing performed

- `fromradio_from_kind` unit test (builds `fileInfo`, rejects unknown kinds).
- Live-socket round-trip test mirroring the existing `inject()` coverage — confirms `inject_fromradio()` reaches a connected client.
- **Live device verification**: injected 4500 FileInfo entries mid-session against a real Pixel 6a running Meshtastic-Android (past the 4096-entry cap just added to that app in response to this exact gap) and confirmed delivery + no crash.
- `ruff check`, `ruff format --check`, `mypy` clean.
- Full `tests/unit/test_replay.py` (35 tests) passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for live injection of raw handshake-style `FromRadio` messages into active replay sessions.
  * Added an MCP tool, `replay_inject_fileinfo`, to inject one or more `fileInfo` handshake messages with automatic filename suffixing for batch runs.
* **Bug Fixes**
  * Improved delivery and accounting of injected handshake messages to connected clients during an ongoing session.
* **Tests**
  * Added unit and end-to-end tests for `fileInfo` message construction (including safe handling of negative `size_bytes`) and for verifying injected payload reach the client.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->