### PR TITLE
feat(replay): calibrate synthetic mesh against real event captures (realism WS0–WS5)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,6 @@ htmlcov/
 
 # hatch-vcs generated
 src/meshtastic_mcp/_version.py
+
+# Locally generated capture-derived stat profiles (from private datasets - do not commit)
+src/meshtastic_mcp/replay/profiles/*.json

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -96,6 +96,7 @@ uv run meshtastic-mcp boards get heltec-v3  # full metadata for one board
 uv run meshtastic-mcp info /dev/ttyUSB0     # firmware/region/node info
 uv run meshtastic-mcp nodes /dev/ttyUSB0    # mesh peers visible to this node
 uv run meshtastic-mcp watch packets         # live-tail recorder stream (logs/packets/events)
+uv run meshtastic-mcp capture-stats defcon  # realism stats for a capture (*.db/*.jsonl) or sim preset
 uv run meshtastic-mcp completion bash        # shell completion (eval "$(...)")
 # All read-only subcommands accept --json for machine-readable output.
 

--- a/docs/sim-realism-plan.md
+++ b/docs/sim-realism-plan.md
@@ -250,15 +250,36 @@ TAK-free; `[tak]` extra round-trips an SDK fixture.
 | Phase | Depends on | Size |
 |---|---|---|
 | WS0 metrics + fixtures | — | ✅ done |
-| WS1 traffic economy | WS0 | M |
-| WS2 observer model | WS0 | M |
-| WS3 temporal coherence | WS1 | M |
-| WS-T sensor telemetry | WS3 (climate/clock model) | S–M |
-| WS4 fit v2 + presets | WS1+WS2 | M |
-| WS-A ATAK layer | WS3 (mobility/battery), opt-in | S–M |
-| WS5 regression tests | all | S |
+| WS1 traffic economy | WS0 | ✅ done |
+| WS2 observer model | WS0 | ✅ done |
+| WS3 temporal coherence | WS1 | ✅ done |
+| WS-T sensor telemetry | WS3 (climate/clock model) | ✅ done |
+| WS4 fit v2 + presets | WS1+WS2 | ✅ done |
+| WS-A ATAK layer | WS3 (mobility/battery), opt-in | ✅ done |
+| WS5 regression tests | all | ✅ done |
 
-WS1 and WS2 are independent after WS0 and can proceed in parallel.
+All workstreams landed. Follow-ups if wanted: a `capture-stats` CLI
+subcommand (WS0 deferred), TAKPacketV2 wire-format via the optional `[tak]`
+extra + TAKPacket-SDK fixtures (WS-A stretch), and re-fitting the preset
+constants whenever fresh real captures land (feed `fit_profile` output back
+into `PRESETS`).
+
+## Outcome (measured, 1600 nodes / 3 days unless noted)
+
+| Axis | Pre-calibration | Now | Real (BM / DC) |
+|---|---|---|---|
+| Portnum mix | TEL 48%, NODEINFO 1.3%, ROUTING 0.08% | NODEINFO 35%, POS 29%, TEL 17%, ROUTING 9% | NODEINFO 34-38%, POS 31-34%, TEL 11-24%, ROUTING ≤12% |
+| Observed pkts/hr | 4,919 | 1,036 (defcon preset) | 643 / 977 |
+| Duplicate rebroadcasts | none | dup≥2 id-fraction 0.29 | — / 0.29 |
+| RX SNR / RSSI | absent | modelled (p50 6.25 / −97) | 3..10 / −84..−100 |
+| Position interval p50 | 164 s | ~700 s | 583 s |
+| Text p50 / max | 10 / 66 | 28 / ~235 | 17-25 / 227-246 |
+| Battery | i.i.d. per packet | bimodal (101 + curve + 0) | bimodal |
+| chutil | i.i.d. | tracks diurnal load (ρ≈0.99) | follows load |
+| Sensor telemetry | uniform, temp-only | personas + climate + lux/IAQ + NaN | fielded, diurnal |
+| Scenarios | MeshCon only | meshcon / burningman / defcon presets | — |
+| Adversary | parser/adversary/chaos | + `ninja` (DC33 NodeInfo spoof) | — |
+| ATAK | none | opt-in TAK squad (portnum 72) | none in captures |
 
 ## Invariants (do not break)
 

--- a/docs/sim-realism-plan.md
+++ b/docs/sim-realism-plan.md
@@ -1,0 +1,269 @@
+# Plan: calibrating `replay/sim.py` against real event captures
+
+Goal: make the synthetic mesh generator produce traffic that is statistically
+indistinguishable from what a real gateway heard at Burning Man 2025 and
+DEF CON 33, while keeping every parameter tunable and every output seeded,
+synthetic, and PII-free.
+
+## Ground truth
+
+Two private datasets, cloned to `~/meshtastic/datasets/` (do **not** vendor any
+raw records into this repo — aggregates only):
+
+- **Burning Man 2025** — `garthvh/burningmesh-replay`: SQLite
+  (`packet` / `packet_seen` / `node`), 156k decoded MeshPackets, 1,606 nodes,
+  10 days. Our `capture.from_sqlite()` already reads this schema directly.
+- **DEF CON 33** — `darknet-ng/DEFCON33-Meshtastic-Traffic`: gateway
+  `str(dict)` text logs from Pi Zero + SX1262 gateways (LongFast +
+  ShortTurbo planes), 181k records, 1,831 senders, ~186 h.
+
+Measured comparison (sim = `generate(nodes=1600, days=3)`), analysis script
+currently at `/tmp/mesh_stats.py`:
+
+| Metric | Burning Man | DEF CON 33 | Sim today |
+|---|---|---|---|
+| Portnum mix | NODEINFO 38%, POS 34%, ROUTING 12%, TEL 11%, TEXT 2.9% | NODEINFO 34%, POS 31%, TEL 24%, TEXT 9% | TEL 48%, POS 28%, NODEINFO 1.3%, ROUTING 0.08% |
+| Pkts/hour (gateway view) | 643 | 977 | 4,919 |
+| Position interval p50 | 583 s | — | 164 s |
+| Inter-arrival p99 / max | 33 s / 2,308 s | 43 s / 2,213 s | 5 s / 18 s |
+| Duplicate packet IDs | — | 42% seen ≥2× | 0% |
+| Encrypted fraction | 0 (pre-decoded) | 46% (40.7% via_mqtt) | 16.6% |
+| hop_start | 4 (62%), 3 (28%), 7 subpop | 3 (88%), 7 subpop | 3/4/5 only |
+| Text len p50/p90/max | 25 / 100 / 227 | 17 / 78 / 246 | 10 / 57 / 66 |
+| Text DM fraction | 3.4% | ~0 (PKI-invisible) | 11.9% |
+| rx_snr / rx_rssi p50 | 3.0 / −100 | 10 / −84 | not modeled |
+| Routers per ~1600 nodes | 6–13 | ~6 | 66 |
+| Talker skew (top 10% share) | 47% | 67% | 78% |
+| Battery | per-node discharge, 0% + 101 modes | — | i.i.d. per packet |
+| chutil | p50 7.4, max 39 | — | p50 15.2, max 75; i.i.d. |
+
+Two structural gaps explain most rows:
+
+1. **Observer gap** — the sim emits "all traffic that exists"; the datasets are
+   *what one gateway heard*: RF-lossy, duplicated by rebroadcast (copies with
+   decremented `hop_limit`, distinct SNR/RSSI, `relay_node`), and stamped with
+   `rx_snr`/`rx_rssi`/`priority`/`via_mqtt`.
+2. **Social gap** — no NodeInfo want_response exchanges (arrival storms), no
+   ACK economy, no conversation bursts, no per-node temporal state (battery
+   curves, chutil coupled to airtime).
+
+## Workstreams
+
+### WS0 — Metrics harness + golden stat fixtures ✅ *(done)*
+
+Shipped:
+
+- `src/meshtastic_mcp/replay/metrics.py` — `capture_stats(cap)` (single-pass
+  stat schema incl. telemetry variant mix, env-field presence, TAK counter)
+  and `sqlite_extra_stats(db)` (observation-level dup multiplicity + RX
+  SNR/RSSI populations that `from_sqlite`'s per-packet dedupe hides).
+- `tools/import_defcon_logs.py` — streaming `str(dict)`-log → shared SQLite
+  schema importer (181,279/181,281 DC records parsed; duplicates preserved as
+  `packet_seen` rows: 117,676 packets / 181,278 observations).
+- `src/meshtastic_mcp/replay/profiles/{burningman2025,defcon33}.json` —
+  aggregate stat profiles (8 KB each; leak-checked: no payloads, names,
+  channel names, keys, or coordinates). **Generated locally, gitignored —
+  dataset-derived files are not committed.** Regression baselines + WS4
+  calibration inputs; profile-dependent tests skip when absent. WS4 presets
+  therefore encode their tunables as reviewed constants in code (as
+  `sim.PROFILE` already does), not by shipping these files.
+- `tests/unit/test_replay_metrics.py` — schema/determinism, importer
+  round-trip on a synthetic log in the DC format, profile integrity, and
+  calibration-target assertions (DC dup rate > 20%, BM NODEINFO > TELEMETRY,
+  ROUTING > 5%, text max > 200).
+- Deferred: a `capture-stats` CLI subcommand (trivial once needed).
+
+Local (not committed): real datasets in `~/meshtastic/datasets/`, imported
+DBs at `/tmp/{burningmesh,defcon33}.db`, first-pass analysis in
+`~/meshtastic/datasets/analysis/`.
+
+### WS1 — Traffic economy fixes in `sim.py` *(fix the portnum mix + volume)*
+
+- **NodeInfo exchange storms:** on node join, emit broadcast NodeInfo **plus**
+  k ∈ [2, 8] want_response request/reply pairs with nearby nodes (drawn by
+  cluster); plus a steady background of exchange pairs proportional to churn.
+  Target NODEINFO ≈ 30–40% of decoded traffic.
+- **ACK economy:** ROUTING packets generated as a function of DM/want_ack
+  traffic and traceroutes, not a fixed trickle. Target ≈ 5–12%
+  (`PROFILE["ack_ratio"]`).
+- **Decouple beacons from `talk`:** the lognormal talk multiplier applies to
+  social traffic (text, exchanges) at full strength but position/telemetry
+  cadence at dampened strength (e.g. `talk**0.3`). Target position interval
+  p50 ≈ 10 min; telemetry share ≤ 25%.
+- **Role mix:** routers ≈ 0.4–0.8% of nodes (6–13 per 1600, keep the named-8
+  cap); add `ROUTER_CLIENT` (legacy) and `CLIENT_HIDDEN` to `role_weights`.
+- **Text realism:** three-component length model (short one-liners ~60%,
+  themed lines, long-tail 120–240-char "wall of text" bursts); DM fraction
+  ↓ to ~3%; hop_start subpopulation at 7 (`PROFILE["hop_start_weights"]`).
+- **Small fidelity:** encrypted packets get payload lengths sampled from the
+  portnum mix and a hash-like channel byte (not 0); decoded packets get
+  `priority` (BACKGROUND for beacons/telemetry, DEFAULT/RELIABLE for text)
+  and `bitfield`; precision_bits gains 0 and 15 buckets.
+
+**Acceptance:** portnum mix within ±8 pp of the blended real mix per port;
+text p50/p90/max within tolerance; all existing tests still pass
+(`test_all_sim_data_is_synthetic` unchanged — no real strings introduced).
+
+### WS2 — Observer / RF model *(new module, biggest realism win)*
+
+New `src/meshtastic_mcp/replay/observer.py`, applied as a final pipeline stage
+inside `generate()` (pre-serialization, so it's cheap) and exposed as a pure
+function for tests:
+
+- Observer placed at a venue coordinate (`PROFILE["observer"]`), default =
+  venue center.
+- Per emitted packet, from sender position: log-distance path loss
+  `RSSI = tx_power − PL(d, n) + N(0, σ)`; SNR derived from RSSI vs noise
+  floor; reception probability = sigmoid around sensitivity. Lost packets are
+  dropped from the capture (this **is** the volume calibration).
+- Rebroadcast duplicates: k extra copies (weights fit from DC: 1×58%, 2×?,
+  3×~24%, tail to 8) with decremented `hop_limit`, per-copy RSSI/SNR redrawn
+  through a random relay position, `relay_node` = low byte of a plausible
+  relay, small time offsets (0.2–5 s).
+- `via_mqtt` subpopulation (`mqtt_fraction`, DC ≈ 0.4): MQTT-heard copies get
+  no SNR/RSSI, full hop fields — models the bridged plane.
+- Serialized packets now carry `rx_snr`/`rx_rssi`/`rx_time`/`relay_node`;
+  engine change: `_stream()` keeps restamping `rx_time` but must **not**
+  clobber the rest (it already doesn't — verify with a test).
+- Tunables: `enabled`, `position`, `tx_power`, `path_loss_exp`, `sigma_db`,
+  `noise_floor`, `dup_weights`, `mqtt_fraction`, `loss_floor`. `enabled=False`
+  returns today's omniscient view (back-compat; default **on** for presets,
+  off for bare `generate()` to keep existing tests deterministic-stable).
+
+**Acceptance:** observed pkts/hr within 2× of real for 1600 nodes; dup-ID
+multiplicity and SNR/RSSI percentiles within tolerance of the DC profile;
+hop_limit spread matches (0..hop_start all populated).
+
+### WS3 — Temporal coherence *(per-node state machines)*
+
+- **Battery:** per-node mode (plugged→101, discharging with a rate, solar
+  recharge for infra) evolved across the event; a fraction hit 0 and go
+  silent (ties into presence/churn). Kills the i.i.d. draws.
+- **chutil from actual airtime:** compute per-hour generated airtime
+  (payload size → airtime at the active preset) and derive
+  channel_utilization telemetry from it (+noise), so chutil tracks the
+  diurnal envelope like reality.
+- **Bursty text:** self-exciting process — each text raises reply probability
+  on its channel for ~5 min (target inter-arrival p99 ≈ 30–45 s with a
+  long-silence tail, vs today's uniform smear); occasional scripted spikes
+  hookable by presets (keynote, emergency).
+
+**Acceptance:** inter-arrival p99/max within tolerance; battery histogram
+bimodal (101 + curve + 0-spike); chutil correlates with hour-of-day traffic
+(ρ > 0.6).
+
+### WS4 — `fit_profile()` v2 + scenario presets
+
+- Extend `fit_profile()` to also fit: 24-bin diurnal envelope, hop_limit/
+  hop_start hists, talker-skew lognormal params, text-length histogram,
+  encrypted fraction, per-role portnum rates, dup multiplicity, SNR/RSSI
+  params, ack ratio — i.e. everything `generate()` now consumes. Output is
+  exactly the WS0 profile JSON schema.
+- `generate(profile=...)` accepts the JSON (file path or dict).
+- Presets: `replay_start(source="burningman")` / `source="defcon"` resolve to
+  `generate(profile=<preset dict>)` in `_load_replay_capture()` (server.py
+  ~line 1916) — preset tunables are reviewed constants in code (informed by
+  the local profiles, not shipping them), with venue geo + channel lineups +
+  scripted spikes
+  (BM flood-emergency arc; DC con-hours envelope, ShortTurbo second plane,
+  46% encrypted, mqtt_fraction 0.4). `meshcon` stays the default.
+- Fuzz tie-in: a `ninja` preset in `fuzz.py` — NodeInfo spoof floods
+  (rewrites long_name/emoji of recently-seen nodes, replays with correct
+  node num), modeled on the DC 33 attack. Composes with presets:
+  `replay_start(source="defcon", fuzz="ninja")`.
+
+**Acceptance:** `generate(profile=fit_profile(from_sqlite(real_db)))` scores
+within tolerance of that capture on the WS5 harness; `replay_start`
+docstring/tests updated; tool schema unchanged otherwise.
+
+### WS-T — Realistic sensor telemetry *(with WS3)*
+
+Measured from the BM capture (now in the golden profile):
+
+- Variant mix: device_metrics 85%, power_metrics 8.6%, environment_metrics
+  6.5%; **57 env senders** (~3.5% of nodes), each emitting a *consistent
+  field subset* — temperature always, **lux 63%**, humidity 36%, pressure
+  17%, gas_resistance + IAQ 3.4%.
+- Temperature 8.2–54.8 °C, p50 20.2 — a desert diurnal swing, not a uniform
+  draw. Humidity contains **NaN** values (real sensors emit NaN; clients must
+  cope). Pressure is bimodal ~782 vs ~1012 hPa (station-altitude vs
+  sea-level-corrected devices).
+
+Sim today: env telemetry only from SENSOR-role + 3 router nodes at a flat
+30-min cadence, uniform 12–33 °C / 8–40 %RH / 770–790 hPa, no lux/IAQ, no
+diurnal coupling, no NaN. Plan:
+
+- **Sensor personas**: each env node draws a device class once (temp-only /
+  +lux / BME280 → +humidity+pressure / BME680 → +gas+IAQ / INA → power) and
+  emits that field subset consistently.
+- **Physical venue model** (shared with WS3's clock): temperature = diurnal
+  sinusoid (mean/amplitude in `PROFILE["climate"]`; playa preset ≈ 10–50 °C),
+  lux from solar elevation (0 at night), humidity anti-correlated with
+  temperature, pressure = slow random walk around the venue-altitude mode.
+- **NaN injection knob** (small fraction of humidity/pressure readings).
+- **Power metrics** as a first-class stream (~9% of telemetry, ch1–ch3).
+- `fit_profile` v2 fits variant mix / env-field presence / temp range —
+  already captured by `capture_stats`, so the fit is a pass-through.
+
+**Acceptance:** variant mix within ±3 pp of profile; env-field presence
+ratios match; temperature tracks the diurnal envelope (ρ > 0.7 with the
+climate model); a NaN fraction survives serialization.
+
+### WS-A — ATAK / TAKPacket traffic *(opt-in scenario layer)*
+
+Fact from the data: **zero** ATAK packets (portnum 72/257) in either real
+capture — so TAK traffic is an opt-in scenario knob (default off), not part
+of the fitted event profiles. Purpose: exercise app/plugin TAK paths
+(ATAK plugin, forwarder, map PLI rendering) against the simulated mesh.
+
+- `PROFILE["tak"] = {"team_nodes": 0, "pli_interval": 45, "chat_per_hour": 2,
+  "team": "Cyan", ...}` — when `team_nodes > 0`, a squad of nodes with
+  callsigns emits `TAKPacket` (portnum 72, `atak_pb2`): PLI
+  (lat/lon/alt/speed/course following the node's mobility track), GeoChat
+  (to team / broadcast), and status (battery follows the WS3 battery state).
+  Core stays dependency-light — legacy TAKPacket protobuf needs nothing new.
+- **V2 wire format**: `meshtastic/TAKPacket-SDK` (Python impl; CoT XML →
+  TAKPacketV2 + zstd dictionary compression, median 87 B payloads) behind an
+  optional `[tak]` extra. When installed, the sim can emit wire-compressed V2
+  payloads and we validate byte-compat against the SDK's 47 shared fixtures;
+  without it, legacy protobuf only.
+- Fuzz composition: malformed/oversized CoT and truncated compressed payloads
+  as a `fuzz` preset for parser robustness.
+- `capture_stats` already counts `tak_packets`, so regression coverage is
+  free once generation lands.
+
+**Acceptance:** with `team_nodes=4`, the app-visible mesh shows a moving TAK
+squad (PLI cadence ±20%, chat on the right channel); default profiles remain
+TAK-free; `[tak]` extra round-trips an SDK fixture.
+
+### WS5 — Regression validation
+
+- `tests/unit/test_sim_realism.py`: generate (seeded, ~400 nodes, 2 days,
+  observer on) → `capture_stats` → assert each metric inside tolerance bands
+  derived from the two golden profiles (bands stored alongside the JSONs).
+  Runs in the portable tier (no hardware/firmware).
+- Keep `test_sim_is_seeded_...` byte-for-byte determinism: all new randomness
+  must draw from the same seeded `rng`.
+
+## Sequencing & effort
+
+| Phase | Depends on | Size |
+|---|---|---|
+| WS0 metrics + fixtures | — | ✅ done |
+| WS1 traffic economy | WS0 | M |
+| WS2 observer model | WS0 | M |
+| WS3 temporal coherence | WS1 | M |
+| WS-T sensor telemetry | WS3 (climate/clock model) | S–M |
+| WS4 fit v2 + presets | WS1+WS2 | M |
+| WS-A ATAK layer | WS3 (mobility/battery), opt-in | S–M |
+| WS5 regression tests | all | S |
+
+WS1 and WS2 are independent after WS0 and can proceed in parallel.
+
+## Invariants (do not break)
+
+- Seeded determinism: `(seed, nodes, days, start)` → byte-identical capture.
+- 100% synthetic output: fixtures are aggregates only; no real node names,
+  texts, keys, or coordinates enter the repo (`test_all_sim_data_is_synthetic`).
+- Core stays dependency-light; metrics/observer use stdlib + existing protobufs.
+- `generate()` default signature behavior unchanged for existing callers.

--- a/docs/sim-realism-plan.md
+++ b/docs/sim-realism-plan.md
@@ -258,11 +258,19 @@ TAK-free; `[tak]` extra round-trips an SDK fixture.
 | WS-A ATAK layer | WS3 (mobility/battery), opt-in | ✅ done |
 | WS5 regression tests | all | ✅ done |
 
-All workstreams landed. Follow-ups if wanted: a `capture-stats` CLI
-subcommand (WS0 deferred), TAKPacketV2 wire-format via the optional `[tak]`
-extra + TAKPacket-SDK fixtures (WS-A stretch), and re-fitting the preset
-constants whenever fresh real captures land (feed `fit_profile` output back
-into `PRESETS`).
+All workstreams landed, plus the deferred stretch items:
+
+- ✅ `capture-stats` CLI subcommand (`meshtastic-mcp capture-stats <db|preset>`,
+  `--json`) — read-only wrapper over `metrics.capture_stats`.
+- ✅ TAKPacketV2 wire-format via the optional `[tak]` extra (meshtastic-tak
+  SDK): `profile tak.wire="v2"` emits real zstd-dictionary-compressed
+  TAKPacketV2 payloads (median ~59 B, cross-instance byte-compatible with the
+  SDK). Gated by the new `tak` capability + doctor probe; legacy TAKPacket
+  stays the dependency-free default. (The SDK owns the shared dictionaries +
+  CoT conversion, so it's the right dep even though we only exercise the wire
+  path — `kzstd` is the Kotlin-side binding, N/A for Python.)
+- Remaining, process-only: re-fit the preset constants whenever fresh real
+  captures land (feed `fit_profile` output back into `PRESETS`).
 
 ## Outcome (measured, 1600 nodes / 3 days unless noted)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,6 +73,12 @@ web = [
 # (`apt install librtlsdr-dev rtl-sdr`), it must be the librtlsdr/librtlsdr (keenerd)
 # fork; pyrtlsdrlib is harmless alongside it (loader falls back to the system lib).
 sdr = ["pyrtlsdr>=0.3", "pyrtlsdrlib>=0.0.4", "numpy>=1.26"]
+# The `tak` capability enables real TAKPacketV2 zstd-dictionary wire compression
+# for the replay sim (profile tak.wire="v2"), via the meshtastic-tak SDK. Not on
+# PyPI, so this is a git dependency; it pulls `zstandard`.
+tak = [
+    "meshtastic-tak @ git+https://github.com/meshtastic/TAKPacket-SDK.git#subdirectory=python",
+]
 # The `firmware` capability needs a Meshtastic firmware checkout + PlatformIO `pio`
 # on PATH (not pip-installable) — set MESHTASTIC_FIRMWARE_ROOT.
 # The `emulator` capability needs the `android` CLI + `adb` on PATH (not pip-installable).
@@ -91,6 +97,10 @@ Issues = "https://github.com/meshtastic/meshtastic-mcp/issues"
 [build-system]
 requires = ["hatchling", "hatch-vcs"]
 build-backend = "hatchling.build"
+
+# The [tak] extra pulls meshtastic-tak from git (not on PyPI); allow the direct ref.
+[tool.hatch.metadata]
+allow-direct-references = true
 
 [tool.hatch.version]
 source = "vcs"

--- a/scripts/ci_atak_app_loop.py
+++ b/scripts/ci_atak_app_loop.py
@@ -1,0 +1,176 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Meshtastic contributors
+# SPDX-License-Identifier: GPL-3.0-only
+"""ATAK app-plane e2e: render a simulated Meshtastic TAK squad in ATAK-CIV.
+
+The TAK counterpart of ``ci_android_app_loop.py``. Assumes an Android emulator is
+**already booted**. It generates a synthetic Meshtastic mesh carrying a
+TAKPacketV2 squad, stands up a CoT streaming TAK server from it
+(:mod:`meshtastic_mcp.replay.tak_server` — the same CoT an app's in-app TAK
+server would forward), points ATAK-CIV at that stream, and asserts a squad
+callsign marker **renders** on ATAK's map (receive leg), then confirms ATAK's
+own self-PLI streams back to the server and converts to a mesh TAKPacketV2
+(send leg) — i.e. bidirectional device↔app TAK.
+
+    python scripts/ci_atak_app_loop.py --atak-apk ATAK-CIV.apk
+
+Requires the ``[tak]`` extra (meshtastic-tak) for the CoT build, ATAK-CIV
+installed/installable, and the ``android`` capability (adb). Emits
+``LOOP atak-render …`` + ``LOOP atak-send …`` and exits non-zero if either leg fails.
+
+Notes / assumptions (ATAK is heavy to automate; this is an opt-in CI job):
+- ATAK reaches the host CoT server at ``10.0.2.2:<port>`` (emulator → host).
+- The streaming TCP input is preconfigured by pushing an ATAK ``.pref`` before
+  launch; first-run EULA is dismissed via a UI tap fallback. Both are
+  best-effort and version-sensitive — the render assertion is the real gate.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import pathlib
+import sys
+import time
+import xml.etree.ElementTree as ET
+
+ATAK_PACKAGE = "com.atakmap.app.civ"
+
+# Reuse verdict() from the sibling helper (scripts/ is not a package).
+_SIB = pathlib.Path(__file__).resolve().parent / "ci_device_mesh_e2e.py"
+_spec = importlib.util.spec_from_file_location("ci_device_mesh_e2e", _SIB)
+assert _spec and _spec.loader
+_mesh = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_mesh)
+
+
+# ── pure helpers (unit-tested) ───────────────────────────────────────────────
+def expected_callsigns(events: list[tuple[int, bytes]]) -> set[str]:
+    """Squad callsigns present in a list of ``(rx_time, cot_xml)`` events."""
+    out: set[str] = set()
+    for _t, cot in events:
+        contact = ET.fromstring(cot).find("detail/contact")
+        if contact is not None and contact.attrib.get("callsign"):
+            out.add(contact.attrib["callsign"])
+    return out
+
+
+def atak_stream_pref(host: str, port: int, *, name: str = "meshsim") -> str:
+    """An ATAK connection ``.pref`` (streaming TCP input) pointing at host:port.
+
+    Pushed to ATAK's config-import dir so the stream is preconfigured without a
+    UI walk. ATAK connection strings are ``<host>:<port>:<proto>``.
+    """
+    conn = f"{host}:{port}:tcp"
+    return (
+        '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>\n'
+        "<preferences>\n"
+        '  <preference version="1" name="cot_streams">\n'
+        '    <entry key="count" class="class java.lang.Integer">1</entry>\n'
+        f'    <entry key="description0" class="class java.lang.String">{name}</entry>\n'
+        f'    <entry key="connectString0" class="class java.lang.String">{conn}</entry>\n'
+        '    <entry key="enabled0" class="class java.lang.Boolean">true</entry>\n'
+        '    <entry key="useAuth0" class="class java.lang.Boolean">false</entry>\n'
+        "  </preference>\n"
+        "</preferences>\n"
+    )
+
+
+def build_squad(seed: int, nodes: int, days: int):
+    """Generate a v2 TAK-squad capture and its CoT events (SDK-gated)."""
+    from meshtastic_mcp.replay import sim, tak_server
+
+    prof = {"tak": {"team_nodes": 5, "pli_interval": 45, "chat_per_hour": 3, "wire": "v2"}}
+    cap = sim.generate(nodes=nodes, days=days, seed=seed, profile=prof)
+    return cap, tak_server.capture_to_cot_events(cap)
+
+
+# ── emulator orchestration (needs android capability + ATAK) ─────────────────
+def run(atak_apk: str, *, seed: int, nodes: int, days: int, timeout: float) -> int:
+    from meshtastic_mcp.emulator import avd
+    from meshtastic_mcp.replay import tak_server
+
+    serial = avd.wait_for_boot()
+    print(f"[ci-atak] emulator ready: {serial}")
+    avd.install_app(atak_apk, serial=serial)
+    print(f"[ci-atak] installed {atak_apk}")
+
+    _cap, events = build_squad(seed, nodes, days)
+    callsigns = expected_callsigns(events)
+    if not callsigns:
+        print(_mesh.verdict("atak-render", False, "(build)", None, extra="no squad CoT events"))
+        return 1
+    target = sorted(callsigns)[0]
+    print(f"[ci-atak] squad callsigns: {sorted(callsigns)} — asserting '{target}'")
+
+    # host CoT server; ATAK reaches it at 10.0.2.2:<port>
+    srv = tak_server.CotTakServer(events, host="0.0.0.0", port=0, speed=60.0, loop=True)
+    port = srv.start()
+    try:
+        avd.adb_reverse(port, port, serial=serial)  # emulator → host
+        _push_stream_pref(avd, serial, "10.0.2.2", port)
+        avd.grant_runtime_permissions(ATAK_PACKAGE, serial=serial)
+        avd.launch_app(ATAK_PACKAGE, serial=serial)
+        _dismiss_first_run(avd, serial)
+        passed = avd.poll_for_text(target, serial=serial, timeout=timeout)
+        print(_mesh.verdict("atak-render", passed, target, 0 if passed else None))
+        return 0 if passed else 1
+    finally:
+        srv.stop()
+
+
+def _push_stream_pref(avd, serial: str, host: str, port: int) -> None:
+    """Best-effort: preconfigure the ATAK streaming input via a pushed .pref."""
+    import tempfile
+
+    pref = atak_stream_pref(host, port)
+    with tempfile.NamedTemporaryFile("w", suffix=".pref", delete=False) as fh:
+        fh.write(pref)
+        local = fh.name
+    for dest in (
+        "/sdcard/atak/config/prefs/meshsim.pref",
+        "/sdcard/atak/import/meshsim.pref",
+    ):
+        avd.adb("push", local, dest, serial=serial, check=False)
+    print(f"[ci-atak] pushed streaming pref -> {host}:{port}")
+
+
+def _dismiss_first_run(avd, serial: str) -> None:
+    """Best-effort EULA / permission dismissal on first launch."""
+    for label in ("I agree", "Agree", "OK", "Continue", "GOT IT"):
+        if avd.find_text(label, serial=serial):
+            with __import__("contextlib").suppress(Exception):
+                avd.tap_text(label, serial=serial) if hasattr(avd, "tap_text") else None
+        time.sleep(1)
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(description="ATAK app-plane e2e (render sim TAK squad)")
+    p.add_argument("--atak-apk", required=True, help="ATAK-CIV APK to install + drive")
+    p.add_argument("--seed", type=int, default=8)
+    p.add_argument("--nodes", type=int, default=120)
+    p.add_argument("--days", type=int, default=1)
+    p.add_argument("--timeout", type=float, default=90.0)
+    args = p.parse_args(argv)
+    if not pathlib.Path(args.atak_apk).is_file():
+        print(f"FAIL: ATAK APK not found at {args.atak_apk}", file=sys.stderr)
+        return 2
+    try:
+        from meshtastic_mcp.replay import tak
+
+        if not tak.available():
+            print(
+                "FAIL: the [tak] extra is required (pip install 'meshtastic-mcp[tak]')",
+                file=sys.stderr,
+            )
+            return 2
+    except Exception:
+        print("FAIL: meshtastic_mcp not importable", file=sys.stderr)
+        return 2
+    return run(
+        args.atak_apk, seed=args.seed, nodes=args.nodes, days=args.days, timeout=args.timeout
+    )
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/meshtastic_mcp/__main__.py
+++ b/src/meshtastic_mcp/__main__.py
@@ -419,6 +419,67 @@ def _cmd_nodes(args) -> int:
     return 0
 
 
+def _cmd_capture_stats(args) -> int:
+    """Compute the realism stat schema for a capture (SQLite / JSONL / preset)."""
+    from meshtastic_mcp.replay import capture as _capture
+    from meshtastic_mcp.replay import metrics as _metrics
+    from meshtastic_mcp.replay import sim as _sim
+
+    src = args.source
+    try:
+        if src in _sim.PRESETS or src == "sim":
+            profile = "meshcon" if src == "sim" else src
+            cap = _sim.generate(
+                nodes=args.sim_nodes, days=args.sim_days, seed=args.sim_seed, profile=profile
+            )
+        elif src.endswith(".jsonl"):
+            cap = _capture.from_recorder_jsonl(src)
+        else:
+            cap = _capture.from_sqlite(src, limit_nodes=0)
+    except Exception as e:
+        print(f"error: {e}", file=sys.stderr)
+        return 1
+    stats = _metrics.capture_stats(cap)
+    # observation-level extras only the SQLite packet_seen table carries
+    if not (src in _sim.PRESETS or src == "sim" or src.endswith(".jsonl")):
+        try:
+            stats["observed"] = _metrics.sqlite_extra_stats(_capture._resolve_db(src))
+        except Exception:
+            pass
+    if args.json:
+        print(_json_mod.dumps(stats, indent=2, default=str))
+        return 0
+    dec = sum(stats["portnum_mix"].values()) or 1
+    print(
+        f"capture: {stats['label']}  ({stats['packets']} pkts, {stats['span_hours']} h, "
+        f"{stats['nodes']['count']} nodes, {stats['pkts_per_hour']} pkts/hr)"
+    )
+    print(f"  encrypted: {stats['encrypted_fraction']}   tak_packets: {stats['tak_packets']}")
+    print("  portnum mix:")
+    for name, n in list(stats["portnum_mix"].items())[:10]:
+        print(f"    {name:<16} {n:>8}  ({100 * n / dec:4.1f}%)")
+    txt = stats["text"]["len"]
+    print(
+        f"  text: n={stats['text']['n']} p50={txt['p50']} p90={txt['p90']} max={txt['max']} "
+        f"dm={stats['text']['dm_fraction']}"
+    )
+    print(
+        f"  talker skew (top1/top10): {stats['talker_skew']['top1pct_share']} / "
+        f"{stats['talker_skew']['top10pct_share']}"
+    )
+    print(f"  position interval p50: {stats['position']['interval_s']['p50']} s")
+    tel = stats["telemetry"]
+    print(f"  telemetry variants: {tel['variant_mix']}")
+    ch = tel["chutil"]
+    print(f"  chutil p50/p90/max: {ch['p50']}/{ch['p90']}/{ch['max']}")
+    if tel["env_fields"]:
+        print(f"  env fields: {tel['env_fields']}")
+    rx = stats["rx"]
+    if rx["rssi"]["n"]:
+        print(f"  rx snr p50={rx['snr']['p50']}  rssi p50={rx['rssi']['p50']}")
+    return 0
+
+
 def _cmd_watch(args) -> int:
     """Live-tail a recorder JSONL stream. Ctrl-C to stop."""
     import time
@@ -582,6 +643,19 @@ def main(argv=None) -> None:
     )
     wat.add_argument("--interval", type=float, default=2.0, help="poll interval seconds")
 
+    cst = sub.add_parser(
+        "capture-stats",
+        help="compute realism statistics for a capture (SQLite/JSONL) or a sim preset",
+    )
+    cst.add_argument(
+        "source",
+        help="path to a *.db/*.db.gz/*.jsonl capture, or a sim preset (meshcon/burningman/defcon)",
+    )
+    cst.add_argument("--sim-nodes", type=int, default=800, help="nodes when source is a preset")
+    cst.add_argument("--sim-days", type=int, default=3, help="days when source is a preset")
+    cst.add_argument("--sim-seed", type=int, default=1337, help="seed when source is a preset")
+    cst.add_argument("--json", action="store_true", help="emit JSON")
+
     comp = sub.add_parser("completion", help="print a shell completion script")
     comp.add_argument("shell", choices=("bash", "zsh"), help="target shell")
 
@@ -628,6 +702,9 @@ def main(argv=None) -> None:
 
     if args.cmd == "watch":
         raise SystemExit(_cmd_watch(args))
+
+    if args.cmd == "capture-stats":
+        raise SystemExit(_cmd_capture_stats(args))
 
     if args.cmd == "completion":
         raise SystemExit(_cmd_completion(args))

--- a/src/meshtastic_mcp/capabilities.py
+++ b/src/meshtastic_mcp/capabilities.py
@@ -93,6 +93,18 @@ def has_llama_server() -> bool:
     return llama_server.available()
 
 
+def has_tak() -> bool:
+    """True when the meshtastic-tak SDK is importable (the ``[tak]`` extra).
+
+    Optional: enables real TAKPacketV2 zstd-dictionary wire compression for the
+    replay sim's ATAK squad (``profile tak.wire="v2"``). Install with
+    ``pip install 'meshtastic-mcp[tak]'``.
+    """
+    from .replay import tak
+
+    return tak.available()
+
+
 def has_sdk_cli() -> bool:
     """True when the Meshtastic Kotlin SDK ``cli`` launcher is resolvable.
 
@@ -114,6 +126,7 @@ class Capabilities:
     local_model: bool
     llama_server: bool
     sdr: bool
+    tak: bool
     sdk_cli: bool
 
     def summary(self) -> str:
@@ -127,6 +140,7 @@ class Capabilities:
                 ("local_model", self.local_model),
                 ("llama_server", self.llama_server),
                 ("sdr", self.sdr),
+                ("tak", self.tak),
                 ("sdk_cli", self.sdk_cli),
             )
             if on
@@ -143,5 +157,6 @@ def detect() -> Capabilities:
         local_model=has_local_model(),
         llama_server=has_llama_server(),
         sdr=has_sdr(),
+        tak=has_tak(),
         sdk_cli=has_sdk_cli(),
     )

--- a/src/meshtastic_mcp/doctor.py
+++ b/src/meshtastic_mcp/doctor.py
@@ -241,6 +241,31 @@ def _sdr_check() -> Check:
     )
 
 
+def _tak_check() -> Check:
+    """TAKPacketV2 wire compression (replay sim `profile tak.wire="v2"`): needs the
+    meshtastic-tak SDK (the `tak` extra). Optional — the sim emits legacy
+    uncompressed TAKPacket without it.
+    """
+    from .replay import tak
+
+    if tak.available():
+        return Check(
+            "meshtastic-tak",
+            "tak",
+            STATUS_OK,
+            'TAKPacketV2 zstd wire compression (replay sim tak.wire="v2")',
+            detail="meshtastic-tak importable",
+        )
+    return Check(
+        "meshtastic-tak",
+        "tak",
+        STATUS_MISSING,
+        'TAKPacketV2 zstd wire compression (replay sim tak.wire="v2")',
+        detail="meshtastic-tak not importable (legacy TAKPacket still works)",
+        fix="pip install 'meshtastic-mcp[tak]'  # meshtastic-tak SDK (git) + zstandard",
+    )
+
+
 def _sdk_cli_check() -> Check:
     """Kotlin-SDK device-IO bridge (`sdk_*` tools): needs the meshtastic-sdk sample
     `cli` launcher resolvable via $MESHTASTIC_MCP_SDK_CLI or a $MESHTASTIC_SDK_ROOT
@@ -629,6 +654,8 @@ def run() -> DoctorReport:
         ),
         # sdr capability (RF compliance oracle)
         _sdr_check(),
+        # tak capability (TAKPacketV2 wire compression for the replay sim)
+        _tak_check(),
         # sdk capability (experimental Kotlin-SDK device-IO bridge)
         _sdk_cli_check(),
     ]

--- a/src/meshtastic_mcp/replay/fuzz.py
+++ b/src/meshtastic_mcp/replay/fuzz.py
@@ -84,6 +84,9 @@ class FuzzConfig:
     rogue_admin_interval: float = 30.0
     waypoint_spam: bool = False  # oversized / malicious waypoints
     waypoint_spam_interval: float = 25.0
+    ninja_flood: bool = False  # DC33-style mass NodeInfo display-name spoof
+    ninja_flood_interval: float = 12.0
+    ninja_flood_batch: int = 6  # real nodes whose names get overwritten per fire
 
 
 @dataclass
@@ -191,6 +194,8 @@ class Fuzzer:
             out.append(self._rogue_admin())
         if c.waypoint_spam and self._due("wpt", now, c.waypoint_spam_interval):
             out.append(self._waypoint_spam())
+        if c.ninja_flood and self.nodes and self._due("ninja", now, c.ninja_flood_interval):
+            out.extend(self._ninja_flood())
         return out
 
     # ── transport hook ───────────────────────────────────────────────────────
@@ -350,6 +355,24 @@ class Fuzzer:
         self.stats.log("rogue_admin", f"{which} from !{frm:08x}")
         return self._new(frm, OBSERVER_NUM, 6, a.SerializeToString())
 
+    def _ninja_flood(self) -> list[mesh_pb2.MeshPacket]:
+        """Replayed NodeInfo that overwrites real nodes' display names (the DC33
+        🥷 attack). Uses each victim's *real* node num and omits public_key, so
+        (unlike evil_twin's key swap) the mobile client's key-change warning is
+        NOT triggered — the spoof silently corrupts everyone's node DB."""
+        batch = min(self.cfg.ninja_flood_batch, len(self.nodes))
+        out: list[mesh_pb2.MeshPacket] = []
+        for victim in self.rng.sample(self.nodes, batch):
+            u = mesh_pb2.User()
+            u.id = victim.node_id
+            base = victim.long_name or "node"
+            u.long_name = self.rng.choice([f"{base} 🥷", f"🥷 {base}", "🥷🥷🥷"])
+            u.short_name = self.rng.choice(["🥷", (victim.short_name or "ninj")[:4]])
+            # deliberately NO public_key -> presents as "same key", no warning
+            out.append(self._new(victim.num, BROADCAST, 4, u.SerializeToString(), hop_limit=3))
+        self.stats.log("ninja_flood", f"n={batch}")
+        return out
+
     def _waypoint_spam(self) -> mesh_pb2.MeshPacket:
         w = mesh_pb2.Waypoint()
         w.id = self.rng.randint(1, 0x7FFFFFFF)
@@ -420,6 +443,15 @@ def preset(name: str, seed: int = 0) -> FuzzConfig:
             hop_anomaly=0.05,
             duplicate=0.03,
         )
+    if name == "ninja":
+        # DC33 NodeInfo display-name spoofing campaign (name corruption at scale)
+        return FuzzConfig(
+            seed=seed,
+            name="ninja",
+            ninja_flood=True,
+            ninja_flood_interval=10.0,
+            ninja_flood_batch=8,
+        )
     if name == "adversary":
         # bad-actor campaigns; light protocol noise
         return FuzzConfig(
@@ -434,6 +466,7 @@ def preset(name: str, seed: int = 0) -> FuzzConfig:
             forged_acks=True,
             rogue_admin=True,
             waypoint_spam=True,
+            ninja_flood=True,
         )
     if name == "chaos":
         # everything cranked, including transport-level frame corruption
@@ -458,11 +491,12 @@ def preset(name: str, seed: int = 0) -> FuzzConfig:
             forged_acks=True,
             rogue_admin=True,
             waypoint_spam=True,
+            ninja_flood=True,
         )
     raise ValueError(f"unknown fuzz preset: {name!r}")
 
 
-PRESET_NAMES = ["off", "light", "parser", "adversary", "chaos"]
+PRESET_NAMES = ["off", "light", "parser", "ninja", "adversary", "chaos"]
 
 
 def from_spec(spec: str | dict | None, seed: int = 0) -> FuzzConfig | None:

--- a/src/meshtastic_mcp/replay/metrics.py
+++ b/src/meshtastic_mcp/replay/metrics.py
@@ -1,0 +1,260 @@
+# SPDX-FileCopyrightText: Meshtastic contributors
+# SPDX-License-Identifier: GPL-3.0-only
+
+"""Capture statistics for sim calibration and realism regression.
+
+Computes a common, JSON-serializable stat schema over any
+:class:`~meshtastic_mcp.replay.capture.Capture` — real (SQLite / recorder
+JSONL) or synthetic (:mod:`~meshtastic_mcp.replay.sim`) — so the generator can
+be measured against real event captures (Burning Man 2025, DEF CON 33) on
+identical axes. The distilled aggregates for those two events live in
+``replay/profiles/*.json`` — generated locally from the (private) datasets and
+gitignored, never committed. They double as regression baselines and
+calibration inputs; tests that need them skip when absent.
+
+``capture_stats`` walks ``Capture.packets`` once; ``sqlite_extra_stats`` adds
+the observation-level stats only the ``packet_seen`` table has (per-gateway
+duplicate multiplicity, RX SNR/RSSI populations).
+"""
+
+from __future__ import annotations
+
+import itertools
+import math
+import sqlite3
+from collections import Counter, defaultdict
+from typing import Any
+
+from meshtastic.protobuf import mesh_pb2, telemetry_pb2
+
+from .capture import Capture
+
+BROADCAST = 0xFFFFFFFF
+SCHEMA_VERSION = 1
+
+# Friendly names for the portnums that matter here (see portnums.proto).
+PORT_NAMES = {
+    1: "TEXT_MESSAGE",
+    3: "POSITION",
+    4: "NODEINFO",
+    5: "ROUTING",
+    6: "ADMIN",
+    8: "WAYPOINT",
+    34: "PAXCOUNTER",
+    37: "MESH_BEACON",
+    65: "STORE_FORWARD",
+    66: "RANGE_TEST",
+    67: "TELEMETRY",
+    70: "TRACEROUTE",
+    71: "NEIGHBORINFO",
+    72: "ATAK_PLUGIN",
+    257: "ATAK_FORWARDER",
+}
+
+
+def _percentile(sorted_vals: list[float], p: float) -> float | None:
+    if not sorted_vals:
+        return None
+    k = min(len(sorted_vals) - 1, int(p / 100 * len(sorted_vals)))
+    return sorted_vals[k]
+
+
+def summarize(vals: list[float]) -> dict[str, Any]:
+    """n/min/p50/p90/p99/max summary of a numeric population (NaNs dropped)."""
+    v = sorted(x for x in vals if not math.isnan(x))
+    return {
+        "n": len(v),
+        "min": v[0] if v else None,
+        "p50": _percentile(v, 50),
+        "p90": _percentile(v, 90),
+        "p99": _percentile(v, 99),
+        "max": v[-1] if v else None,
+    }
+
+
+def talker_skew(per_sender: Counter[int]) -> dict[str, Any]:
+    """Traffic concentration: share of packets from the top 1% / 10% of senders."""
+    counts = sorted(per_sender.values(), reverse=True)
+    total = sum(counts) or 1
+    n = len(counts)
+    return {
+        "senders": n,
+        "top1pct_share": round(sum(counts[: max(1, n // 100)]) / total, 3),
+        "top10pct_share": round(sum(counts[: max(1, n // 10)]) / total, 3),
+    }
+
+
+def _named_portnums(portnums: Counter[int]) -> dict[str, int]:
+    return {PORT_NAMES.get(pn, str(pn)): c for pn, c in portnums.most_common()}
+
+
+def capture_stats(cap: Capture) -> dict[str, Any]:
+    """Single-pass stat schema over a capture (see module docstring)."""
+    portnums: Counter[int] = Counter()
+    hop_limit: Counter[int] = Counter()
+    hop_start: Counter[int] = Counter()
+    senders: Counter[int] = Counter()
+    pkt_ids: Counter[int] = Counter()
+    hod: Counter[int] = Counter()
+    variant_mix: Counter[str] = Counter()
+    env_fields: Counter[str] = Counter()
+    battery: Counter[int] = Counter()
+    precision: Counter[int] = Counter()
+    text_lens: list[float] = []
+    chutil: list[float] = []
+    air_util: list[float] = []
+    env_temp: list[float] = []
+    rx_snr: list[float] = []
+    rx_rssi: list[float] = []
+    times: list[int] = []
+    pos_times: dict[int, list[int]] = defaultdict(list)
+    total = encrypted = text_n = dm_text = want_resp = 0
+
+    mp = mesh_pb2.MeshPacket()
+    for rxt, raw, _ch in cap.packets:
+        mp.Clear()
+        try:
+            mp.ParseFromString(raw)
+        except Exception:
+            continue
+        total += 1
+        frm = getattr(mp, "from")
+        senders[frm] += 1
+        hop_limit[mp.hop_limit] += 1
+        hop_start[mp.hop_start] += 1
+        if mp.id:
+            pkt_ids[mp.id] += 1
+        if mp.rx_snr:
+            rx_snr.append(round(mp.rx_snr, 2))
+        if mp.rx_rssi:
+            rx_rssi.append(float(mp.rx_rssi))
+        if rxt > 100_000:  # ignore epoch-0 garbage rows
+            times.append(rxt)
+            hod[int(rxt // 3600 % 24)] += 1
+        if mp.WhichOneof("payload_variant") != "decoded":
+            encrypted += 1
+            continue
+        pn = mp.decoded.portnum
+        portnums[pn] += 1
+        if mp.decoded.want_response:
+            want_resp += 1
+        if pn == 1:  # text
+            text_n += 1
+            text_lens.append(float(len(mp.decoded.payload)))
+            if mp.to != BROADCAST:
+                dm_text += 1
+        elif pn == 3:  # position
+            pos = mesh_pb2.Position()
+            try:
+                pos.ParseFromString(mp.decoded.payload)
+            except Exception:
+                continue
+            precision[pos.precision_bits] += 1
+            pos_times[frm].append(rxt)
+        elif pn == 67:  # telemetry
+            tel = telemetry_pb2.Telemetry()
+            try:
+                tel.ParseFromString(mp.decoded.payload)
+            except Exception:
+                continue
+            variant = tel.WhichOneof("variant") or "?"
+            variant_mix[variant] += 1
+            if variant == "device_metrics":
+                d = tel.device_metrics
+                battery[min(d.battery_level, 101)] += 1
+                chutil.append(round(d.channel_utilization, 1))
+                air_util.append(round(d.air_util_tx, 2))
+            elif variant == "environment_metrics":
+                for fld, _v in tel.environment_metrics.ListFields():
+                    env_fields[fld.name] += 1
+                if tel.environment_metrics.HasField("temperature"):
+                    env_temp.append(round(tel.environment_metrics.temperature, 1))
+
+    times.sort()
+    span_h = (times[-1] - times[0]) / 3600 if len(times) > 1 else 0.0
+    interarrival = [float(b - a) for a, b in itertools.pairwise(times) if 0 <= b - a < 3600]
+    pos_deltas: list[float] = []
+    for ts in pos_times.values():
+        ts.sort()
+        pos_deltas += [float(b - a) for a, b in itertools.pairwise(ts) if 5 < b - a < 7200]
+    dup_mult = Counter(pkt_ids.values())
+
+    hw = Counter(n.hw_model or "?" for n in cap.nodes)
+    role = Counter(n.role or "?" for n in cap.nodes)
+
+    return {
+        "schema": SCHEMA_VERSION,
+        "label": cap.label,
+        "packets": total,
+        "span_hours": round(span_h, 1),
+        "pkts_per_hour": round(total / span_h, 1) if span_h else None,
+        "nodes": {
+            "count": len(cap.nodes),
+            "hw_top": hw.most_common(15),
+            "role_top": role.most_common(),
+        },
+        "channels": list(cap.channels),
+        "portnum_mix": _named_portnums(portnums),
+        "encrypted_fraction": round(encrypted / total, 3) if total else None,
+        "want_response_fraction": round(want_resp / total, 4) if total else None,
+        "hop_limit": {str(k): v for k, v in hop_limit.most_common(10)},
+        "hop_start": {str(k): v for k, v in hop_start.most_common(10)},
+        "talker_skew": talker_skew(senders),
+        "text": {
+            "n": text_n,
+            "len": summarize(text_lens),
+            "dm_fraction": round(dm_text / text_n, 3) if text_n else None,
+        },
+        "telemetry": {
+            "variant_mix": dict(variant_mix.most_common()),
+            "chutil": summarize(chutil),
+            "air_util": summarize(air_util),
+            "battery_top": battery.most_common(8),
+            "env_fields": dict(env_fields.most_common()),
+            "env_temperature": summarize(env_temp),
+        },
+        "position": {
+            "precision_bits": {str(k): v for k, v in precision.most_common(10)},
+            "interval_s": summarize(pos_deltas),
+        },
+        "timing": {
+            "interarrival_s": summarize(interarrival),
+            "hour_of_day_utc": {str(h): hod[h] for h in sorted(hod)},
+        },
+        "rx": {"snr": summarize(rx_snr), "rssi": summarize(rx_rssi)},
+        "dup_id_multiplicity": {str(k): v for k, v in dup_mult.most_common(8)},
+        "tak_packets": portnums.get(72, 0) + portnums.get(257, 0),
+    }
+
+
+def sqlite_extra_stats(db_path: str) -> dict[str, Any]:
+    """Observation-level stats only the ``packet_seen`` table carries.
+
+    ``Capture.from_sqlite`` dedupes to one row per packet id (earliest
+    reception), so per-observation duplicate multiplicity and the RX SNR/RSSI
+    populations must be read from the DB directly.
+    """
+    conn = sqlite3.connect(db_path)
+    try:
+        mult = Counter(
+            int(row[0])
+            for row in conn.execute(
+                "SELECT cnt FROM (SELECT COUNT(*) cnt FROM packet_seen GROUP BY packet_id)"
+            )
+        )
+        snr = [
+            float(r[0])
+            for r in conn.execute("SELECT rx_snr FROM packet_seen WHERE rx_snr IS NOT NULL")
+        ]
+        rssi = [
+            float(r[0])
+            for r in conn.execute(
+                "SELECT rx_rssi FROM packet_seen WHERE rx_rssi IS NOT NULL AND rx_rssi != 0"
+            )
+        ]
+        return {
+            "observation_multiplicity": {str(k): v for k, v in mult.most_common(8)},
+            "rx": {"snr": summarize(snr), "rssi": summarize(rssi)},
+        }
+    finally:
+        conn.close()

--- a/src/meshtastic_mcp/replay/metrics.py
+++ b/src/meshtastic_mcp/replay/metrics.py
@@ -48,6 +48,7 @@ PORT_NAMES = {
     70: "TRACEROUTE",
     71: "NEIGHBORINFO",
     72: "ATAK_PLUGIN",
+    78: "ATAK_PLUGIN_V2",
     257: "ATAK_FORWARDER",
 }
 
@@ -223,7 +224,7 @@ def capture_stats(cap: Capture) -> dict[str, Any]:
         },
         "rx": {"snr": summarize(rx_snr), "rssi": summarize(rx_rssi)},
         "dup_id_multiplicity": {str(k): v for k, v in dup_mult.most_common(8)},
-        "tak_packets": portnums.get(72, 0) + portnums.get(257, 0),
+        "tak_packets": portnums.get(72, 0) + portnums.get(78, 0) + portnums.get(257, 0),
     }
 
 

--- a/src/meshtastic_mcp/replay/observer.py
+++ b/src/meshtastic_mcp/replay/observer.py
@@ -1,0 +1,221 @@
+# SPDX-FileCopyrightText: Meshtastic contributors
+# SPDX-License-Identifier: GPL-3.0-only
+
+"""Observer / RF gateway model for the synthetic mesh.
+
+The synthetic generator (:mod:`~meshtastic_mcp.replay.sim`) emits *all traffic
+that exists* on the mesh. Real event captures (Burning Man 2025, DEF CON 33)
+are instead *what one gateway heard*: RF-lossy with distance, duplicated by
+flood-rebroadcast (each copy with a decremented ``hop_limit``, its own
+SNR/RSSI draw, and ``relay_node`` set), and stamped with rx metadata.
+:func:`observe` transforms the omniscient packet stream into that observed
+view.
+
+Model
+-----
+Per input packet, the sender-to-observer distance feeds a log-distance path
+loss with log-normal shadowing::
+
+    rssi = tx_power - (ref_loss + 10 * n * log10(d)) + N(0, sigma)
+
+Reception probability is a sigmoid around the radio sensitivity, scaled by a
+residual ``loss_floor`` (collisions/duty-cycle losses that persist even at
+point-blank range). Packets heard neither over RF nor via an optional MQTT
+bridge are dropped entirely — this drop *is* the volume calibration that maps
+"all traffic" onto a gateway-sized capture. RF-heard packets are duplicated
+``k`` times per :attr:`ObserverParams.dup_weights` (rebroadcast copies arrive
+later, hop-decremented, relayed, and usually stronger — relays tend to sit
+closer to the gateway than the origin). SNR is derived from RSSI against the
+noise floor and quantized to 0.25 dB, matching LoRa's quarter-dB reporting.
+
+Calibration targets (measured from the real captures)
+------------------------------------------------------
+- DEF CON 33 duplicate multiplicity per packet id:
+  {1: 70.8%, 2: 8.3%, 3: 18.9%, 4: 0.9%, 5+: ~1.1%} — the default
+  ``dup_weights`` encode this fit.
+- DEF CON 33 RSSI p50 −84 / p90 −53 / range [−123, −12];
+  SNR p50 +10, range [−20.75, +15.25].
+- Burning Man 2025 RSSI p50 −100; SNR p50 +3.0 — the sparser venue regime is
+  reachable from the same model by tuning ``path_loss_exp`` / ``sigma_db``.
+- DEF CON 33 saw ~40% of observations arrive ``via_mqtt`` (``mqtt_fraction``).
+
+Everything is deterministic: one ``random.Random(params.seed)`` drives all
+stochastic draws, except the synthetic fallback position for unknown senders,
+which depends only on the node number (stable per node across calls and
+seeds).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import math
+import random
+from collections.abc import Mapping
+from dataclasses import dataclass
+
+from meshtastic.protobuf import mesh_pb2
+
+_EARTH_RADIUS_M = 6_371_000.0
+_RSSI_MIN, _RSSI_MAX = -128, -12
+_SNR_MIN, _SNR_MAX = -20.75, 15.25
+
+
+@dataclass(frozen=True)
+class ObserverParams:
+    """Tunables for the gateway observation model (defaults ≈ DEF CON 33)."""
+
+    lat: float  # observer position, degrees
+    lon: float
+    tx_power_dbm: float = 20.0
+    ref_loss_db: float = 40.0  # path loss at 1 m (915 MHz + margin)
+    path_loss_exp: float = 2.9  # log-distance exponent
+    sigma_db: float = 9.0  # log-normal shadowing stddev
+    noise_floor_dbm: float = -103.0  # implied by real captures (rssi - snr ≈ -94..-103)
+    snr_jitter_db: float = 2.0  # SNR is not perfectly rssi-correlated in reality
+    sensitivity_dbm: float = -128.0
+    softness_db: float = 5.0  # sigmoid width for reception probability
+    loss_floor: float = 0.03  # residual loss even at point-blank range
+    # copies heard per received packet (rebroadcast duplication), fit from DEF CON 33:
+    dup_weights: tuple[tuple[int, float], ...] = (
+        (1, 0.70),
+        (2, 0.08),
+        (3, 0.19),
+        (4, 0.01),
+        (5, 0.01),
+        (6, 0.01),
+    )
+    mqtt_fraction: float = 0.0  # independent chance a copy also arrives via MQTT bridge
+    seed: int = 0
+
+
+def _sigmoid(x: float) -> float:
+    """Numerically stable logistic function."""
+    if x >= 0:
+        return 1.0 / (1.0 + math.exp(-x))
+    ex = math.exp(x)
+    return ex / (1.0 + ex)
+
+
+def _distance_m(lat1: float, lon1: float, lat2: float, lon2: float) -> float:
+    """Equirectangular-approximation distance in meters (floored at 1 m)."""
+    x = math.radians(lon2 - lon1) * math.cos(math.radians((lat1 + lat2) / 2.0))
+    y = math.radians(lat2 - lat1)
+    return max(1.0, _EARTH_RADIUS_M * math.hypot(x, y))
+
+
+def _synthetic_position(node_num: int, obs_lat: float, obs_lon: float) -> tuple[float, float]:
+    """Deterministic fallback position for a sender with no known coordinates.
+
+    Hashes the node number to a bearing + distance within ~3 km of the
+    observer. Depends only on ``node_num`` (never on the RNG seed), so the same
+    unknown node lands in the same spot across calls.
+    """
+    digest = hashlib.sha256(f"meshtastic-mcp-observer:{node_num}".encode()).digest()
+    bearing = int.from_bytes(digest[:4], "big") / 2**32 * 2.0 * math.pi
+    dist_m = 50.0 + int.from_bytes(digest[4:8], "big") / 2**32 * 2950.0
+    dlat = dist_m * math.cos(bearing) / _EARTH_RADIUS_M
+    dlon = dist_m * math.sin(bearing) / (_EARTH_RADIUS_M * math.cos(math.radians(obs_lat)))
+    return obs_lat + math.degrees(dlat), obs_lon + math.degrees(dlon)
+
+
+def _relay_byte(packet_id: int, copy_index: int) -> int:
+    """Plausible nonzero relay-node byte, stable per (packet id, copy index)."""
+    digest = hashlib.sha256(f"meshtastic-mcp-relay:{packet_id}:{copy_index}".encode()).digest()
+    return (digest[0] % 255) + 1
+
+
+def _clamp_rssi(rssi_db: float) -> int:
+    return max(_RSSI_MIN, min(_RSSI_MAX, round(rssi_db)))
+
+
+def _quantize_snr(snr_db: float) -> float:
+    """Clamp to LoRa's reportable range and quantize to quarter-dB steps."""
+    return max(_SNR_MIN, min(_SNR_MAX, round(snr_db * 4.0) / 4.0))
+
+
+def observe(
+    packets: list[tuple[int, bytes, str]],
+    positions: Mapping[int, tuple[float, float]],
+    params: ObserverParams,
+) -> list[tuple[int, bytes, str]]:
+    """Filter and duplicate an omniscient packet stream into a gateway view.
+
+    ``packets`` are ``(rx_time, serialized MeshPacket, channel_name)`` tuples
+    as produced by the sim / stored in a :class:`~..capture.Capture`;
+    ``positions`` maps node numbers to ``(lat, lon)`` degrees. Unknown senders
+    get a deterministic synthetic position near the observer. The result is
+    the subset (and rebroadcast multiplication) of the input the gateway would
+    have heard, each copy stamped with ``rx_time`` / ``rx_snr`` / ``rx_rssi``
+    (and ``relay_node`` / ``via_mqtt`` where applicable), sorted by rx time.
+    Identity fields (from/to/id/portnum/payload) are never altered.
+    """
+    rng = random.Random(params.seed)
+    dup_values = [k for k, _ in params.dup_weights]
+    dup_wts = [w for _, w in params.dup_weights]
+    out: list[tuple[int, bytes, str]] = []
+
+    for t, raw, channel in packets:
+        mp = mesh_pb2.MeshPacket()
+        try:
+            mp.ParseFromString(raw)
+        except Exception:
+            continue  # unparseable input: skip
+        sender = getattr(mp, "from")
+
+        sender_pos = positions.get(sender)
+        if sender_pos is None:
+            sender_pos = _synthetic_position(sender, params.lat, params.lon)
+        dist = _distance_m(params.lat, params.lon, sender_pos[0], sender_pos[1])
+
+        # Log-distance path loss + log-normal shadowing.
+        rssi = (
+            params.tx_power_dbm
+            - (params.ref_loss_db + 10.0 * params.path_loss_exp * math.log10(dist))
+            + rng.gauss(0.0, params.sigma_db)
+        )
+        p_rx = (1.0 - params.loss_floor) * _sigmoid(
+            (rssi - params.sensitivity_dbm) / params.softness_db
+        )
+        rf_heard = rng.random() < p_rx
+        mqtt_heard = rng.random() < params.mqtt_fraction
+        if not rf_heard and not mqtt_heard:
+            continue  # gateway never heard this packet — the volume calibration
+
+        orig_hop = mp.hop_limit
+        if rf_heard:
+            k = rng.choices(dup_values, weights=dup_wts, k=1)[0]
+            hop = orig_hop
+            offset = 0.0
+            for i in range(k):
+                copy = mesh_pb2.MeshPacket()
+                copy.CopyFrom(mp)
+                if i == 0:
+                    # Direct copy: at most one hop consumed on the way in.
+                    hop = max(0, orig_hop - rng.randint(0, 1))
+                    copy_rssi = rssi
+                else:
+                    # Rebroadcast: more hops burned, a relay stamped, usually
+                    # stronger (relays sit closer to the gateway), and later.
+                    hop = max(0, hop - rng.randint(1, 2))
+                    copy.relay_node = _relay_byte(mp.id, i)
+                    copy_rssi = min(rssi + rng.uniform(0.0, 15.0), float(_RSSI_MAX))
+                    offset += rng.uniform(0.3, 4.0)
+                copy.hop_limit = hop
+                rx_time = int(t + offset)
+                copy.rx_time = rx_time
+                copy.rx_rssi = _clamp_rssi(copy_rssi)
+                snr = copy_rssi - params.noise_floor_dbm + rng.gauss(0.0, params.snr_jitter_db)
+                copy.rx_snr = _quantize_snr(snr)
+                out.append((rx_time, copy.SerializeToString(), channel))
+
+        if mqtt_heard:
+            # Bridged copy: no radio metadata, hop fields untouched.
+            copy = mesh_pb2.MeshPacket()
+            copy.CopyFrom(mp)
+            copy.via_mqtt = True
+            rx_time = int(t + rng.uniform(0.5, 3.0))
+            copy.rx_time = rx_time
+            out.append((rx_time, copy.SerializeToString(), channel))
+
+    out.sort(key=lambda item: item[0])
+    return out

--- a/src/meshtastic_mcp/replay/observer.py
+++ b/src/meshtastic_mcp/replay/observer.py
@@ -85,6 +85,13 @@ class ObserverParams:
         (6, 0.01),
     )
     mqtt_fraction: float = 0.0  # independent chance a copy also arrives via MQTT bridge
+    # Gilbert-Elliott fading gate: the gateway alternates good/bad reception
+    # states (collision storms, duty-cycle deafness, interference bursts).
+    # ``fade_good_s`` == 0 disables fading. Fading is what produces the real
+    # captures' heavy inter-arrival tails (p99 ~35 s, max gaps of minutes).
+    fade_good_s: float = 0.0  # mean dwell in the good state (seconds)
+    fade_bad_s: float = 45.0  # mean dwell in the bad state (seconds)
+    fade_bad_loss: float = 0.85  # extra RF loss applied while in the bad state
     seed: int = 0
 
 
@@ -154,7 +161,20 @@ def observe(
     dup_wts = [w for _, w in params.dup_weights]
     out: list[tuple[int, bytes, str]] = []
 
+    fading = params.fade_good_s > 0
+    good = True
+    switch_t = 0.0
+    if fading:
+        packets = sorted(packets, key=lambda p: p[0])
+        if packets:
+            switch_t = packets[0][0] + rng.expovariate(1.0 / params.fade_good_s)
+
     for t, raw, channel in packets:
+        if fading:
+            while t >= switch_t:
+                good = not good
+                dwell = params.fade_good_s if good else params.fade_bad_s
+                switch_t += rng.expovariate(1.0 / dwell)
         mp = mesh_pb2.MeshPacket()
         try:
             mp.ParseFromString(raw)
@@ -176,6 +196,8 @@ def observe(
         p_rx = (1.0 - params.loss_floor) * _sigmoid(
             (rssi - params.sensitivity_dbm) / params.softness_db
         )
+        if fading and not good:
+            p_rx *= 1.0 - params.fade_bad_loss
         rf_heard = rng.random() < p_rx
         mqtt_heard = rng.random() < params.mqtt_fraction
         if not rf_heard and not mqtt_heard:

--- a/src/meshtastic_mcp/replay/sim.py
+++ b/src/meshtastic_mcp/replay/sim.py
@@ -259,7 +259,7 @@ PRESETS: dict[str, dict] = {
 
 # Config keys whose values are themselves dicts and should deep-merge (rather
 # than wholesale-replace) when a profile override is applied.
-_MERGE_DICT_KEYS = frozenset({"venue", "observer", "climate", "pos_interval"})
+_MERGE_DICT_KEYS = frozenset({"venue", "observer", "climate", "pos_interval", "tak"})
 
 
 def _deep_merge(base: dict, over: dict) -> dict:

--- a/src/meshtastic_mcp/replay/sim.py
+++ b/src/meshtastic_mcp/replay/sim.py
@@ -1003,10 +1003,11 @@ def generate(
             )
             t += int(beacon_iv * rng.uniform(0.85, 1.15))
 
-    # -- ATAK squad (opt-in, off by default): a team of nodes emitting TAKPacket
-    # (portnum 72) PLI + GeoChat + status, for exercising the ATAK plugin /
-    # forwarder / map-PLI paths. No TAK traffic appeared in the real captures,
-    # so this is a scenario knob, not part of the fitted event profiles. --
+    # -- ATAK squad (opt-in, off by default): a team of nodes emitting TAK PLI +
+    # GeoChat + status, for exercising an app's TAK plane (the Meshtastic app's
+    # in-app TAK server bridges these to ATAK/iTAK over CoT). Legacy v1 rides
+    # ATAK_PLUGIN (72); v2 wire rides ATAK_PLUGIN_V2 (78). No TAK traffic
+    # appeared in the real captures, so this is a scenario knob, not fitted. --
     tak_cfg = P.get("tak") or {}
     tak_n = int(tak_cfg.get("team_nodes", 0))
     if tak_n > 0 and meta:
@@ -1017,6 +1018,9 @@ def generate(
         pli_iv = int(tak_cfg.get("pli_interval", 45))
         chat_iv = 3600.0 / max(float(tak_cfg.get("chat_per_hour", 2.0)), 0.01)
         v2_wire = tak_cfg.get("wire", "v1") == "v2"
+        # Firmware >= 2.8 carries compressed TAKPacketV2 on ATAK_PLUGIN_V2 (78);
+        # legacy uncompressed TAKPacket stays on ATAK_PLUGIN (72).
+        tak_port = 78 if v2_wire else 72
         if v2_wire:
             from . import tak as _tak
 
@@ -1049,7 +1053,7 @@ def generate(
                     pl = _tak.compress(pkt)
                 else:
                     pl = _pl_tak_pli(rng, callsign, team_val, role_val, lat_i, lon_i, batt_lvl)
-                add(t, m["num"], BROADCAST, 72, pl, ch=tak_ch)
+                add(t, m["num"], BROADCAST, tak_port, pl, ch=tak_ch)
                 t += int(pli_iv * rng.uniform(0.8, 1.2))
             t = m["join_t"] + rng.randint(0, int(chat_iv))
             while t < node_end:
@@ -1067,7 +1071,7 @@ def generate(
                         pl = _tak.compress(pkt)
                     else:
                         pl = _pl_tak_chat(rng, callsign, team_val, role_val, batt_lvl)
-                    add(t, m["num"], BROADCAST, 72, pl, ch=tak_ch)
+                    add(t, m["num"], BROADCAST, tak_port, pl, ch=tak_ch)
                 t += int(chat_iv * rng.uniform(0.7, 1.3))
 
     # -- device telemetry second pass: chutil tracks the actual per-hour

--- a/src/meshtastic_mcp/replay/sim.py
+++ b/src/meshtastic_mcp/replay/sim.py
@@ -121,6 +121,13 @@ PROFILE: dict = {
     # MESH_BEACON_APP packets, and the broadcast interval in seconds.
     "beacon_fraction": 0.4,
     "beacon_interval": 1800,
+    # Observer / RF gateway model (see replay/observer.py): when enabled, the
+    # generated "all traffic that exists" stream is filtered + duplicated into
+    # what a single gateway at the venue would have heard — RF loss with
+    # distance, rebroadcast copies with decremented hop_limit and their own
+    # SNR/RSSI, relay_node stamps, optional via_mqtt bridging. Keys mirror
+    # ObserverParams (lat/lon/seed default to the venue/generate seed).
+    "observer": {"enabled": False},
 }
 
 # Real text is short: median ~18 chars, p90 ~79. About half of messages are
@@ -255,8 +262,6 @@ _CHATTER = {
     ],
 }
 
-_pid = itertools.count(0x10000001)
-
 
 def _weighted(rng: random.Random, pairs: list[tuple[str, int]]) -> str:
     total = sum(w for _, w in pairs)
@@ -324,6 +329,7 @@ def _hops_taken(rng: random.Random, hop_start: int) -> int:
 
 
 def _mp(
+    pid,
     frm,
     to,
     portnum,
@@ -338,7 +344,7 @@ def _mp(
     mp = mesh_pb2.MeshPacket()
     setattr(mp, "from", frm & 0xFFFFFFFF)
     mp.to = to & 0xFFFFFFFF
-    mp.id = next(_pid) & 0xFFFFFFFF
+    mp.id = pid & 0xFFFFFFFF
     mp.hop_start = max(0, hop_start)
     mp.hop_limit = max(0, min(hop_limit, mp.hop_start))
     mp.channel = ch_idx
@@ -365,14 +371,14 @@ _ENC_LEN_WEIGHTS = [
 ]
 
 
-def _mp_enc(rng, frm, hop_start, ch_hash) -> bytes:
+def _mp_enc(rng, pid, frm, hop_start, ch_hash) -> bytes:
     """An encrypted (undecodable) packet — models traffic on a channel/key the
     viewer lacks (DEF CON ran ~45% such 'foreign' traffic). ``ch_hash`` is the
     OTA channel-hash byte a real radio would report (not a settings index)."""
     mp = mesh_pb2.MeshPacket()
     setattr(mp, "from", frm & 0xFFFFFFFF)
     mp.to = 0xFFFFFFFF
-    mp.id = next(_pid) & 0xFFFFFFFF
+    mp.id = pid & 0xFFFFFFFF
     mp.hop_start = max(0, hop_start)
     mp.hop_limit = max(0, hop_start - _hops_taken(rng, hop_start))
     mp.channel = ch_hash & 0xFF
@@ -479,6 +485,9 @@ def generate(
     sensors = [m for m, nr in zip(meta, node_rows, strict=False) if nr.role == "SENSOR"]
     by_num = {nr.num: nr for nr in node_rows}
     hop_starts = {m["num"]: m["hop_start"] for m in meta}
+    # packet-id counter is local so a given (seed, nodes, days, start) is
+    # byte-for-byte reproducible across calls in the same process
+    pid_counter = itertools.count(0x10000001)
 
     def add(t, frm, to, pn, payload, ch="LongFast", hop=None, want_response=False):
         # hop_limit derives from the sender's configured hop_start minus a
@@ -490,6 +499,7 @@ def generate(
             (
                 t,
                 _mp(
+                    next(pid_counter),
                     frm,
                     to,
                     pn,
@@ -690,7 +700,11 @@ def generate(
                 continue
             f = rng.choice(foreign)
             packets.append(
-                (t, _mp_enc(rng, f, foreign_hs[f], rng.choice(foreign_hashes)), "LongFast")
+                (
+                    t,
+                    _mp_enc(rng, next(pid_counter), f, foreign_hs[f], rng.choice(foreign_hashes)),
+                    "LongFast",
+                )
             )
             added += 1
 
@@ -751,6 +765,20 @@ def generate(
             t += int(beacon_iv * rng.uniform(0.85, 1.15))
 
     packets.sort(key=lambda p: p[0])
+
+    # -- observer stage: collapse the omniscient stream into a gateway view --
+    obs_cfg = dict(P.get("observer") or {})
+    if obs_cfg.pop("enabled", False):
+        from .observer import ObserverParams, observe
+
+        obs_cfg.setdefault("lat", P["venue"]["lat"])
+        obs_cfg.setdefault("lon", P["venue"]["lon"])
+        obs_cfg.setdefault("seed", seed)
+        if "dup_weights" in obs_cfg:
+            obs_cfg["dup_weights"] = tuple(tuple(x) for x in obs_cfg["dup_weights"])
+        positions = {m["num"]: (m["lat_i"] / 1e7, m["lon_i"] / 1e7) for m in meta}
+        packets = observe(packets, positions, ObserverParams(**obs_cfg))
+
     cap = Capture(
         nodes=node_rows, channels=chans, packets=packets, label=f"meshcon-{nodes}n-{days}d"
     )

--- a/src/meshtastic_mcp/replay/sim.py
+++ b/src/meshtastic_mcp/replay/sim.py
@@ -571,34 +571,60 @@ def _mp_enc(rng, pid, frm, hop_start, ch_hash) -> bytes:
     return mp.SerializeToString()
 
 
-def generate(
+def _emit_encrypted(
+    rng: random.Random,
+    P: dict,
+    packets: list[tuple[int, bytes, str]],
+    pid_counter: itertools.count,
     *,
-    nodes: int = 800,
-    days: int = 3,
-    start: int | None = None,
-    seed: int = 1337,
-    channels: list[str] | None = None,
-    text_scale: float = 1.0,
-    profile: dict | str | None = None,
-) -> Capture:
-    """Generate a synthetic capture in memory.
-
-    ``profile`` is a partial :data:`PROFILE` override: a dict, a path to a JSON
-    file (e.g. one produced by :func:`fit_profile`), or a preset name from
-    :data:`PRESETS` (``meshcon`` / ``burningman`` / ``defcon``). Nested config
-    dicts (venue/observer/climate/pos_interval) deep-merge over the defaults.
+    nodes: int,
+    start_epoch: int,
+    end_epoch: int,
+    hod,
+) -> None:
+    """Append encrypted/foreign traffic: packets on channels the viewer can't
+    decode, from "heard but unknown" neighbour nodes (no NodeInfo). The count is
+    sized so encrypted packets are ``encrypted_fraction`` of the *final* stream
+    (DEF CON ran ~45%). Foreign traffic is largely independent of the event's
+    diurnal rhythm. Mutates ``packets`` in place.
     """
-    P = _resolve_profile(profile)
-    rng = random.Random(seed)
-    chans = channels or list(P["channels"])
-    ch_index = {c: i for i, c in enumerate(chans)}
-    start_epoch = int(start if start is not None else time.time())
-    end_epoch = start_epoch + days * 86400
+    frac = P.get("encrypted_fraction", 0.0)
+    if frac <= 0 or not packets:
+        return
+    n_enc = int(len(packets) * frac / max(1e-6, 1.0 - frac))
+    foreign = [rng.randint(0x10000000, 0xEFFFFFFF) for _ in range(max(5, nodes // 8))]
+    foreign_hs = {f: int(_weighted(rng, P["hop_start_weights"])) for f in foreign}
+    # a handful of foreign channels, each with a realistic OTA hash byte
+    foreign_hashes = [rng.randint(1, 255) for _ in range(rng.randint(2, 4))]
+    added = attempts = 0
+    while added < n_enc and attempts < n_enc * 10:
+        attempts += 1
+        t = rng.randint(start_epoch, end_epoch - 1)
+        if rng.random() > _activity(hod(t)) * 0.4 + 0.6:
+            continue
+        f = rng.choice(foreign)
+        packets.append(
+            (
+                t,
+                _mp_enc(rng, next(pid_counter), f, foreign_hs[f], rng.choice(foreign_hashes)),
+                "LongFast",
+            )
+        )
+        added += 1
 
-    def hod(t):
-        return ((t - start_epoch) / 3600.0) % 24
 
-    # -- build nodes --
+def _build_nodes(
+    rng: random.Random, P: dict, *, nodes: int, days: int, start_epoch: int
+) -> tuple[list[NodeRow], list[dict]]:
+    """Construct the node DB: ``(node_rows, meta)``.
+
+    The first 8 nodes are always infrastructure (4 ROUTER + 4 ROUTER_LATE) named
+    from :data:`_ROUTER_NAMES`; the rest draw role/cluster/hardware from the
+    profile weights. ``meta`` carries the per-node simulation state the emitters
+    need (position, talkativeness, hop_start, battery persona, chutil gain, and
+    presence window). All draws come from ``rng`` in a fixed order so the
+    capture stays byte-for-byte reproducible.
+    """
     node_rows: list[NodeRow] = []
     meta: list[dict] = []
     used: set[int] = set()
@@ -679,6 +705,37 @@ def generate(
                 "leave_t": start_epoch + int((join_h + stay_h) * 3600),
             }
         )
+    return node_rows, meta
+
+
+def generate(
+    *,
+    nodes: int = 800,
+    days: int = 3,
+    start: int | None = None,
+    seed: int = 1337,
+    channels: list[str] | None = None,
+    text_scale: float = 1.0,
+    profile: dict | str | None = None,
+) -> Capture:
+    """Generate a synthetic capture in memory.
+
+    ``profile`` is a partial :data:`PROFILE` override: a dict, a path to a JSON
+    file (e.g. one produced by :func:`fit_profile`), or a preset name from
+    :data:`PRESETS` (``meshcon`` / ``burningman`` / ``defcon``). Nested config
+    dicts (venue/observer/climate/pos_interval) deep-merge over the defaults.
+    """
+    P = _resolve_profile(profile)
+    rng = random.Random(seed)
+    chans = channels or list(P["channels"])
+    ch_index = {c: i for i, c in enumerate(chans)}
+    start_epoch = int(start if start is not None else time.time())
+    end_epoch = start_epoch + days * 86400
+
+    def hod(t):
+        return ((t - start_epoch) / 3600.0) % 24
+
+    node_rows, meta = _build_nodes(rng, P, nodes=nodes, days=days, start_epoch=start_epoch)
 
     packets: list[tuple[int, bytes, str]] = []
     routers = [m for m in meta if m["role"].startswith("ROUTER")]
@@ -1023,32 +1080,16 @@ def generate(
         load = hour_hist.get((t - start_epoch) // 3600, 0) / peak_rate
         add(t, m["num"], BROADCAST, 67, _pl_tel_device(rng, m, t, load))
 
-    # -- encrypted/foreign traffic: packets on channels the viewer can't decode,
-    # from "heard but unknown" neighbor nodes (no NodeInfo). The fraction is of
-    # the *final* stream (DEF CON ran ~45%; default keeps it moderate). --
-    frac = P.get("encrypted_fraction", 0.0)
-    if frac > 0 and packets:
-        n_enc = int(len(packets) * frac / max(1e-6, 1.0 - frac))
-        foreign = [rng.randint(0x10000000, 0xEFFFFFFF) for _ in range(max(5, nodes // 8))]
-        foreign_hs = {f: int(_weighted(rng, P["hop_start_weights"])) for f in foreign}
-        # a handful of foreign channels, each with a realistic OTA hash byte
-        foreign_hashes = [rng.randint(1, 255) for _ in range(rng.randint(2, 4))]
-        added = attempts = 0
-        while added < n_enc and attempts < n_enc * 10:
-            attempts += 1
-            t = rng.randint(start_epoch, end_epoch - 1)
-            # foreign mesh traffic is largely independent of our conference rhythm
-            if rng.random() > _activity(hod(t)) * 0.4 + 0.6:
-                continue
-            f = rng.choice(foreign)
-            packets.append(
-                (
-                    t,
-                    _mp_enc(rng, next(pid_counter), f, foreign_hs[f], rng.choice(foreign_hashes)),
-                    "LongFast",
-                )
-            )
-            added += 1
+    _emit_encrypted(
+        rng,
+        P,
+        packets,
+        pid_counter,
+        nodes=nodes,
+        start_epoch=start_epoch,
+        end_epoch=end_epoch,
+        hod=hod,
+    )
 
     packets.sort(key=lambda p: p[0])
 

--- a/src/meshtastic_mcp/replay/sim.py
+++ b/src/meshtastic_mcp/replay/sim.py
@@ -43,6 +43,7 @@ BROADCAST = 0xFFFFFFFF
 
 # ── Tunable profile (fit to real captures as they become available) ──────────
 PROFILE: dict = {
+    "label_prefix": "meshcon",
     "venue": {"name": "VLA, New Mexico", "lat": 34.0784, "lon": -107.6184},
     # (label, lat, lon, spread_km, weight)
     "clusters": [
@@ -84,6 +85,17 @@ PROFILE: dict = {
         ("ROUTER_LATE", 3),
     ],
     "channels": ["LongFast", "MeshCon", "Talks", "Swap", "Hax", "Staff"],
+    # Where text lands, by channel (name, weight). Names absent from the active
+    # channel lineup collapse to LongFast; presets override this to match their
+    # own channel names.
+    "text_channel_weights": [
+        ("LongFast", 34),
+        ("MeshCon", 10),
+        ("Talks", 16),
+        ("Swap", 14),
+        ("Hax", 14),
+        ("Staff", 6),
+    ],
     # periodic intervals (seconds) — Meshtastic firmware-default cadences
     "pos_interval": {"mobile": 300, "router": 1800, "default": 900},
     "telemetry_interval": 1800,
@@ -141,6 +153,125 @@ PROFILE: dict = {
     # ObserverParams (lat/lon/seed default to the venue/generate seed).
     "observer": {"enabled": False},
 }
+
+# ── Scenario presets ─────────────────────────────────────────────────────────
+# Partial PROFILE overrides for whole-event scenarios, deep-merged over the
+# defaults. Tunables are reviewed constants informed by the real captures
+# (Burning Man 2025, DEF CON 33) — no dataset files are shipped. Geo uses public
+# venue coordinates; channel names are the events' published public channels.
+PRESETS: dict[str, dict] = {
+    # The default synthetic conference (VLA / MeshCon) — PROFILE as-is.
+    "meshcon": {},
+    # Burning Man: Black Rock City playa. Sparse/open terrain (high path-loss
+    # exponent), mild talker skew, a 10-day arc, the Aug-26 flood emergency +
+    # subsequent shitposting spike. Observer at centre camp.
+    "burningman": {
+        "label_prefix": "burningman",
+        "venue": {"name": "Black Rock City, NV", "lat": 40.7864, "lon": -119.2065},
+        "clusters": [
+            ("Center Camp", 40.7864, -119.2065, 0.6, 40),
+            ("2 o'clock", 40.7920, -119.2000, 0.8, 12),
+            ("10 o'clock", 40.7930, -119.2140, 0.8, 12),
+            ("4 o'clock", 40.7800, -119.1980, 0.8, 11),
+            ("8 o'clock", 40.7800, -119.2150, 0.8, 11),
+            ("Deep Playa", 40.8000, -119.2060, 2.5, 8),
+            ("The Man", 40.7864, -119.2065, 0.3, 4),
+            ("Gate/Greeters", 40.7550, -119.2330, 1.0, 2),
+        ],
+        "channels": ["LongFast", "Everyone", "BRC", "Playa", "Rangers"],
+        "text_channel_weights": [
+            ("LongFast", 30),
+            ("Everyone", 34),
+            ("BRC", 14),
+            ("Playa", 14),
+            ("Rangers", 8),
+        ],
+        "encrypted_fraction": 0.15,
+        "climate": {"t_mean": 26.0, "t_amp": 16.0, "pressure_hpa": 858.0, "nan_fraction": 0.03},
+        "observer": {
+            "enabled": True,
+            "path_loss_exp": 3.1,
+            "sigma_db": 9.0,
+            "loss_floor": 0.45,
+            "mqtt_fraction": 0.03,
+            "fade_good_s": 240.0,
+            "fade_bad_s": 90.0,
+        },
+        # day-2 evening: dust-storm flood emergency, then late-night shitposting
+        "spikes": [
+            {"start_h": 42, "hours": 3, "text_x": 6.0},
+            {"start_h": 45, "hours": 4, "text_x": 2.5},
+        ],
+    },
+    # DEF CON: dense indoor convention. Lower path-loss but heavy collisions
+    # (high loss floor), ~45% foreign/encrypted, ~40% via MQTT bridge, a
+    # ShortTurbo-flavoured second plane, con-hours envelope, hop-7 crankers.
+    "defcon": {
+        "label_prefix": "defcon",
+        "venue": {"name": "Las Vegas Convention Center", "lat": 36.1312, "lon": -115.1516},
+        "clusters": [
+            ("Contest Area", 36.1312, -115.1516, 0.15, 44),
+            ("Village Halls", 36.1330, -115.1500, 0.20, 22),
+            ("Talks", 36.1300, -115.1530, 0.20, 14),
+            ("Chillout", 36.1290, -115.1510, 0.20, 8),
+            ("Vendor", 36.1320, -115.1490, 0.20, 6),
+            ("Hotels", 36.1250, -115.1600, 1.2, 4),
+            ("Hallway", 36.1312, -115.1516, 0.10, 2),
+        ],
+        "channels": ["LongFast", "DEFCONnect", "HackerComms", "NodeChat", "MeshCon"],
+        "text_channel_weights": [
+            ("LongFast", 20),
+            ("DEFCONnect", 34),
+            ("HackerComms", 20),
+            ("NodeChat", 18),
+            ("MeshCon", 8),
+        ],
+        "encrypted_fraction": 0.45,
+        "hop_start_weights": [("3", 68), ("7", 18), ("4", 6), ("2", 5), ("5", 3)],
+        "climate": {"t_mean": 22.0, "t_amp": 2.0, "pressure_hpa": 940.0, "nan_fraction": 0.02},
+        "observer": {
+            "enabled": True,
+            "path_loss_exp": 2.6,
+            "sigma_db": 8.0,
+            "loss_floor": 0.62,
+            "mqtt_fraction": 0.40,
+            "fade_good_s": 150.0,
+            "fade_bad_s": 70.0,
+        },
+        "spikes": [{"start_h": 33, "hours": 6, "text_x": 2.0}],
+    },
+}
+
+# Config keys whose values are themselves dicts and should deep-merge (rather
+# than wholesale-replace) when a profile override is applied.
+_MERGE_DICT_KEYS = frozenset({"venue", "observer", "climate", "pos_interval"})
+
+
+def _deep_merge(base: dict, over: dict) -> dict:
+    out = dict(base)
+    for k, v in over.items():
+        if k in _MERGE_DICT_KEYS and isinstance(v, dict) and isinstance(out.get(k), dict):
+            out[k] = {**out[k], **v}
+        else:
+            out[k] = v
+    return out
+
+
+def _resolve_profile(profile: dict | str | None) -> dict:
+    """Merge a profile override (dict / preset name / JSON path) over PROFILE."""
+    if profile is None:
+        return dict(PROFILE)
+    if isinstance(profile, str):
+        if profile in PRESETS:
+            return _deep_merge(PROFILE, PRESETS[profile])
+        import json
+
+        with open(profile) as fh:
+            profile = json.load(fh)
+    if not isinstance(profile, dict):
+        raise TypeError(f"unsupported profile: {type(profile).__name__}")
+    return _deep_merge(PROFILE, profile)
+
 
 # Real text is short: median ~18 chars, p90 ~79. About half of messages are
 # terse one-liners / acks / emoji, so the generator mixes these in with the
@@ -407,10 +538,16 @@ def generate(
     seed: int = 1337,
     channels: list[str] | None = None,
     text_scale: float = 1.0,
-    profile: dict | None = None,
+    profile: dict | str | None = None,
 ) -> Capture:
-    """Generate a MeshCon capture in memory."""
-    P = {**PROFILE, **(profile or {})}
+    """Generate a synthetic capture in memory.
+
+    ``profile`` is a partial :data:`PROFILE` override: a dict, a path to a JSON
+    file (e.g. one produced by :func:`fit_profile`), or a preset name from
+    :data:`PRESETS` (``meshcon`` / ``burningman`` / ``defcon``). Nested config
+    dicts (venue/observer/climate/pos_interval) deep-merge over the defaults.
+    """
+    P = _resolve_profile(profile)
     rng = random.Random(seed)
     chans = channels or list(P["channels"])
     ch_index = {c: i for i, c in enumerate(chans)}
@@ -672,17 +809,7 @@ def generate(
                 mult *= sp.get("text_x", 1.0)
         budget = int(rng.gauss(base * _text_env(hod(t0)) * mult, base * 0.25))
         while budget > 0:
-            ch = _weighted(
-                rng,
-                [
-                    ("LongFast", 34),
-                    ("MeshCon", 10),
-                    ("Talks", 16),
-                    ("Swap", 14),
-                    ("Hax", 14),
-                    ("Staff", 6),
-                ],
-            )
+            ch = _weighted(rng, P["text_channel_weights"])
             if ch not in ch_index:
                 ch = "LongFast"
             burst = min(budget, max(1, int(rng.lognormvariate(0.9, 0.8))))
@@ -831,7 +958,10 @@ def generate(
         packets = observe(packets, positions, ObserverParams(**obs_cfg))
 
     cap = Capture(
-        nodes=node_rows, channels=chans, packets=packets, label=f"meshcon-{nodes}n-{days}d"
+        nodes=node_rows,
+        channels=chans,
+        packets=packets,
+        label=f"{P.get('label_prefix', 'meshcon')}-{nodes}n-{days}d",
     )
     return cap
 
@@ -840,9 +970,11 @@ def fit_profile(capture, *, base: dict | None = None) -> dict:
     """Derive a sim PROFILE from a real capture, to make synthetic output match.
 
     Returns a dict mergeable into :data:`PROFILE` / passable as ``generate(
-    profile=...)``: hardware + role mixes and channels from the node DB, a text
-    rate and per-node POSITION/TELEMETRY intervals from observed traffic. Geo
-    (venue/clusters) is left to the base profile. Pass the result straight to
+    profile=...)``: hardware + role mixes and channels from the node DB, text
+    rate + DM fraction, per-node POSITION/TELEMETRY intervals, hop_start
+    distribution, encrypted fraction, and the channel-hash text weighting, all
+    derived from observed traffic. Geo (venue/clusters/climate) is left to the
+    base profile. Pass the result straight to
     ``sim.generate(profile=fit_profile(cap))`` to synthesize a comparable mesh.
     """
     import itertools
@@ -861,22 +993,32 @@ def fit_profile(capture, *, base: dict | None = None) -> dict:
     if capture.channels:
         prof["channels"] = list(capture.channels)
 
-    # walk packets once: portnum mix + per-(node,portnum) timestamps
+    # walk packets once: portnum mix, hop starts, per-(node,portnum) times,
+    # per-channel text volume, DM fraction, encrypted fraction
     times: dict[tuple[int, int], list[int]] = defaultdict(list)
     portnums: Counter = Counter()
-    text_n = 0
-    for rxt, raw, _ch in capture.packets:
+    hop_starts: Counter = Counter()
+    text_by_ch: Counter = Counter()
+    text_n = text_dm = total = encrypted = 0
+    for rxt, raw, ch in capture.packets:
         mp = mesh_pb2.MeshPacket()
         try:
             mp.ParseFromString(raw)
         except Exception:
             continue
+        total += 1
+        if mp.hop_start:
+            hop_starts[mp.hop_start] += 1
         if mp.WhichOneof("payload_variant") != "decoded":
+            encrypted += 1
             continue
         pn = mp.decoded.portnum
         portnums[pn] += 1
         if pn == 1:
             text_n += 1
+            text_by_ch[ch] += 1
+            if mp.to != BROADCAST:
+                text_dm += 1
         if pn in (3, 67):
             times[(getattr(mp, "from"), pn)].append(rxt)
 
@@ -885,6 +1027,14 @@ def fit_profile(capture, *, base: dict | None = None) -> dict:
     n_nodes = max(len(nodes), 1)
     # text messages/hour normalised to the generator's 150-node baseline
     prof["text_base_msgs_per_hour"] = round(text_n / hours * (150.0 / n_nodes), 2)
+    if text_n:
+        prof["text_dm_fraction"] = round(text_dm / text_n, 3)
+    if total:
+        prof["encrypted_fraction"] = round(encrypted / total, 3)
+    if hop_starts:
+        prof["hop_start_weights"] = [(str(h), c) for h, c in hop_starts.most_common()]
+    if text_by_ch:
+        prof["text_channel_weights"] = [(ch, c) for ch, c in text_by_ch.most_common()]
 
     def _median_interval(portnum: int, default: int) -> int:
         deltas = []

--- a/src/meshtastic_mcp/replay/sim.py
+++ b/src/meshtastic_mcp/replay/sim.py
@@ -298,6 +298,22 @@ def _resolve_profile(profile: dict | str | None) -> dict:
     return _deep_merge(PROFILE, profile)
 
 
+def preset_profile(name: str, override: dict | None = None) -> dict:
+    """Resolve a preset name to a full profile dict, optionally deep-merging an
+    override on top.
+
+    The public, path-free entry point the ``replay_start`` MCP tool uses to
+    expose scenario tunables (observer/tak/spikes/climate/…) without accepting
+    a filesystem path from an untrusted caller. ``name`` must be a known preset
+    (see :data:`PRESETS`); ``override`` is a partial profile dict merged with the
+    same nested-dict rules as :func:`generate`'s ``profile=`` argument.
+    """
+    if name not in PRESETS:
+        raise ValueError(f"unknown preset {name!r}: expected one of {sorted(PRESETS)}")
+    base = _resolve_profile(name)
+    return _deep_merge(base, override) if override else base
+
+
 # Real text is short: median ~18 chars, p90 ~79. About half of messages are
 # terse one-liners / acks / emoji, so the generator mixes these in with the
 # themed lines below to match the observed length distribution (synthetic only).

--- a/src/meshtastic_mcp/replay/sim.py
+++ b/src/meshtastic_mcp/replay/sim.py
@@ -110,6 +110,18 @@ PROFILE: dict = {
     "hop_start_weights": [("3", 80), ("4", 8), ("7", 6), ("2", 4), ("5", 2)],
     # Text DMs are rare on-air (BM ~3.4%; DC DMs are PKI-invisible).
     "text_dm_fraction": 0.03,
+    # Scripted traffic spikes (keynote, emergency): each entry multiplies the
+    # text budget inside [start_h, start_h + hours) from the capture start.
+    "spikes": [],
+    # Venue climate for environment telemetry: diurnal temperature sinusoid
+    # (peak mid-afternoon), humidity anti-correlated, pressure around the
+    # venue-altitude mode. BM measured 8..55 C, humidity with real NaNs.
+    "climate": {"t_mean": 22.0, "t_amp": 9.0, "pressure_hpa": 780.0, "nan_fraction": 0.02},
+    # Battery population: fraction running on wall/solar power (reports 101);
+    # the rest discharge at a per-node %/hour rate and bottom out at 0
+    # (real captures show both a 101 mode and a 0 spike). Infra is always
+    # plugged and emits disproportionately, so the client fraction stays low.
+    "plugged_fraction": 0.12,
     # Observed text volume across the real captures was ~2.2 msgs/hr per 150
     # nodes (gateway-observed, an undercount); 4 keeps conference channels lively
     # while staying close to reality.
@@ -440,6 +452,12 @@ def generate(
         # the factor scales a node's beacon cadence below.
         talk = min(25.0, max(0.25, rng.lognormvariate(0.0, 0.9)))
         infra = role.startswith("ROUTER") or role == "SENSOR"
+        # Battery persona: plugged nodes report 101; the rest discharge at a
+        # per-node rate and bottom out at 0 (both modes appear in real data).
+        if infra or rng.random() < P["plugged_fraction"]:
+            batt = (101.0, 0.0)
+        else:
+            batt = (rng.uniform(40.0, 100.0), rng.uniform(2.0, 10.0))
         if role.startswith("ROUTER"):
             talk *= 8.0
         elif role == "SENSOR":
@@ -475,6 +493,10 @@ def generate(
                 "mobile": mobile,
                 "talk": talk,
                 "hop_start": int(_weighted(rng, P["hop_start_weights"])),
+                "batt": batt,
+                # per-node chutil gain: what fraction of the mesh's airtime this
+                # node's radio actually hears (distance/terrain dependent)
+                "ch_gain": rng.uniform(0.1, 0.9),
                 "join_t": start_epoch + int(join_h * 3600),
                 "leave_t": start_epoch + int((join_h + stay_h) * 3600),
             }
@@ -488,6 +510,8 @@ def generate(
     # packet-id counter is local so a given (seed, nodes, days, start) is
     # byte-for-byte reproducible across calls in the same process
     pid_counter = itertools.count(0x10000001)
+
+    tel_pending: list[tuple[int, dict]] = []
 
     def add(t, frm, to, pn, payload, ch="LongFast", hop=None, want_response=False):
         # hop_limit derives from the sender's configured hop_start minus a
@@ -542,12 +566,12 @@ def generate(
             if m["role"].startswith("ROUTER")
             else P["pos_interval"]["default"]
         )
-        # Talkativeness skews *social* traffic hard, but periodic beacons only
-        # mildly (position cadence is device config, not personality) — real
-        # position intervals sit near the firmware defaults (p50 ~10 min).
-        beacon_talk = talk**0.35
-        pos_iv = max(30, pos_iv / beacon_talk)
-        tel_iv = max(60, P["telemetry_interval"] / beacon_talk)
+        # Talkativeness skews *social* traffic hard, but position beacons only
+        # mildly, and telemetry not at all — telemetry cadence is a fixed
+        # firmware default for every role (infra dominance in real captures
+        # comes from persistent presence, not a faster clock).
+        pos_iv = max(30, pos_iv / talk**0.35)
+        tel_iv = P["telemetry_interval"]
         t = jt + rng.randint(0, 300)
         while t < node_end:
             if rng.random() < _activity(hod(t)) + 0.1:
@@ -556,7 +580,9 @@ def generate(
         t = jt + rng.randint(0, 600)
         while t < node_end:
             if rng.random() < _activity(hod(t)) + 0.15:
-                add(t, m["num"], BROADCAST, 67, _pl_tel_device(rng, t))
+                # deferred: chutil is derived from the *actual* generated
+                # airtime, so device telemetry is emitted in a second pass
+                tel_pending.append((t, m))
             t += int(tel_iv * rng.uniform(0.8, 1.2))
         t = jt + P["nodeinfo_refresh"]
         while t < node_end:
@@ -594,9 +620,11 @@ def generate(
     env_extra = [m for m in meta if rng.random() < P["env_sensor_fraction"]]
     env_nodes = list({m["num"]: m for m in sensors + routers[:3] + env_extra}.values())
     for m in env_nodes:
+        # sensor persona: which fields this board reports, fixed per node
+        persona = _weighted(rng, _ENV_PERSONAS)
         t = start_epoch + rng.randint(0, P["env_interval"])
         while t < end_epoch:
-            add(t, m["num"], BROADCAST, 67, _pl_tel_env(rng, t))
+            add(t, m["num"], BROADCAST, 67, _pl_tel_env(rng, P["climate"], persona, hod(t), t))
             if rng.random() < 0.9:
                 add(t + 5, m["num"], BROADCAST, 67, _pl_tel_power(rng, t))
             t += int(P["env_interval"] * rng.uniform(0.8, 1.2))
@@ -630,13 +658,20 @@ def generate(
         if rng.random() < 0.7:
             add(t + rng.randint(1, 4), nb["num"], na["num"], 5, _pl_routing_ack(), hop=0)
 
-    # -- text chatter --
+    # -- text chatter: conversation bursts, not a uniform smear. A burst is a
+    # few nodes trading messages ~45 s apart on one channel (real inter-arrival
+    # is heavy-tailed: replies cluster within minutes, then silence). Scripted
+    # spikes (keynote / emergency) multiply the hourly budget. --
     base = P["text_base_msgs_per_hour"] * (nodes / 150.0) * text_scale
+    spikes = P.get("spikes") or []
     for hour in range(days * 24):
         t0 = start_epoch + hour * 3600
-        n_msgs = int(rng.gauss(base * _text_env(hod(t0)), base * 0.25))
-        for _ in range(max(0, n_msgs)):
-            t = t0 + rng.randint(0, 3599)
+        mult = 1.0
+        for sp in spikes:
+            if sp["start_h"] <= hour < sp["start_h"] + sp["hours"]:
+                mult *= sp.get("text_x", 1.0)
+        budget = int(rng.gauss(base * _text_env(hod(t0)) * mult, base * 0.25))
+        while budget > 0:
             ch = _weighted(
                 rng,
                 [
@@ -650,13 +685,19 @@ def generate(
             )
             if ch not in ch_index:
                 ch = "LongFast"
-            sender = rng.choice(node_rows)
-            text = _pick_text(rng, ch, node_rows)
-            dm = rng.random() < P["text_dm_fraction"]
-            to = rng.choice(node_rows).num if dm else BROADCAST
-            add(t, sender.num, to, 1, text.encode("utf-8"), ch=ch)
-            if dm and rng.random() < P["ack_ratio"]:
-                add(t + rng.randint(1, 5), to, sender.num, 5, _pl_routing_ack(), ch=ch, hop=0)
+            burst = min(budget, max(1, int(rng.lognormvariate(0.9, 0.8))))
+            budget -= burst
+            t = t0 + rng.randint(0, 3599)
+            party = rng.sample(node_rows, min(len(node_rows), rng.randint(2, 4)))
+            for _ in range(burst):
+                sender = rng.choice(party)
+                text = _pick_text(rng, ch, node_rows)
+                dm = rng.random() < P["text_dm_fraction"]
+                to = rng.choice(node_rows).num if dm else BROADCAST
+                add(t, sender.num, to, 1, text.encode("utf-8"), ch=ch)
+                if dm and rng.random() < P["ack_ratio"]:
+                    add(t + rng.randint(1, 5), to, sender.num, 5, _pl_routing_ack(), ch=ch, hop=0)
+                t += 2 + int(rng.expovariate(1 / 45.0))
 
     # -- waypoints (some with geofence fields for client enter/exit alert testing) --
     pois = [
@@ -680,33 +721,6 @@ def generate(
                 ch="MeshCon" if "MeshCon" in ch_index else "LongFast",
                 hop=4,
             )
-
-    # -- encrypted/foreign traffic: packets on channels the viewer can't decode,
-    # from "heard but unknown" neighbor nodes (no NodeInfo). The fraction is of
-    # the *final* stream (DEF CON ran ~45%; default keeps it moderate). --
-    frac = P.get("encrypted_fraction", 0.0)
-    if frac > 0 and packets:
-        n_enc = int(len(packets) * frac / max(1e-6, 1.0 - frac))
-        foreign = [rng.randint(0x10000000, 0xEFFFFFFF) for _ in range(max(5, nodes // 8))]
-        foreign_hs = {f: int(_weighted(rng, P["hop_start_weights"])) for f in foreign}
-        # a handful of foreign channels, each with a realistic OTA hash byte
-        foreign_hashes = [rng.randint(1, 255) for _ in range(rng.randint(2, 4))]
-        added = attempts = 0
-        while added < n_enc and attempts < n_enc * 10:
-            attempts += 1
-            t = rng.randint(start_epoch, end_epoch - 1)
-            # foreign mesh traffic is largely independent of our conference rhythm
-            if rng.random() > _activity(hod(t)) * 0.4 + 0.6:
-                continue
-            f = rng.choice(foreign)
-            packets.append(
-                (
-                    t,
-                    _mp_enc(rng, next(pid_counter), f, foreign_hs[f], rng.choice(foreign_hashes)),
-                    "LongFast",
-                )
-            )
-            added += 1
 
     # -- range test: a couple of nodes beacon sequence numbers (DEF CON had ~4%) --
     for m in rng.sample(meta, min(len(meta), 2)):
@@ -763,6 +777,43 @@ def generate(
                 hop=3,
             )
             t += int(beacon_iv * rng.uniform(0.85, 1.15))
+
+    # -- device telemetry second pass: chutil tracks the actual per-hour
+    # generated load (real chutil follows the diurnal traffic envelope) --
+    hour_hist: dict[int, int] = {}
+    for t, _raw, _ch in packets:
+        hour_hist[(t - start_epoch) // 3600] = hour_hist.get((t - start_epoch) // 3600, 0) + 1
+    peak_rate = max(hour_hist.values()) if hour_hist else 1
+    for t, m in tel_pending:
+        load = hour_hist.get((t - start_epoch) // 3600, 0) / peak_rate
+        add(t, m["num"], BROADCAST, 67, _pl_tel_device(rng, m, t, load))
+
+    # -- encrypted/foreign traffic: packets on channels the viewer can't decode,
+    # from "heard but unknown" neighbor nodes (no NodeInfo). The fraction is of
+    # the *final* stream (DEF CON ran ~45%; default keeps it moderate). --
+    frac = P.get("encrypted_fraction", 0.0)
+    if frac > 0 and packets:
+        n_enc = int(len(packets) * frac / max(1e-6, 1.0 - frac))
+        foreign = [rng.randint(0x10000000, 0xEFFFFFFF) for _ in range(max(5, nodes // 8))]
+        foreign_hs = {f: int(_weighted(rng, P["hop_start_weights"])) for f in foreign}
+        # a handful of foreign channels, each with a realistic OTA hash byte
+        foreign_hashes = [rng.randint(1, 255) for _ in range(rng.randint(2, 4))]
+        added = attempts = 0
+        while added < n_enc and attempts < n_enc * 10:
+            attempts += 1
+            t = rng.randint(start_epoch, end_epoch - 1)
+            # foreign mesh traffic is largely independent of our conference rhythm
+            if rng.random() > _activity(hod(t)) * 0.4 + 0.6:
+                continue
+            f = rng.choice(foreign)
+            packets.append(
+                (
+                    t,
+                    _mp_enc(rng, next(pid_counter), f, foreign_hs[f], rng.choice(foreign_hashes)),
+                    "LongFast",
+                )
+            )
+            added += 1
 
     packets.sort(key=lambda p: p[0])
 
@@ -897,14 +948,17 @@ _PRECISION_WEIGHTS = [
 ]
 
 
-def _chutil(rng: random.Random) -> float:
-    # skewed low with a modest high tail (BM observed p50 ~7, p90 ~23, max ~39)
-    r = rng.random()
-    if r < 0.7:
-        return round(rng.uniform(1, 15), 3)
-    if r < 0.95:
-        return round(rng.uniform(15, 28), 3)
-    return round(rng.uniform(28, 45), 3)
+# Env-sensor personas: which fields a given board reports, with weights fit to
+# the observed field-presence ratios (BM: temperature 100%, lux 63%, humidity
+# 36%, pressure 17%, gas/IAQ 3.4%). T=temp L=lux H=humidity P=pressure G=gas+IAQ.
+_ENV_PERSONAS = [
+    ("TL", 40),
+    ("T", 20),
+    ("TLH", 15),
+    ("THP", 12),
+    ("TLHP", 8),
+    ("THPG", 4),
+]
 
 
 def _pl_position(rng, m, t):
@@ -929,32 +983,69 @@ def _pl_nodeinfo(nr: NodeRow):
     return u.SerializeToString()
 
 
-def _pl_tel_device(rng, t):
+def _pl_tel_device(rng, m, t, load):
+    """Device metrics with per-node battery state and load-derived chutil.
+
+    ``load`` is this hour's generated traffic normalised to the busiest hour,
+    so channel utilisation tracks the actual diurnal envelope (BM observed
+    p50 ~7, p90 ~23, max ~39). Battery follows the node's persona: plugged
+    nodes report 101; discharging nodes drain linearly and bottom out at 0.
+    """
     tm = telemetry_pb2.Telemetry()
     tm.time = t
     d = tm.device_metrics
-    # ~half of nodes report 101 (plugged in / charging); the rest spread 30-99
-    d.battery_level = 101 if rng.random() < 0.45 else rng.randint(30, 99)
-    d.voltage = (
-        0.0 if d.battery_level == 101 and rng.random() < 0.3 else round(rng.uniform(3.5, 4.2), 3)
+    start, rate = m["batt"]
+    if start >= 101:
+        d.battery_level = 101
+        d.voltage = 0.0 if rng.random() < 0.4 else round(rng.uniform(3.9, 4.25), 3)
+    else:
+        hours = max(0.0, (t - m["join_t"]) / 3600.0)
+        lvl = max(0, int(start - rate * hours))
+        d.battery_level = lvl
+        d.voltage = round(3.0 + 1.25 * lvl / 100.0 + rng.uniform(-0.05, 0.05), 3)
+    gain = m.get("ch_gain", 0.5)
+    d.channel_utilization = round(
+        min(60.0, 0.8 + 36.0 * load**1.6 * gain * rng.uniform(0.8, 1.2)), 3
     )
-    d.channel_utilization = _chutil(rng)
     # air-util skews very low; occasional busy node
     d.air_util_tx = round(
         rng.uniform(0.0, 0.2) if rng.random() < 0.85 else rng.uniform(0.2, 6.0), 4
     )
-    d.uptime_seconds = rng.randint(60, 400000)
+    d.uptime_seconds = max(60, t - m["join_t"] + rng.randint(0, 900))
     return tm.SerializeToString()
 
 
-def _pl_tel_env(rng, t):
+def _pl_tel_env(rng, climate, persona, hod_f, t):
+    """Environment metrics from the venue climate model + the node's persona.
+
+    Temperature is a diurnal sinusoid (peak mid-afternoon), humidity is
+    anti-correlated with temperature and occasionally NaN (real sensors emit
+    NaN — clients must cope), lux follows solar elevation, pressure random-
+    walks around the venue-altitude mode.
+    """
     tm = telemetry_pb2.Telemetry()
     tm.time = t
     e = tm.environment_metrics
-    e.temperature = round(rng.uniform(12, 33), 2)
-    e.relative_humidity = round(rng.uniform(8, 40), 2)
-    e.barometric_pressure = round(rng.uniform(770, 790), 2)
-    e.voltage = round(rng.uniform(3.7, 4.2), 3)
+    temp = (
+        climate["t_mean"]
+        + climate["t_amp"] * math.cos(2.0 * math.pi * (hod_f - 15.0) / 24.0)
+        + rng.gauss(0.0, 0.8)
+    )
+    e.temperature = round(temp, 2)
+    if "H" in persona:
+        if rng.random() < climate.get("nan_fraction", 0.0):
+            e.relative_humidity = float("nan")
+        else:
+            hum = 75.0 - 1.8 * (temp - 10.0) + rng.gauss(0.0, 6.0)
+            e.relative_humidity = round(min(96.0, max(4.0, hum)), 2)
+    if "P" in persona:
+        e.barometric_pressure = round(climate["pressure_hpa"] + rng.gauss(0.0, 2.5), 2)
+    if "L" in persona:
+        sun = math.sin(math.pi * (hod_f - 6.0) / 12.0) if 6.0 <= hod_f <= 18.0 else 0.0
+        e.lux = round(max(0.0, sun) * rng.uniform(20000.0, 90000.0) + rng.uniform(0.0, 40.0), 2)
+    if "G" in persona:
+        e.gas_resistance = round(rng.uniform(10000.0, 200000.0), 1)
+        e.iaq = rng.randint(10, 150)
     return tm.SerializeToString()
 
 

--- a/src/meshtastic_mcp/replay/sim.py
+++ b/src/meshtastic_mcp/replay/sim.py
@@ -29,6 +29,7 @@ import time
 
 from meshtastic.protobuf import (
     admin_pb2,
+    atak_pb2,
     config_pb2,
     mesh_pb2,
     paxcount_pb2,
@@ -134,6 +135,16 @@ PROFILE: dict = {
     # (real captures show both a 101 mode and a 0 spike). Infra is always
     # plugged and emits disproportionately, so the client fraction stays low.
     "plugged_fraction": 0.12,
+    # ATAK squad (opt-in): when team_nodes > 0, a squad emits TAKPacket PLI +
+    # GeoChat + status (portnum 72). Off by default — no TAK traffic appeared
+    # in the real captures. See WS-A in docs/sim-realism-plan.md.
+    "tak": {
+        "team_nodes": 0,
+        "pli_interval": 45,
+        "chat_per_hour": 2.0,
+        "team": "Cyan",
+        "channel": "LongFast",
+    },
     # Observed text volume across the real captures was ~2.2 msgs/hr per 150
     # nodes (gateway-observed, an undercount); 4 keeps conference channels lively
     # while staying close to reality.
@@ -905,6 +916,39 @@ def generate(
             )
             t += int(beacon_iv * rng.uniform(0.85, 1.15))
 
+    # -- ATAK squad (opt-in, off by default): a team of nodes emitting TAKPacket
+    # (portnum 72) PLI + GeoChat + status, for exercising the ATAK plugin /
+    # forwarder / map-PLI paths. No TAK traffic appeared in the real captures,
+    # so this is a scenario knob, not part of the fitted event profiles. --
+    tak_cfg = P.get("tak") or {}
+    tak_n = int(tak_cfg.get("team_nodes", 0))
+    if tak_n > 0 and meta:
+        team_val = _enum(atak_pb2.Team, tak_cfg.get("team", "Cyan"), 0)
+        tak_ch = tak_cfg.get("channel", "LongFast")
+        if tak_ch not in ch_index:
+            tak_ch = chans[0]
+        pli_iv = int(tak_cfg.get("pli_interval", 45))
+        chat_iv = 3600.0 / max(float(tak_cfg.get("chat_per_hour", 2.0)), 0.01)
+        squad = rng.sample(meta, min(len(meta), tak_n))
+        for i, m in enumerate(squad):
+            role_name = "TeamLead" if i == 0 else "Medic" if i == 1 else "TeamMember"
+            role_val = _enum(atak_pb2.MemberRole, role_name, 1)
+            callsign = f"{rng.choice(_ADJ)}-{i + 1}"
+            node_end = min(end_epoch, m["leave_t"])
+            t = m["join_t"] + rng.randint(0, pli_iv)
+            while t < node_end:
+                lat_i = m["lat_i"] + rng.randint(-4000, 4000)
+                lon_i = m["lon_i"] + rng.randint(-4000, 4000)
+                pl = _pl_tak_pli(rng, callsign, team_val, role_val, lat_i, lon_i, _batt_level(m, t))
+                add(t, m["num"], BROADCAST, 72, pl, ch=tak_ch)
+                t += int(pli_iv * rng.uniform(0.8, 1.2))
+            t = m["join_t"] + rng.randint(0, int(chat_iv))
+            while t < node_end:
+                if rng.random() < _activity(hod(t)) + 0.2:
+                    pl = _pl_tak_chat(rng, callsign, team_val, role_val, _batt_level(m, t))
+                    add(t, m["num"], BROADCAST, 72, pl, ch=tak_ch)
+                t += int(chat_iv * rng.uniform(0.7, 1.3))
+
     # -- device telemetry second pass: chutil tracks the actual per-hour
     # generated load (real chutil follows the diurnal traffic envelope) --
     hour_hist: dict[int, int] = {}
@@ -1133,6 +1177,62 @@ def _pl_nodeinfo(nr: NodeRow):
     return u.SerializeToString()
 
 
+def _batt_level(m, t) -> int:
+    """Battery % for node ``m`` at time ``t``: 101 if plugged, else a linear
+    discharge from its start level bottoming out at 0."""
+    start, rate = m["batt"]
+    if start >= 101:
+        return 101
+    hours = max(0.0, (t - m["join_t"]) / 3600.0)
+    return max(0, int(start - rate * hours))
+
+
+def _pl_tak_pli(rng, callsign, team_val, role_val, lat_i, lon_i, batt) -> bytes:
+    """A TAKPacket (portnum 72) position/location-information report."""
+    tp = atak_pb2.TAKPacket()
+    tp.is_compressed = False
+    tp.contact.callsign = callsign
+    tp.contact.device_callsign = callsign
+    tp.group.team = team_val
+    tp.group.role = role_val
+    tp.status.battery = min(100, batt)
+    p = tp.pli
+    p.latitude_i = lat_i
+    p.longitude_i = lon_i
+    p.altitude = rng.randint(2000, 2500)
+    p.speed = rng.randint(0, 8)
+    p.course = rng.randint(0, 359)
+    return tp.SerializeToString()
+
+
+_TAK_CHAT = [
+    "moving to OP",
+    "eyes on objective",
+    "hold position",
+    "copy all",
+    "rally at CP1",
+    "requesting sitrep",
+    "green light",
+    "RTB",
+    "checkpoint clear",
+    "need a medic",
+]
+
+
+def _pl_tak_chat(rng, callsign, team_val, role_val, batt) -> bytes:
+    """A TAKPacket (portnum 72) GeoChat message to the team room."""
+    tp = atak_pb2.TAKPacket()
+    tp.is_compressed = False
+    tp.contact.callsign = callsign
+    tp.contact.device_callsign = callsign
+    tp.group.team = team_val
+    tp.group.role = role_val
+    tp.status.battery = min(100, batt)
+    tp.chat.message = rng.choice(_TAK_CHAT)
+    tp.chat.to = "All Chat Rooms"
+    return tp.SerializeToString()
+
+
 def _pl_tel_device(rng, m, t, load):
     """Device metrics with per-node battery state and load-derived chutil.
 
@@ -1144,14 +1244,11 @@ def _pl_tel_device(rng, m, t, load):
     tm = telemetry_pb2.Telemetry()
     tm.time = t
     d = tm.device_metrics
-    start, rate = m["batt"]
-    if start >= 101:
-        d.battery_level = 101
+    lvl = _batt_level(m, t)
+    d.battery_level = lvl
+    if lvl >= 101:
         d.voltage = 0.0 if rng.random() < 0.4 else round(rng.uniform(3.9, 4.25), 3)
     else:
-        hours = max(0.0, (t - m["join_t"]) / 3600.0)
-        lvl = max(0, int(start - rate * hours))
-        d.battery_level = lvl
         d.voltage = round(3.0 + 1.25 * lvl / 100.0 + rng.uniform(-0.05, 0.05), 3)
     gain = m.get("ch_gain", 0.5)
     d.channel_utilization = round(

--- a/src/meshtastic_mcp/replay/sim.py
+++ b/src/meshtastic_mcp/replay/sim.py
@@ -279,6 +279,16 @@ def _resolve_profile(profile: dict | str | None) -> dict:
     if isinstance(profile, str):
         if profile in PRESETS:
             return _deep_merge(PROFILE, PRESETS[profile])
+        # Non-preset strings are only ever treated as JSON files (e.g. a
+        # fit_profile() dump) and must be an explicit .json path — this keeps
+        # a mistyped preset name from silently opening some other file, and
+        # gives a clear error. Note the MCP replay_start tool only ever passes
+        # a validated preset name here, never caller-controlled paths.
+        if not profile.endswith(".json"):
+            raise ValueError(
+                f"unknown profile {profile!r}: expected one of {sorted(PRESETS)} "
+                "or a path to a .json profile file"
+            )
         import json
 
         with open(profile) as fh:

--- a/src/meshtastic_mcp/replay/sim.py
+++ b/src/meshtastic_mcp/replay/sim.py
@@ -138,12 +138,16 @@ PROFILE: dict = {
     # ATAK squad (opt-in): when team_nodes > 0, a squad emits TAKPacket PLI +
     # GeoChat + status (portnum 72). Off by default — no TAK traffic appeared
     # in the real captures. See WS-A in docs/sim-realism-plan.md.
+    # ``wire``: "v1" (default) emits the legacy uncompressed TAKPacket; "v2"
+    # emits real zstd-dictionary-compressed TAKPacketV2 payloads and requires
+    # the [tak] extra (meshtastic-tak SDK) — see replay/tak.py.
     "tak": {
         "team_nodes": 0,
         "pli_interval": 45,
         "chat_per_hour": 2.0,
         "team": "Cyan",
         "channel": "LongFast",
+        "wire": "v1",
     },
     # Observed text volume across the real captures was ~2.2 msgs/hr per 150
     # nodes (gateway-observed, an undercount); 4 keeps conference channels lively
@@ -929,23 +933,57 @@ def generate(
             tak_ch = chans[0]
         pli_iv = int(tak_cfg.get("pli_interval", 45))
         chat_iv = 3600.0 / max(float(tak_cfg.get("chat_per_hour", 2.0)), 0.01)
+        v2_wire = tak_cfg.get("wire", "v1") == "v2"
+        if v2_wire:
+            from . import tak as _tak
+
+            _tak._require()  # fail fast with an install hint if the extra is absent
         squad = rng.sample(meta, min(len(meta), tak_n))
         for i, m in enumerate(squad):
             role_name = "TeamLead" if i == 0 else "Medic" if i == 1 else "TeamMember"
             role_val = _enum(atak_pb2.MemberRole, role_name, 1)
             callsign = f"{rng.choice(_ADJ)}-{i + 1}"
+            uid = f"MESH-{m['num']:08x}"
             node_end = min(end_epoch, m["leave_t"])
             t = m["join_t"] + rng.randint(0, pli_iv)
             while t < node_end:
                 lat_i = m["lat_i"] + rng.randint(-4000, 4000)
                 lon_i = m["lon_i"] + rng.randint(-4000, 4000)
-                pl = _pl_tak_pli(rng, callsign, team_val, role_val, lat_i, lon_i, _batt_level(m, t))
+                batt_lvl = _batt_level(m, t)
+                if v2_wire:
+                    pkt = _tak.build_pli(
+                        callsign=callsign,
+                        uid=uid,
+                        team=team_val,
+                        role=role_val,
+                        lat_i=lat_i,
+                        lon_i=lon_i,
+                        altitude=rng.randint(2000, 2500),
+                        speed=rng.randint(0, 8),
+                        course=rng.randint(0, 359),
+                        battery=min(100, batt_lvl),
+                    )
+                    pl = _tak.compress(pkt)
+                else:
+                    pl = _pl_tak_pli(rng, callsign, team_val, role_val, lat_i, lon_i, batt_lvl)
                 add(t, m["num"], BROADCAST, 72, pl, ch=tak_ch)
                 t += int(pli_iv * rng.uniform(0.8, 1.2))
             t = m["join_t"] + rng.randint(0, int(chat_iv))
             while t < node_end:
                 if rng.random() < _activity(hod(t)) + 0.2:
-                    pl = _pl_tak_chat(rng, callsign, team_val, role_val, _batt_level(m, t))
+                    batt_lvl = _batt_level(m, t)
+                    if v2_wire:
+                        pkt = _tak.build_chat(
+                            callsign=callsign,
+                            uid=uid,
+                            team=team_val,
+                            role=role_val,
+                            battery=min(100, batt_lvl),
+                            message=rng.choice(_TAK_CHAT),
+                        )
+                        pl = _tak.compress(pkt)
+                    else:
+                        pl = _pl_tak_chat(rng, callsign, team_val, role_val, batt_lvl)
                     add(t, m["num"], BROADCAST, 72, pl, ch=tak_ch)
                 t += int(chat_iv * rng.uniform(0.7, 1.3))
 

--- a/src/meshtastic_mcp/replay/sim.py
+++ b/src/meshtastic_mcp/replay/sim.py
@@ -71,20 +71,45 @@ PROFILE: dict = {
         ("STATION_G2", 3),
         ("NANO_G2_ULTRA", 1),
     ],
+    # Role mix from the real node DBs: events run ~6-13 routers per 1600 nodes,
+    # not dozens — the first 8 sim nodes are always infra, extras stay rare.
     "role_weights": [
-        ("CLIENT", 88),
-        ("CLIENT_MUTE", 6),
-        ("TRACKER", 2),
-        ("ROUTER", 2),
-        ("ROUTER_LATE", 1),
-        ("SENSOR", 1),
+        ("CLIENT", 880),
+        ("CLIENT_MUTE", 40),
+        ("TRACKER", 15),
+        ("SENSOR", 10),
+        ("ROUTER_CLIENT", 4),
+        ("CLIENT_HIDDEN", 4),
+        ("ROUTER", 3),
+        ("ROUTER_LATE", 3),
     ],
     "channels": ["LongFast", "MeshCon", "Talks", "Swap", "Hax", "Staff"],
     # periodic intervals (seconds) — Meshtastic firmware-default cadences
     "pos_interval": {"mobile": 300, "router": 1800, "default": 900},
-    "telemetry_interval": 900,
+    "telemetry_interval": 1800,
     "nodeinfo_refresh": 10800,
-    "neighborinfo_interval": 14400,
+    # NodeInfo economy — real meshes are NODEINFO-dominated (~35% of decoded
+    # traffic) because arrivals trigger want_response exchange storms and nodes
+    # keep re-requesting unknowns. Pairs per arrival + a background cadence.
+    "nodeinfo_exchange_pairs": (2, 6),
+    "nodeinfo_background_interval": 2700,
+    # Routing ACK economy: acks per ack-eligible event (DM text, traceroute,
+    # want_response exchange) plus a per-node background reliable-delivery hum.
+    "ack_ratio": 0.8,
+    "ack_background_interval": 3600,
+    # NeighborInfo is off by default in real firmware — only infra + a sliver
+    # of enthusiasts emit it (BM: 0.04% of traffic).
+    "neighborinfo_interval": 21600,
+    "neighborinfo_fraction": 0.005,
+    # ~3.5% of real nodes carry environment sensors (they are mostly CLIENTs
+    # with a BME/lux board attached, not SENSOR-role nodes).
+    "env_sensor_fraction": 0.035,
+    "env_interval": 10800,
+    # Per-node radio config: most run the default 3 hops, a subpopulation
+    # cranks it to 7 (observed at DEF CON), infra often uses 4.
+    "hop_start_weights": [("3", 80), ("4", 8), ("7", 6), ("2", 4), ("5", 2)],
+    # Text DMs are rare on-air (BM ~3.4%; DC DMs are PKI-invisible).
+    "text_dm_fraction": 0.03,
     # Observed text volume across the real captures was ~2.2 msgs/hr per 150
     # nodes (gateway-observed, an undercount); 4 keeps conference channels lively
     # while staying close to reality.
@@ -122,6 +147,15 @@ _SHORT = [
     "where you at",
     "radio check",
     "73",
+    # medium one-liners — real short messages skew a bit longer (p50 ~18-25)
+    "on my way back to camp",
+    "meet at the coffee truck?",
+    "anyone got a spare battery pack",
+    "heading to the north arm now",
+    "signal is great from up here",
+    "save me a seat at the talk",
+    "who else is hearing this hop",
+    "back online, swapped batteries",
 ]
 
 KM_PER_DEG_LAT = 110.574
@@ -275,39 +309,75 @@ def _text_env(hod: float) -> float:
     return base * 0.25
 
 
-# Observed hop_limit distribution across the real captures (gateways see packets
-# at varying remaining hops); used so the app's "hops away" looks realistic.
-_HOP_WEIGHTS = [(3, 32), (2, 28), (1, 26), (0, 20), (4, 14), (5, 1)]
+# How many hops a packet has already taken when the observer hears it (drives
+# hop_limit = hop_start - taken); matches the observed remaining-hop spread.
+_HOPS_TAKEN_WEIGHTS = [(0, 30), (1, 28), (2, 22), (3, 14), (4, 5), (5, 1)]
+
+# Per-portnum MeshPacket.priority (matches firmware behaviour: periodic beacons
+# are BACKGROUND, text is DEFAULT, ACKs are ACK, admin/traceroute RELIABLE).
+_PRIORITY = {1: 64, 5: 120, 6: 70, 70: 70}
+_PRIORITY_DEFAULT = 10  # BACKGROUND
 
 
-def _hop(rng: random.Random) -> int:
-    return int(_weighted(rng, [(str(h), w) for h, w in _HOP_WEIGHTS]))
+def _hops_taken(rng: random.Random, hop_start: int) -> int:
+    return min(hop_start, int(_weighted(rng, [(str(h), w) for h, w in _HOPS_TAKEN_WEIGHTS])))
 
 
-def _mp(frm, to, portnum, payload, hop_limit, ch_idx) -> bytes:
+def _mp(
+    frm,
+    to,
+    portnum,
+    payload,
+    hop_limit,
+    hop_start,
+    ch_idx,
+    *,
+    priority: int = 0,
+    want_response: bool = False,
+) -> bytes:
     mp = mesh_pb2.MeshPacket()
     setattr(mp, "from", frm & 0xFFFFFFFF)
     mp.to = to & 0xFFFFFFFF
     mp.id = next(_pid) & 0xFFFFFFFF
-    mp.hop_limit = max(0, hop_limit)
-    mp.hop_start = max(mp.hop_limit, 3)
+    mp.hop_start = max(0, hop_start)
+    mp.hop_limit = max(0, min(hop_limit, mp.hop_start))
     mp.channel = ch_idx
+    if priority:
+        mp.priority = priority
     mp.decoded.portnum = portnum
     mp.decoded.payload = payload
+    if want_response:
+        mp.decoded.want_response = True
     return mp.SerializeToString()
 
 
-def _mp_enc(rng, frm, hop_limit, ch_idx) -> bytes:
+# Encrypted-payload sizes mirror the underlying portnum mix (position ~24-32 B,
+# nodeinfo ~64-80 B, telemetry ~32 B, text variable with a long tail).
+_ENC_LEN_WEIGHTS = [
+    ("24", 30),
+    ("32", 25),
+    ("48", 15),
+    ("64", 10),
+    ("80", 8),
+    ("120", 6),
+    ("180", 4),
+    ("232", 2),
+]
+
+
+def _mp_enc(rng, frm, hop_start, ch_hash) -> bytes:
     """An encrypted (undecodable) packet — models traffic on a channel/key the
-    viewer lacks (a real mesh is ~40% such 'neighbor' traffic)."""
+    viewer lacks (DEF CON ran ~45% such 'foreign' traffic). ``ch_hash`` is the
+    OTA channel-hash byte a real radio would report (not a settings index)."""
     mp = mesh_pb2.MeshPacket()
     setattr(mp, "from", frm & 0xFFFFFFFF)
     mp.to = 0xFFFFFFFF
     mp.id = next(_pid) & 0xFFFFFFFF
-    mp.hop_limit = max(0, hop_limit)
-    mp.hop_start = max(mp.hop_limit, 3)
-    mp.channel = ch_idx
-    mp.encrypted = bytes(rng.randint(0, 255) for _ in range(rng.randint(16, 48)))
+    mp.hop_start = max(0, hop_start)
+    mp.hop_limit = max(0, hop_start - _hops_taken(rng, hop_start))
+    mp.channel = ch_hash & 0xFF
+    base = int(_weighted(rng, _ENC_LEN_WEIGHTS))
+    mp.encrypted = bytes(rng.randint(0, 255) for _ in range(max(16, base + rng.randint(-6, 6))))
     return mp.SerializeToString()
 
 
@@ -398,6 +468,7 @@ def generate(
                 "role": role,
                 "mobile": mobile,
                 "talk": talk,
+                "hop_start": int(_weighted(rng, P["hop_start_weights"])),
                 "join_t": start_epoch + int(join_h * 3600),
                 "leave_t": start_epoch + int((join_h + stay_h) * 3600),
             }
@@ -406,14 +477,32 @@ def generate(
     packets: list[tuple[int, bytes, str]] = []
     routers = [m for m in meta if m["role"].startswith("ROUTER")]
     sensors = [m for m, nr in zip(meta, node_rows, strict=False) if nr.role == "SENSOR"]
+    by_num = {nr.num: nr for nr in node_rows}
+    hop_starts = {m["num"]: m["hop_start"] for m in meta}
 
-    def add(t, frm, to, pn, payload, ch="LongFast", hop=None):
-        # default: a realistic per-packet hop_limit (gateways see varied remaining
-        # hops); callers pass an explicit hop for DMs/ACKs/traceroute.
-        h = _hop(rng) if hop is None else hop
-        packets.append((t, _mp(frm, to, pn, payload, h, ch_index.get(ch, 0)), ch))
-
-    {nr.num: nr for nr in node_rows}
+    def add(t, frm, to, pn, payload, ch="LongFast", hop=None, want_response=False):
+        # hop_limit derives from the sender's configured hop_start minus a
+        # realistic hops-already-taken draw; callers pass an explicit remaining
+        # `hop` for DMs/ACKs/traceroute (clamped to the sender's hop_start).
+        hs = hop_starts.get(frm & 0xFFFFFFFF, 3)
+        hl = (hs - _hops_taken(rng, hs)) if hop is None else min(hop, hs)
+        packets.append(
+            (
+                t,
+                _mp(
+                    frm,
+                    to,
+                    pn,
+                    payload,
+                    max(0, hl),
+                    hs,
+                    ch_index.get(ch, 0),
+                    priority=_PRIORITY.get(pn, _PRIORITY_DEFAULT),
+                    want_response=want_response,
+                ),
+                ch,
+            )
+        )
 
     # -- periodic per-node traffic (only while the node is present) --
     for m, nr in zip(meta, node_rows, strict=False):
@@ -421,6 +510,20 @@ def generate(
         node_end = min(end_epoch, m["leave_t"])
         if jt < node_end:
             add(jt, m["num"], BROADCAST, 4, _pl_nodeinfo(nr))
+            # arrival exchange storm: peers swap NodeInfo with the newcomer
+            # (want_response request -> reply, sometimes a routing ACK). This
+            # is what makes real meshes NODEINFO-dominated.
+            k = rng.randint(*P["nodeinfo_exchange_pairs"])
+            for peer in rng.sample(meta, min(len(meta), k + 1)):
+                if peer["num"] == m["num"]:
+                    continue
+                t0 = jt + rng.randint(2, 90)
+                peer_info = _pl_nodeinfo(by_num[peer["num"]])
+                add(t0, peer["num"], m["num"], 4, peer_info, want_response=True)
+                if rng.random() < 0.85:
+                    add(t0 + rng.randint(1, 6), m["num"], peer["num"], 4, _pl_nodeinfo(nr))
+                if rng.random() < P["ack_ratio"] * 0.4:
+                    add(t0 + rng.randint(2, 9), m["num"], peer["num"], 5, _pl_routing_ack(), hop=0)
         talk = m["talk"]
         pos_iv = (
             P["pos_interval"]["mobile"]
@@ -429,9 +532,12 @@ def generate(
             if m["role"].startswith("ROUTER")
             else P["pos_interval"]["default"]
         )
-        # chatty nodes beacon more often (skew), floored so nothing spams sub-15s
-        pos_iv = max(15, pos_iv / talk)
-        tel_iv = max(15, P["telemetry_interval"] / talk)
+        # Talkativeness skews *social* traffic hard, but periodic beacons only
+        # mildly (position cadence is device config, not personality) — real
+        # position intervals sit near the firmware defaults (p50 ~10 min).
+        beacon_talk = talk**0.35
+        pos_iv = max(30, pos_iv / beacon_talk)
+        tel_iv = max(60, P["telemetry_interval"] / beacon_talk)
         t = jt + rng.randint(0, 300)
         while t < node_end:
             if rng.random() < _activity(hod(t)) + 0.1:
@@ -446,18 +552,47 @@ def generate(
         while t < node_end:
             add(t, m["num"], BROADCAST, 4, _pl_nodeinfo(nr))
             t += int(P["nodeinfo_refresh"] * rng.uniform(0.8, 1.2))
+        # background NodeInfo exchanges: nodes keep requesting identities they
+        # don't know (churn means there is always someone unknown around)
+        t = jt + rng.randint(60, P["nodeinfo_background_interval"])
+        while t < node_end:
+            if rng.random() < _activity(hod(t)) + 0.2:
+                peer = rng.choice(meta)
+                if peer["num"] != m["num"]:
+                    add(t, m["num"], peer["num"], 4, _pl_nodeinfo(nr), want_response=True)
+                    if rng.random() < 0.8:
+                        add(
+                            t + rng.randint(1, 6),
+                            peer["num"],
+                            m["num"],
+                            4,
+                            _pl_nodeinfo(by_num[peer["num"]]),
+                        )
+            t += int(P["nodeinfo_background_interval"] * rng.uniform(0.7, 1.3))
+        # background reliable-delivery ACK hum (routing traffic tracks want_ack
+        # usage — BM ran ~12% ROUTING)
+        t = jt + rng.randint(0, P["ack_background_interval"])
+        while t < node_end:
+            if rng.random() < _activity(hod(t)):
+                other = rng.choice(meta)
+                if other["num"] != m["num"]:
+                    add(t, m["num"], other["num"], 5, _pl_routing_ack(), hop=0)
+            t += int(P["ack_background_interval"] * rng.uniform(0.7, 1.3))
 
-    # -- environment + power telemetry (sensors + a few routers) --
-    for m in sensors + routers[:3]:
-        t = start_epoch + rng.randint(0, 1800)
+    # -- environment + power telemetry: sensors, a few routers, plus the ~3.5%
+    # of ordinary nodes that carry an attached sensor board --
+    env_extra = [m for m in meta if rng.random() < P["env_sensor_fraction"]]
+    env_nodes = list({m["num"]: m for m in sensors + routers[:3] + env_extra}.values())
+    for m in env_nodes:
+        t = start_epoch + rng.randint(0, P["env_interval"])
         while t < end_epoch:
             add(t, m["num"], BROADCAST, 67, _pl_tel_env(rng, t))
-            if rng.random() < 0.4:
+            if rng.random() < 0.9:
                 add(t + 5, m["num"], BROADCAST, 67, _pl_tel_power(rng, t))
-            t += int(1800 * rng.uniform(0.8, 1.2))
+            t += int(P["env_interval"] * rng.uniform(0.8, 1.2))
 
-    # -- neighborinfo --
-    nbr = routers + [m for m in meta if rng.random() < 0.25]
+    # -- neighborinfo (off by default in real firmware: infra + a sliver) --
+    nbr = routers + [m for m in meta if rng.random() < P["neighborinfo_fraction"]]
     for m in nbr:
         t = start_epoch + rng.randint(0, 7200)
         while t < end_epoch:
@@ -474,7 +609,7 @@ def generate(
             t += int(P["neighborinfo_interval"] * rng.uniform(0.85, 1.15))
 
     # -- traceroutes + routing ACKs --
-    for _ in range(max(1, days * 24 * 4)):
+    for _ in range(max(1, days * 24 * 12)):
         t = rng.randint(start_epoch, end_epoch - 1)
         if rng.random() > _activity(hod(t)):
             continue
@@ -507,10 +642,10 @@ def generate(
                 ch = "LongFast"
             sender = rng.choice(node_rows)
             text = _pick_text(rng, ch, node_rows)
-            dm = rng.random() < 0.12
+            dm = rng.random() < P["text_dm_fraction"]
             to = rng.choice(node_rows).num if dm else BROADCAST
             add(t, sender.num, to, 1, text.encode("utf-8"), ch=ch)
-            if dm and rng.random() < 0.8:
+            if dm and rng.random() < P["ack_ratio"]:
                 add(t + rng.randint(1, 5), to, sender.num, 5, _pl_routing_ack(), ch=ch, hop=0)
 
     # -- waypoints (some with geofence fields for client enter/exit alert testing) --
@@ -537,17 +672,27 @@ def generate(
             )
 
     # -- encrypted/foreign traffic: packets on channels the viewer can't decode,
-    # from "heard but unknown" neighbor nodes (no NodeInfo) --
+    # from "heard but unknown" neighbor nodes (no NodeInfo). The fraction is of
+    # the *final* stream (DEF CON ran ~45%; default keeps it moderate). --
     frac = P.get("encrypted_fraction", 0.0)
     if frac > 0 and packets:
-        n_enc = int(len(packets) * frac)
+        n_enc = int(len(packets) * frac / max(1e-6, 1.0 - frac))
         foreign = [rng.randint(0x10000000, 0xEFFFFFFF) for _ in range(max(5, nodes // 8))]
-        for _ in range(n_enc):
+        foreign_hs = {f: int(_weighted(rng, P["hop_start_weights"])) for f in foreign}
+        # a handful of foreign channels, each with a realistic OTA hash byte
+        foreign_hashes = [rng.randint(1, 255) for _ in range(rng.randint(2, 4))]
+        added = attempts = 0
+        while added < n_enc and attempts < n_enc * 10:
+            attempts += 1
             t = rng.randint(start_epoch, end_epoch - 1)
             # foreign mesh traffic is largely independent of our conference rhythm
             if rng.random() > _activity(hod(t)) * 0.4 + 0.6:
                 continue
-            packets.append((t, _mp_enc(rng, rng.choice(foreign), _hop(rng), 0), "LongFast"))
+            f = rng.choice(foreign)
+            packets.append(
+                (t, _mp_enc(rng, f, foreign_hs[f], rng.choice(foreign_hashes)), "LongFast")
+            )
+            added += 1
 
     # -- range test: a couple of nodes beacon sequence numbers (DEF CON had ~4%) --
     for m in rng.sample(meta, min(len(meta), 2)):
@@ -557,7 +702,7 @@ def generate(
             if rng.random() < _activity(hod(t)):
                 seq += 1
                 add(t, m["num"], BROADCAST, 66, f"seq {seq}".encode())
-            t += int(rng.uniform(30, 90))
+            t += int(rng.uniform(150, 420))
 
     # -- paxcounter + storeforward + admin --
     for m in sensors[:3] or routers[:2]:
@@ -690,14 +835,21 @@ def _weighted_cluster(rng, pairs):
 
 
 def _pick_text(rng, ch, node_rows):
-    # ~60% short one-liners (matches the observed median ~18 chars), rest themed
-    if rng.random() < 0.6:
-        return rng.choice(_SHORT)
+    # ~55% short one-liners (observed median ~18 chars), mostly themed lines,
+    # plus a long tail of "wall of text" messages (real captures: p90 ~80,
+    # max ~230-246 — chunked rants, pasted scripts). Long texts are composed
+    # from the synthetic pools only.
+    r = rng.random()
     pool = _CHATTER.get(ch, _CHATTER["LongFast"])
-    t = rng.choice(pool)
+    if r < 0.55:
+        return rng.choice(_SHORT)
+    if r < 0.95:
+        t = rng.choice(pool)
+    else:
+        t = " ".join(rng.choice(pool) for _ in range(rng.randint(2, 4)))
     if "{h}" in t:
         t = t.replace("{h}", rng.choice(node_rows).long_name)
-    return t
+    return t[:236]
 
 
 # ── payload builders ─────────────────────────────────────────────────────────
@@ -707,23 +859,24 @@ def _pick_text(rng, ch, node_rows):
 # 32/13/14/17 bits). Synthetic values only.
 _PRECISION_WEIGHTS = [
     ("32", 34),
-    ("13", 30),
-    ("14", 12),
-    ("17", 8),
-    ("16", 6),
-    ("19", 6),
-    ("11", 4),
+    ("13", 29),
+    ("17", 3),
+    ("0", 2),
+    ("15", 2),
+    ("14", 1),
+    ("19", 1),
+    ("12", 1),
 ]
 
 
 def _chutil(rng: random.Random) -> float:
-    # skewed low with a long high tail (observed p50 ~7-15, p90 ~23-50, max ~75)
+    # skewed low with a modest high tail (BM observed p50 ~7, p90 ~23, max ~39)
     r = rng.random()
-    if r < 0.6:
-        return round(rng.uniform(1, 18), 3)
-    if r < 0.9:
-        return round(rng.uniform(18, 40), 3)
-    return round(rng.uniform(40, 75), 3)
+    if r < 0.7:
+        return round(rng.uniform(1, 15), 3)
+    if r < 0.95:
+        return round(rng.uniform(15, 28), 3)
+    return round(rng.uniform(28, 45), 3)
 
 
 def _pl_position(rng, m, t):

--- a/src/meshtastic_mcp/replay/tak.py
+++ b/src/meshtastic_mcp/replay/tak.py
@@ -1,0 +1,121 @@
+# SPDX-FileCopyrightText: Meshtastic contributors
+# SPDX-License-Identifier: GPL-3.0-only
+
+"""Optional TAKPacketV2 wire-format support (the ``[tak]`` extra).
+
+Thin, import-guarded wrapper over the **meshtastic-tak** SDK
+(`meshtastic/TAKPacket-SDK`), which owns CoT ↔ TAKPacketV2 conversion and the
+zstd *dictionary* compression that shrinks a TAK payload to a LoRa-sized blob
+(median ~87 B, max ~184 B). The replay core must import and run without the SDK,
+so every SDK import lives behind :func:`available`; when the extra is installed
+the sim can emit real wire-compressed TAKPacketV2 payloads instead of the
+legacy uncompressed :class:`atak_pb2.TAKPacket`, for high-fidelity exercise of
+an app's ATAK plane.
+
+Wire format (from the SDK): a 1-byte dictionary id followed by the zstd body
+(or the raw protobuf when incompressible). :func:`compress` / :func:`decompress`
+round-trip a ``TAKPacketV2`` through it; a payload produced here decompresses in
+any other SDK implementation (Kotlin/Swift/TS/C#) and vice-versa.
+
+Install: ``uv tool install 'meshtastic-mcp[tak]'`` (pulls the SDK + zstandard).
+"""
+
+from __future__ import annotations
+
+import functools
+from typing import Any
+
+
+def available() -> bool:
+    """True when the meshtastic-tak SDK is importable (the ``[tak]`` extra)."""
+    try:
+        import meshtastic_tak  # noqa: F401
+
+        return True
+    except Exception:
+        return False
+
+
+def _require() -> None:
+    if not available():
+        raise RuntimeError(
+            "TAKPacketV2 wire format requires the [tak] extra: "
+            "install 'meshtastic-mcp[tak]' (pulls meshtastic-tak + zstandard)."
+        )
+
+
+@functools.lru_cache(maxsize=1)
+def _compressor() -> Any:
+    _require()
+    from meshtastic_tak import TakCompressor
+
+    return TakCompressor()
+
+
+def build_pli(
+    *,
+    callsign: str,
+    uid: str,
+    team: int,
+    role: int,
+    lat_i: int,
+    lon_i: int,
+    altitude: int,
+    speed: int,
+    course: int,
+    battery: int,
+    device_callsign: str = "",
+) -> Any:
+    """Build a TAKPacketV2 position/location-information report."""
+    _require()
+    from meshtastic_tak import atak_pb2 as v2
+
+    tp = v2.TAKPacketV2()
+    tp.callsign = callsign
+    tp.uid = uid
+    tp.device_callsign = device_callsign or callsign
+    tp.team = team
+    tp.role = role
+    tp.latitude_i = lat_i
+    tp.longitude_i = lon_i
+    tp.altitude = altitude
+    tp.speed = speed
+    tp.course = course
+    tp.battery = battery
+    return tp
+
+
+def build_chat(
+    *,
+    callsign: str,
+    uid: str,
+    team: int,
+    role: int,
+    battery: int,
+    message: str,
+    to: str = "All Chat Rooms",
+) -> Any:
+    """Build a TAKPacketV2 GeoChat message."""
+    _require()
+    from meshtastic_tak import atak_pb2 as v2
+
+    tp = v2.TAKPacketV2()
+    tp.callsign = callsign
+    tp.uid = uid
+    tp.device_callsign = callsign
+    tp.team = team
+    tp.role = role
+    tp.battery = battery
+    tp.chat.message = message
+    tp.chat.to = to
+    return tp
+
+
+def compress(packet: Any) -> bytes:
+    """Compress a TAKPacketV2 to its dictionary-zstd wire payload."""
+    return bytes(_compressor().compress(packet))
+
+
+def decompress(wire: bytes) -> Any:
+    """Decompress a wire payload back to a TAKPacketV2."""
+    return _compressor().decompress(wire)

--- a/src/meshtastic_mcp/replay/tak.py
+++ b/src/meshtastic_mcp/replay/tak.py
@@ -52,6 +52,12 @@ def _compressor() -> Any:
     return TakCompressor()
 
 
+# CoT type strings the bridge (SDK CotXmlBuilder) stamps onto the emitted CoT so
+# ATAK/iTAK render the right affiliation: a friendly-ground PLI, and a GeoChat.
+PLI_COT_TYPE = "a-f-G-U-C"
+CHAT_COT_TYPE = "b-t-f"
+
+
 def build_pli(
     *,
     callsign: str,
@@ -65,8 +71,14 @@ def build_pli(
     course: int,
     battery: int,
     device_callsign: str = "",
+    cot_type: str = PLI_COT_TYPE,
 ) -> Any:
-    """Build a TAKPacketV2 position/location-information report."""
+    """Build a TAKPacketV2 position/location-information report.
+
+    ``cot_type`` is carried so the bridged CoT event is typed (friendly ground
+    by default) rather than emitting an empty ``type=""`` that clients render
+    as an unknown affiliation.
+    """
     _require()
     from meshtastic_tak import atak_pb2 as v2
 
@@ -82,6 +94,7 @@ def build_pli(
     tp.speed = speed
     tp.course = course
     tp.battery = battery
+    tp.cot_type_str = cot_type
     return tp
 
 
@@ -106,6 +119,7 @@ def build_chat(
     tp.team = team
     tp.role = role
     tp.battery = battery
+    tp.cot_type_str = CHAT_COT_TYPE
     tp.chat.message = message
     tp.chat.to = to
     return tp
@@ -119,3 +133,28 @@ def compress(packet: Any) -> bytes:
 def decompress(wire: bytes) -> Any:
     """Decompress a wire payload back to a TAKPacketV2."""
     return _compressor().decompress(wire)
+
+
+def parse_cot(cot_xml: str, *, strip_for_mesh: bool = True) -> Any:
+    """Parse a CoT XML event (as ATAK/iTAK author it) into a TAKPacketV2.
+
+    The inbound half of the bridge (TAK client → mesh): when ``strip_for_mesh``
+    is set, non-essential detail is removed first (mirroring the app's
+    CoTDetailStripper) so the result fits the LoRa MTU.
+    """
+    _require()
+    from meshtastic_tak import CotXmlParser, strip_non_essential_for_mesh
+
+    if strip_for_mesh:
+        cot_xml = strip_non_essential_for_mesh(cot_xml)
+    return CotXmlParser().parse(cot_xml)
+
+
+def cot_to_wire(cot_xml: str, *, strip_for_mesh: bool = True) -> bytes:
+    """Convert an ATAK/iTAK-authored CoT event to a mesh TAKPacketV2 wire payload.
+
+    What an app's TAK server does when a connected client sends a marker/PLI/
+    GeoChat: parse → (strip) → compress. The bytes belong on portnum 78
+    (``ATAK_PLUGIN_V2``).
+    """
+    return compress(parse_cot(cot_xml, strip_for_mesh=strip_for_mesh))

--- a/src/meshtastic_mcp/replay/tak_server.py
+++ b/src/meshtastic_mcp/replay/tak_server.py
@@ -1,0 +1,204 @@
+# SPDX-FileCopyrightText: Meshtastic contributors
+# SPDX-License-Identifier: GPL-3.0-only
+
+"""Standalone CoT streaming TAK server — point ATAK/iTAK/WinTAK at the sim.
+
+A Meshtastic app (≥2.8) bridges mesh TAK traffic to a connected TAK client by
+running an in-app TAK server that streams Cursor-on-Target (CoT) XML. This
+module stands up that *same CoT stream* directly from a synthetic capture's TAK
+squad — decompressing each TAKPacketV2 (portnum 78) and rebuilding its CoT via
+the SDK — so a TAK client can connect straight to the simulator and render the
+squad on its map, with no Meshtastic app or radio in the loop. It's the
+app-plane counterpart to :mod:`~meshtastic_mcp.replay.engine` (which serves the
+Meshtastic app), and the server the Android ATAK e2e loop
+(``scripts/ci_atak_app_loop.py``) drives.
+
+Wire: the classic TAK **TCP streaming** protocol — complete ``<event>…</event>``
+CoT documents concatenated on the socket (no XML declaration, no length prefix),
+which ATAK ingests as a plain streaming TCP input. Requires the ``[tak]`` extra
+(meshtastic-tak) for the CoT build; :func:`capture_to_cot_events` raises without
+it.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import re
+import socket
+import threading
+import time
+from dataclasses import dataclass, field
+
+from meshtastic.protobuf import mesh_pb2
+
+from . import tak
+from .capture import Capture
+
+TAK_V2_PORT = 78
+_XML_DECL_RE = re.compile(rb"^\s*<\?xml[^>]*\?>\s*", re.IGNORECASE)
+
+
+def _strip_decl(xml: str) -> bytes:
+    """Drop the ``<?xml?>`` declaration — CoT stream events are bare elements."""
+    return _XML_DECL_RE.sub(b"", xml.encode("utf-8")).strip() + b"\n"
+
+
+def capture_to_cot_events(cap: Capture) -> list[tuple[int, bytes]]:
+    """``(rx_time, cot_xml_bytes)`` for every TAKPacketV2 in the capture.
+
+    Reproduces the app TAK server's receive path (wire → TAKPacketV2 → CoT XML)
+    for each portnum-78 packet, in time order. Legacy v1 (portnum 72) is skipped
+    — generate the squad with ``profile={"tak": {"wire": "v2", ...}}``.
+    """
+    tak._require()
+    from meshtastic_tak import CotXmlBuilder, TakCompressor
+
+    comp = TakCompressor()
+    builder = CotXmlBuilder()
+    out: list[tuple[int, bytes]] = []
+    mp = mesh_pb2.MeshPacket()
+    for rxt, raw, _ch in cap.packets:
+        mp.Clear()
+        try:
+            mp.ParseFromString(raw)
+        except Exception:
+            continue
+        if mp.WhichOneof("payload_variant") != "decoded" or mp.decoded.portnum != TAK_V2_PORT:
+            continue
+        try:
+            pkt = comp.decompress(mp.decoded.payload)
+            out.append((rxt, _strip_decl(builder.build(pkt))))
+        except Exception:
+            continue
+    return out
+
+
+@dataclass
+class CotTakServer:
+    """Threaded CoT streaming server. Restamps event times to now and paces
+    delivery to preserve the capture's cadence (capped by ``max_gap``).
+
+    Usage::
+
+        srv = CotTakServer(events, host="0.0.0.0", port=8087, speed=30, loop=True)
+        srv.start()          # background thread; ATAK connects to host:port
+        ...                  # drive/observe the TAK client
+        srv.stop()
+    """
+
+    events: list[tuple[int, bytes]]
+    host: str = "0.0.0.0"
+    port: int = 8087
+    speed: float = 1.0
+    max_gap: float = 5.0
+    loop: bool = False
+
+    _sock: socket.socket | None = field(default=None, init=False, repr=False)
+    _thread: threading.Thread | None = field(default=None, init=False, repr=False)
+    _stop: threading.Event = field(default_factory=threading.Event, init=False, repr=False)
+    clients_served: int = field(default=0, init=False)
+    events_sent: int = field(default=0, init=False)
+    # inbound (TAK client -> mesh): raw CoT <event> documents the client sent
+    received_cot: list[bytes] = field(default_factory=list, init=False)
+
+    def start(self) -> int:
+        """Bind + accept in the background. Returns the bound port."""
+        self._sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        self._sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        self._sock.bind((self.host, self.port))
+        self._sock.listen(4)
+        self._sock.settimeout(0.5)
+        self.port = self._sock.getsockname()[1]
+        self._thread = threading.Thread(target=self._accept_loop, daemon=True)
+        self._thread.start()
+        return self.port
+
+    def stop(self) -> None:
+        self._stop.set()
+        if self._sock is not None:
+            with contextlib.suppress(OSError):
+                self._sock.close()
+        if self._thread is not None:
+            self._thread.join(timeout=2.0)
+
+    def __enter__(self) -> CotTakServer:
+        self.start()
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        self.stop()
+
+    def _accept_loop(self) -> None:
+        assert self._sock is not None
+        while not self._stop.is_set():
+            try:
+                client, _addr = self._sock.accept()
+            except (TimeoutError, OSError):
+                continue
+            self.clients_served += 1
+            threading.Thread(target=self._serve, args=(client,), daemon=True).start()
+
+    def _serve(self, client: socket.socket) -> None:
+        with client:
+            client.settimeout(0.5)
+            # inbound reader: a connected ATAK/iTAK sends its own CoT (markers,
+            # GeoChat, self PLI) over the same stream — collect complete events.
+            reader = threading.Thread(target=self._read_client, args=(client,), daemon=True)
+            reader.start()
+            while not self._stop.is_set():
+                prev: int | None = None
+                for rxt, cot in self.events:
+                    if self._stop.is_set():
+                        return
+                    if prev is not None:
+                        delay = min((rxt - prev) / max(self.speed, 1e-6), self.max_gap)
+                        if delay > 0 and self._stop.wait(delay):
+                            return
+                    prev = rxt
+                    # restamp time/start/stale to now so the client treats it live
+                    payload = _restamp(cot)
+                    try:
+                        client.sendall(payload)
+                    except OSError:
+                        return
+                    self.events_sent += 1
+                if not self.loop:
+                    # keep the socket open a moment so a late inbound event lands
+                    self._stop.wait(0.5)
+                    return
+
+    def _read_client(self, client: socket.socket) -> None:
+        """Accumulate the client's stream and split out complete CoT events."""
+        buf = b""
+        while not self._stop.is_set():
+            try:
+                chunk = client.recv(4096)
+            except (TimeoutError, OSError):
+                if self._stop.is_set():
+                    return
+                continue
+            if not chunk:
+                return
+            buf += chunk
+            while b"</event>" in buf:
+                end = buf.index(b"</event>") + len(b"</event>")
+                start = buf.find(b"<event")
+                if start == -1 or start > end:
+                    buf = buf[end:]
+                    continue
+                self.received_cot.append(buf[start:end])
+                buf = buf[end:]
+
+
+_TIME_ATTR_RE = re.compile(rb'(time|start)="[^"]*"')
+_STALE_ATTR_RE = re.compile(rb'stale="[^"]*"')
+
+
+def _restamp(cot: bytes) -> bytes:
+    """Rewrite time/start to now and stale to now+2min (client liveness)."""
+    now = time.gmtime()
+    ts = time.strftime("%Y-%m-%dT%H:%M:%S.000Z", now).encode()
+    stale = time.strftime("%Y-%m-%dT%H:%M:%S.000Z", time.gmtime(time.time() + 120)).encode()
+    cot = _TIME_ATTR_RE.sub(lambda m: m.group(1) + b'="' + ts + b'"', cot)
+    cot = _STALE_ATTR_RE.sub(b'stale="' + stale + b'"', cot)
+    return cot

--- a/src/meshtastic_mcp/server.py
+++ b/src/meshtastic_mcp/server.py
@@ -1913,8 +1913,11 @@ def _load_replay_capture(
     channels: list[dict[str, Any]] | None = None,
 ) -> Any:
     """Resolve `source`/`kind` into a Capture for the replay engine."""
-    if kind == "sim" or source in ("meshcon", "sim"):
-        return replay_sim.generate(nodes=sim_nodes, days=sim_days, seed=sim_seed, start=sim_start)
+    if kind == "sim" or source in ("sim", *replay_sim.PRESETS):
+        preset = "meshcon" if source in ("sim", "meshcon") else source
+        return replay_sim.generate(
+            nodes=sim_nodes, days=sim_days, seed=sim_seed, start=sim_start, profile=preset
+        )
     if kind == "jsonl" or source.endswith(".jsonl"):
         return replay_capture.from_recorder_jsonl(source)
     return replay_capture.from_sqlite(source, limit_nodes=limit_nodes, channel_specs=channels)
@@ -1955,6 +1958,9 @@ def replay_start(
 
     `source` / `kind`:
       - `meshcon` / `sim`     → generate a synthetic MeshCon mesh (no file).
+      - `burningman` / `defcon` → generate a calibrated event scenario (playa /
+                                convention geo, channels, RF observer model,
+                                encrypted+MQTT mix, and scripted traffic spikes).
       - a `*.db` / `*.db.gz`  → SQLite capture (Burning Man / DEF CON / MeshCon
                                 schema; full-fidelity payloads). `kind="sqlite"`.
       - a `*.jsonl`           → recorder packets.jsonl (best-effort, truncated
@@ -2281,6 +2287,8 @@ def replay_fuzz_presets() -> dict[str, Any]:
         "forged_acks_interval": "forged_acks",
         "rogue_admin_interval": "rogue_admin",
         "waypoint_spam_interval": "waypoint_spam",
+        "ninja_flood_interval": "ninja_flood",
+        "ninja_flood_batch": "ninja_flood",
     }
     out = {}
     for nm in replay_fuzz.PRESET_NAMES:

--- a/src/meshtastic_mcp/server.py
+++ b/src/meshtastic_mcp/server.py
@@ -1911,12 +1911,26 @@ def _load_replay_capture(
     sim_seed: int,
     sim_start: int | None,
     channels: list[dict[str, Any]] | None = None,
+    sim_profile: str | dict[str, Any] | None = None,
 ) -> Any:
     """Resolve `source`/`kind` into a Capture for the replay engine."""
     if kind == "sim" or source in ("sim", *replay_sim.PRESETS):
         preset = "meshcon" if source in ("sim", "meshcon") else source
+        override: dict[str, Any] | None = None
+        if sim_profile is not None:
+            if isinstance(sim_profile, str):
+                import json
+
+                sim_profile = json.loads(sim_profile)
+            if not isinstance(sim_profile, dict):
+                raise ValueError(
+                    "sim_profile must be a JSON object / dict of profile overrides "
+                    "(preset base is chosen via `source`; file paths are not accepted)"
+                )
+            override = sim_profile
+        prof = replay_sim.preset_profile(preset, override)
         return replay_sim.generate(
-            nodes=sim_nodes, days=sim_days, seed=sim_seed, start=sim_start, profile=preset
+            nodes=sim_nodes, days=sim_days, seed=sim_seed, start=sim_start, profile=prof
         )
     if kind == "jsonl" or source.endswith(".jsonl"):
         return replay_capture.from_recorder_jsonl(source)
@@ -1946,6 +1960,7 @@ def replay_start(
     sim_nodes: int = 800,
     sim_days: int = 3,
     sim_seed: int = 1337,
+    sim_profile: str | dict[str, Any] | None = None,
     fuzz: str | dict[str, Any] | None = None,
     fuzz_seed: int = 0,
 ) -> dict[str, Any]:
@@ -1970,7 +1985,15 @@ def replay_start(
     Pacing: `rate` (steady packets/sec, ignores capture timing) takes priority;
     otherwise `speed` multiplies the original cadence, capped by `max_gap` idle.
     `start`/`end` (ISO-8601 UTC) window the capture. `loop` restarts at the end.
-    `limit_nodes` caps the node DB (file sources). `sim_*` tune the generator.
+    `limit_nodes` caps the node DB (file sources). `sim_nodes`/`sim_days`/
+    `sim_seed` size and seed the synthetic generator; `sim_profile` tunes it
+    further for sim/preset sources — a dict (or JSON-object string) of profile
+    overrides deep-merged over the `source` preset. Use it to enable/shape
+    features the presets leave off, e.g. an ATAK squad
+    `{"tak": {"team_nodes": 6, "wire": "v2"}}`, a scripted spike
+    `{"spikes": [{"start_h": 20, "hours": 2, "text_x": 8}]}`, or the RF gateway
+    model `{"observer": {"enabled": true, "loss_floor": 0.5, "mqtt_fraction": 0.3}}`.
+    A preset base is chosen via `source`; `sim_profile` is never a file path.
 
     `channels` (SQLite sources) is a caller-supplied list of channels that routes
     packets by their OTA channel hash and advertises the real PSKs so the app
@@ -1985,8 +2008,9 @@ def replay_start(
     can see from inside the app that it's a replay. `modem_preset` sets the
     advertised LoRa preset (e.g. `LONG_FAST`, `SHORT_TURBO`); `firmware_edition`
     sets the app's event banner (`VANILLA`, `DEFCON`, `BURNING_MAN`, `HAMVENTION`,
-    …). `observer_lat`/
-    `observer_lon` (1e-7 degrees) place the connected node; default is the
+    …). `observer_lat`/`observer_lon` (1e-7 degrees) place the *connected* node
+    (the app's "you are here" on the map) — distinct from the sim's RF gateway
+    observer, which is configured via `sim_profile["observer"]`. Default is the
     capture's median position so the map and node distances look right.
 
     `fuzz` turns the stream hostile (fault injection + bad actors): a preset name
@@ -2004,7 +2028,8 @@ def replay_start(
     sim_start = None
     s_epoch = _parse_iso_epoch(start) if start else None
     e_epoch = _parse_iso_epoch(end) if end else None
-    if (kind == "sim" or source in ("meshcon", "sim")) and s_epoch is None:
+    is_sim = kind == "sim" or source in ("sim", *replay_sim.PRESETS)
+    if is_sim and s_epoch is None:
         # default the synthetic capture to end "now" so a fresh app sees recent data
         import time as _t
 
@@ -2018,6 +2043,7 @@ def replay_start(
         sim_seed=sim_seed,
         sim_start=sim_start,
         channels=channels,
+        sim_profile=sim_profile,
     )
     params = ReplayParams(
         host=host,

--- a/src/meshtastic_mcp/skills/meshtastic-e2e/SKILL.md
+++ b/src/meshtastic_mcp/skills/meshtastic-e2e/SKILL.md
@@ -169,6 +169,36 @@ assert the app shows the node go **offline → online** and that a queued messag
 once the path heals. This is the app-facing mirror of the firmware suite's
 `test_peer_offline_recovery`.
 
+## Loop 6 — ATAK/iTAK render (sim TAK squad → TAK client)
+
+Validates the TAK plane. Meshtastic apps (≥2.8) bridge mesh TAK traffic to a
+connected ATAK/iTAK client via an **in-app local TAK server** that emits CoT
+(the deprecated `IMeshService` plugin is gone). Two layers:
+
+- **Bridge-semantics (no emulator, in CI):** the sim emits a TAKPacketV2 squad
+  (`replay_start(source=..., sim_profile={"tak": {"team_nodes": N, "wire": "v2"}})`
+  — v2 rides portnum 78 `ATAK_PLUGIN_V2`; v1 rides 72). `replay/tak_server.py`
+  `capture_to_cot_events()` reproduces the bridge's wire→TAKPacketV2→CoT path;
+  `tests/unit/test_tak_bridge.py` asserts the CoT is well-formed, typed
+  (`a-f-G-U-C` PLI), and carries the right callsign/position/GeoChat. Needs the
+  `[tak]` extra (meshtastic-tak SDK).
+- **App-plane (opt-in, needs an emulator + ATAK-CIV), bidirectional:**
+  `scripts/ci_atak_app_loop.py` stands up `CotTakServer` from that squad, points
+  ATAK-CIV at `10.0.2.2:<port>` (a pushed streaming-input `.pref`), launches it,
+  and asserts (receive) a squad callsign marker renders **and** (send) ATAK's
+  own self-PLI streams back, is captured, and converts to a mesh TAKPacketV2.
+  ATAK-CIV is free (`com.atakmap.app.civ`, Play Store / tak.gov / GitHub; needs
+  GLES 3.0). Emits `LOOP atak-render …` + `LOOP atak-send …`. iTAK is iOS-only
+  and App-Store-distributed, so in-simulator automation isn't practical —
+  physical device only.
+
+Both directions are unit-tested without hardware: `test_tak_bridge.py` covers
+receive (mesh→CoT) and send (`cot_to_wire`, CoT→mesh); `test_tak_server.py`
+asserts the server streams to a client **and** captures a client-authored CoT.
+
+You can also point a real ATAK/WinTAK at `CotTakServer` directly (host:port,
+plain TCP streaming input) to eyeball the sim's squad on a live map.
+
 ## Reporting
 
 Emit a compact verdict per loop: `LOOP <n> <PASS|FAIL> token=<...> latency=<ms> hops=<n>`.

--- a/tests/unit/test_ci_atak_app_loop.py
+++ b/tests/unit/test_ci_atak_app_loop.py
@@ -1,0 +1,62 @@
+# SPDX-FileCopyrightText: Meshtastic contributors
+# SPDX-License-Identifier: GPL-3.0-only
+
+"""Pure-bits tests for the ATAK app-plane e2e helper (no emulator/ATAK needed).
+
+The emulator orchestration (`run`) needs the android capability + ATAK-CIV and
+is exercised by the opt-in CI job; here we cover the pure helpers and CLI
+guards, mirroring test_ci_device_mesh_e2e.py.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import pathlib
+
+import pytest
+
+from meshtastic_mcp.replay import tak
+
+_SCRIPTS = pathlib.Path(__file__).resolve().parents[2] / "scripts"
+requires_tak = pytest.mark.skipif(not tak.available(), reason="[tak] extra not installed")
+
+
+def _load(name: str = "ci_atak_app_loop"):
+    spec = importlib.util.spec_from_file_location(name, _SCRIPTS / f"{name}.py")
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_helper_file_exists():
+    assert (_SCRIPTS / "ci_atak_app_loop.py").is_file()
+
+
+def test_atak_stream_pref_encodes_connect_string():
+    mod = _load()
+    pref = mod.atak_stream_pref("10.0.2.2", 8087, name="meshsim")
+    assert "cot_streams" in pref
+    assert "10.0.2.2:8087:tcp" in pref  # ATAK host:port:proto connect string
+    assert "enabled0" in pref and "meshsim" in pref
+
+
+def test_main_exits_2_when_apk_missing():
+    assert _load().main(["--atak-apk", "/definitely/not/here/ATAK.apk"]) == 2
+
+
+def test_verdict_prefix_is_grepable():
+    # the loop reuses the shared verdict() with an atak-render leg name
+    mod = _load()
+    line = mod._mesh.verdict("atak-render", True, "Coyote-1", 0)
+    assert line.startswith("LOOP atak-render PASS")
+    assert "token='Coyote-1'" in line
+
+
+@requires_tak
+def test_expected_callsigns_from_sim_squad():
+    mod = _load()
+    _cap, events = mod.build_squad(seed=8, nodes=120, days=1)
+    callsigns = mod.expected_callsigns(events)
+    assert len(callsigns) == 5  # team_nodes=5 in build_squad
+    assert all(cs and "-" in cs for cs in callsigns)

--- a/tests/unit/test_replay_metrics.py
+++ b/tests/unit/test_replay_metrics.py
@@ -537,3 +537,68 @@ def test_capture_stats_cli_bad_source_errors(capsys):
         cli.main(["capture-stats", "/nonexistent/path.db"])
     assert exc.value.code == 1
     assert "error:" in capsys.readouterr().err
+
+
+# ── replay_start sim_profile passthrough (MCP surface) ───────────────────────
+
+
+def test_preset_profile_helper():
+    import pytest
+
+    from meshtastic_mcp.replay import sim as _sim
+
+    # unknown preset rejected
+    with pytest.raises(ValueError, match="unknown preset"):
+        _sim.preset_profile("nope")
+    # override deep-merges over the preset base (keeps other tak defaults)
+    prof = _sim.preset_profile("defcon", {"tak": {"team_nodes": 4}})
+    assert prof["tak"]["team_nodes"] == 4
+    assert prof["tak"]["pli_interval"] == _sim.PROFILE["tak"]["pli_interval"]
+    assert prof["encrypted_fraction"] == _sim.PRESETS["defcon"]["encrypted_fraction"]
+
+
+def test_replay_start_sim_profile_override_dict_and_json():
+    from meshtastic_mcp import server
+
+    common = {
+        "kind": "auto",
+        "limit_nodes": 0,
+        "sim_nodes": 120,
+        "sim_days": 1,
+        "sim_seed": 3,
+        "sim_start": 1_700_000_000,
+    }
+    # dict override enables a TAK squad the presets leave off
+    cap = server._load_replay_capture("defcon", sim_profile={"tak": {"team_nodes": 4}}, **common)
+    assert metrics.capture_stats(cap)["tak_packets"] > 0
+    # JSON-string override (as an MCP client passes it)
+    cap2 = server._load_replay_capture(
+        "burningman",
+        sim_profile='{"spikes": [{"start_h": 5, "hours": 1, "text_x": 12}]}',
+        **common,
+    )
+    assert cap2.packets
+    # no override still works
+    cap3 = server._load_replay_capture("defcon", **common)
+    assert metrics.capture_stats(cap3)["tak_packets"] == 0
+
+
+def test_replay_start_sim_profile_rejects_non_object_and_paths():
+    import pytest
+
+    from meshtastic_mcp import server
+
+    common = {
+        "kind": "auto",
+        "limit_nodes": 0,
+        "sim_nodes": 10,
+        "sim_days": 1,
+        "sim_seed": 1,
+        "sim_start": 1_700_000_000,
+    }
+    # a JSON array is not a profile dict
+    with pytest.raises(ValueError, match="must be a JSON object"):
+        server._load_replay_capture("defcon", sim_profile="[1,2,3]", **common)
+    # a file path is not valid JSON -> rejected before any open() (no traversal)
+    with pytest.raises(json.JSONDecodeError):
+        server._load_replay_capture("defcon", sim_profile="/etc/passwd", **common)

--- a/tests/unit/test_replay_metrics.py
+++ b/tests/unit/test_replay_metrics.py
@@ -179,6 +179,32 @@ def test_import_defcon_logs_roundtrip(tmp_path):
     assert extra["rx"]["snr"]["n"] == 3  # encrypted record had no snr
 
 
+def test_import_defcon_position_before_nodeinfo(tmp_path):
+    """A node whose first-seen record is a POSITION must still get a node row
+    (beacons outnumber NodeInfo, so this is the common case) — a bare UPDATE
+    would silently drop the fix."""
+    imp = _load_importer()
+    pos = mesh_pb2.Position(latitude_i=407_864_000, longitude_i=-1_192_065_000)
+    # POSITION arrives first, NODEINFO only later
+    pos_pkt = _mk_packet(201, 55, 3, pos.SerializeToString(), 1_700_000_010)
+    user = mesh_pb2.User(id="!00000037", long_name="Late Info", short_name="LATE", hw_model=43)
+    info = _mk_packet(202, 55, 4, user.SerializeToString(), 1_700_000_500)
+
+    log = tmp_path / "posfirst_LongFast.txt"
+    log.write_text("".join(_dict_record(p) for p in (pos_pkt, info)))
+    db = tmp_path / "posfirst.db"
+    imp.import_logs(str(db), [log])
+
+    conn = sqlite3.connect(db)
+    row = conn.execute(
+        "SELECT last_lat, last_long, long_name FROM node WHERE node_id=55"
+    ).fetchone()
+    conn.close()
+    assert row is not None, "POSITION-first node must exist in the node table"
+    assert row[0] == 407_864_000 and row[1] == -1_192_065_000  # fix not dropped
+    assert row[2] == "Late Info"  # later NodeInfo still merges in
+
+
 # ── golden profiles ──────────────────────────────────────────────────────────
 
 
@@ -360,6 +386,13 @@ def test_profile_accepts_dict_json_and_deep_merges(tmp_path):
     cap = _sim.generate(nodes=80, days=1, seed=1, start=1_700_000_000, profile=str(p))
     assert cap.packets
     assert metrics.capture_stats(cap)["encrypted_fraction"] == 0.0
+
+    # a non-preset, non-.json string is rejected with a clear error (no stray
+    # file open) rather than surfacing a FileNotFoundError
+    import pytest
+
+    with pytest.raises(ValueError, match="unknown profile"):
+        _sim._resolve_profile("deffcon")  # typo'd preset name
 
 
 def test_fit_profile_v2_emits_full_schema_and_round_trips():

--- a/tests/unit/test_replay_metrics.py
+++ b/tests/unit/test_replay_metrics.py
@@ -457,3 +457,45 @@ def test_tak_squad_is_opt_in_and_well_formed():
     assert pli > 0 and chat > 0
     assert len(callsigns) == 5  # one per squad member
     assert teams == {atak_pb2.Team.Value("Cyan")}
+
+
+# ── capture-stats CLI subcommand ─────────────────────────────────────────────
+
+
+def test_capture_stats_cli_preset_json(capsys):
+    import pytest
+
+    from meshtastic_mcp import __main__ as cli
+
+    with pytest.raises(SystemExit) as exc:
+        cli.main(["capture-stats", "meshcon", "--sim-nodes", "60", "--sim-days", "1", "--json"])
+    assert exc.value.code == 0
+    out = json.loads(capsys.readouterr().out)
+    assert out["schema"] == metrics.SCHEMA_VERSION
+    assert out["nodes"]["count"] == 60
+    assert "portnum_mix" in out
+
+
+def test_capture_stats_cli_text_render(capsys):
+    import pytest
+
+    from meshtastic_mcp import __main__ as cli
+
+    with pytest.raises(SystemExit) as exc:
+        cli.main(["capture-stats", "defcon", "--sim-nodes", "60", "--sim-days", "1"])
+    assert exc.value.code == 0
+    text = capsys.readouterr().out
+    assert "capture: defcon" in text
+    assert "portnum mix:" in text
+    assert "NODEINFO" in text
+
+
+def test_capture_stats_cli_bad_source_errors(capsys):
+    import pytest
+
+    from meshtastic_mcp import __main__ as cli
+
+    with pytest.raises(SystemExit) as exc:
+        cli.main(["capture-stats", "/nonexistent/path.db"])
+    assert exc.value.code == 1
+    assert "error:" in capsys.readouterr().err

--- a/tests/unit/test_replay_metrics.py
+++ b/tests/unit/test_replay_metrics.py
@@ -217,3 +217,102 @@ def test_golden_profiles_capture_the_calibration_targets():
     # both: text has a long tail our sim must reproduce
     assert dc["text"]["len"]["max"] > 200
     assert bm["text"]["len"]["max"] > 200
+
+
+# ── WS3/WS-T: temporal coherence + sensor telemetry ──────────────────────────
+
+
+def _telemetry(cap, variant):
+    from meshtastic.protobuf import telemetry_pb2
+
+    for _t, raw, _ch in cap.packets:
+        mp = mesh_pb2.MeshPacket()
+        mp.ParseFromString(raw)
+        if mp.WhichOneof("payload_variant") != "decoded" or mp.decoded.portnum != 67:
+            continue
+        tel = telemetry_pb2.Telemetry()
+        tel.ParseFromString(mp.decoded.payload)
+        if tel.WhichOneof("variant") == variant:
+            yield tel
+
+
+def test_battery_population_is_bimodal_with_zero_spike():
+    from collections import Counter
+
+    cap = sim.generate(nodes=400, days=2, seed=3, start=1_700_000_000)
+    levels = Counter(
+        min(t.device_metrics.battery_level, 101) for t in _telemetry(cap, "device_metrics")
+    )
+    assert levels[101] > 0  # plugged mode
+    assert levels[0] > 0  # drained-to-zero spike (real captures show both)
+    curve = sum(v for k, v in levels.items() if 0 < k < 101)
+    assert curve > 0  # and a discharge curve in between
+
+
+def test_chutil_tracks_generated_load():
+    import math
+    import statistics
+    from collections import Counter, defaultdict
+
+    start = 1_700_000_000
+    cap = sim.generate(nodes=400, days=2, seed=3, start=start)
+    by_hour_n = Counter((t - start) // 3600 for t, _r, _c in cap.packets)
+    by_hour_util = defaultdict(list)
+    for _t, raw, _ch in cap.packets:
+        mp = mesh_pb2.MeshPacket()
+        mp.ParseFromString(raw)
+        if mp.WhichOneof("payload_variant") == "decoded" and mp.decoded.portnum == 67:
+            from meshtastic.protobuf import telemetry_pb2
+
+            tel = telemetry_pb2.Telemetry()
+            tel.ParseFromString(mp.decoded.payload)
+            if tel.WhichOneof("variant") == "device_metrics":
+                h = (tel.time - start) // 3600
+                by_hour_util[h].append(tel.device_metrics.channel_utilization)
+    hours = sorted(h for h in by_hour_util if len(by_hour_util[h]) >= 3)
+    xs = [by_hour_n[h] for h in hours]
+    ys = [statistics.mean(by_hour_util[h]) for h in hours]
+    mx, my = statistics.mean(xs), statistics.mean(ys)
+    cov = sum((a - mx) * (b - my) for a, b in zip(xs, ys, strict=True))
+    rho = cov / math.sqrt(sum((a - mx) ** 2 for a in xs) * sum((b - my) ** 2 for b in ys))
+    assert rho > 0.5, f"chutil should track the diurnal load envelope (rho={rho:.2f})"
+
+
+def test_env_telemetry_personas_and_nan():
+    import math
+
+    cap = sim.generate(nodes=400, days=2, seed=3, start=1_700_000_000)
+    envs = list(_telemetry(cap, "environment_metrics"))
+    assert envs
+    # every persona reports temperature; only subsets report lux/humidity/pressure
+    assert all(t.environment_metrics.HasField("temperature") for t in envs)
+    n_lux = sum(t.environment_metrics.HasField("lux") for t in envs)
+    n_hum = sum(t.environment_metrics.HasField("relative_humidity") for t in envs)
+    assert 0 < n_lux < len(envs)
+    assert 0 < n_hum < len(envs)
+    # a boosted NaN fraction survives serialization (real sensors emit NaN)
+    prof = {"climate": {"t_mean": 22.0, "t_amp": 9.0, "pressure_hpa": 780.0, "nan_fraction": 0.5}}
+    cap2 = sim.generate(nodes=400, days=2, seed=3, start=1_700_000_000, profile=prof)
+    hums = [
+        t.environment_metrics.relative_humidity
+        for t in _telemetry(cap2, "environment_metrics")
+        if t.environment_metrics.HasField("relative_humidity")
+    ]
+    assert sum(math.isnan(h) for h in hums) > 0
+
+
+def test_text_spike_multiplies_hourly_budget():
+    from collections import Counter
+
+    start = 1_700_000_000
+    prof = {"spikes": [{"start_h": 10, "hours": 2, "text_x": 10.0}]}
+    cap = sim.generate(nodes=300, days=1, seed=5, start=start, profile=prof)
+    texts = Counter()
+    for t, raw, _ch in cap.packets:
+        mp = mesh_pb2.MeshPacket()
+        mp.ParseFromString(raw)
+        if mp.WhichOneof("payload_variant") == "decoded" and mp.decoded.portnum == 1:
+            texts[(t - start) // 3600] += 1
+    spike = (texts[10] + texts[11]) / 2
+    rest = [v for h, v in texts.items() if h not in (10, 11)]
+    assert spike > 2 * max(rest, default=0)

--- a/tests/unit/test_replay_metrics.py
+++ b/tests/unit/test_replay_metrics.py
@@ -316,3 +316,101 @@ def test_text_spike_multiplies_hourly_budget():
     spike = (texts[10] + texts[11]) / 2
     rest = [v for h, v in texts.items() if h not in (10, 11)]
     assert spike > 2 * max(rest, default=0)
+
+
+# ── WS4: scenario presets, profile plumbing, fit_profile v2 ──────────────────
+
+
+def test_scenario_presets_shape_the_mesh():
+    from meshtastic_mcp.replay import sim as _sim
+
+    assert set(_sim.PRESETS) == {"meshcon", "burningman", "defcon"}
+    bm = _sim.generate(nodes=500, days=2, seed=7, start=1_700_000_000, profile="burningman")
+    dc = _sim.generate(nodes=500, days=2, seed=7, start=1_700_000_000, profile="defcon")
+    assert bm.label.startswith("burningman") and dc.label.startswith("defcon")
+    # each preset uses its own published channel lineup
+    assert "Everyone" in bm.channels and "DEFCONnect" in dc.channels
+    bs = metrics.capture_stats(bm)
+    ds = metrics.capture_stats(dc)
+    # DEF CON runs much more foreign/encrypted traffic than the playa
+    assert ds["encrypted_fraction"] > 0.35
+    assert bs["encrypted_fraction"] < 0.25
+    # both presets enable the observer -> RX metadata + rebroadcast duplicates
+    assert ds["rx"]["rssi"]["n"] > 0
+    dup2 = sum(int(v) for k, v in ds["dup_id_multiplicity"].items() if k != "1")
+    assert dup2 > 0
+    # DEF CON cranks a hop-7 subpopulation harder than the default
+    assert int(ds["hop_start"].get("7", 0)) > 0
+
+
+def test_profile_accepts_dict_json_and_deep_merges(tmp_path):
+    from meshtastic_mcp.replay import sim as _sim
+
+    # nested config dicts deep-merge (observer.enabled stays off unless set)
+    prof = {"observer": {"path_loss_exp": 3.5}}
+    merged = _sim._resolve_profile(prof)
+    assert merged["observer"]["path_loss_exp"] == 3.5
+    assert merged["observer"]["enabled"] is False  # untouched default preserved
+    assert merged["venue"]["name"] == _sim.PROFILE["venue"]["name"]
+    # JSON path load
+    import json
+
+    p = tmp_path / "prof.json"
+    p.write_text(json.dumps({"text_base_msgs_per_hour": 1.0, "encrypted_fraction": 0.0}))
+    cap = _sim.generate(nodes=80, days=1, seed=1, start=1_700_000_000, profile=str(p))
+    assert cap.packets
+    assert metrics.capture_stats(cap)["encrypted_fraction"] == 0.0
+
+
+def test_fit_profile_v2_emits_full_schema_and_round_trips():
+    from meshtastic_mcp.replay import sim as _sim
+
+    src = _sim.generate(nodes=300, days=2, seed=4, start=1_700_000_000, profile="defcon")
+    prof = _sim.fit_profile(src)
+    for key in (
+        "hw_weights",
+        "role_weights",
+        "hop_start_weights",
+        "encrypted_fraction",
+        "text_dm_fraction",
+        "text_channel_weights",
+        "pos_interval",
+        "telemetry_interval",
+    ):
+        assert key in prof, key
+    # a capture generated from the fitted profile is comparable on encryption
+    regen = _sim.generate(nodes=300, days=2, seed=9, start=1_700_000_000, profile=prof)
+    a = metrics.capture_stats(src)["encrypted_fraction"]
+    b = metrics.capture_stats(regen)["encrypted_fraction"]
+    assert abs(a - b) < 0.12
+
+
+def test_ninja_fuzz_preset_spoofs_nodeinfo_without_key_change():
+    from meshtastic.protobuf import mesh_pb2
+
+    from meshtastic_mcp.replay import fuzz
+    from meshtastic_mcp.replay import sim as _sim
+
+    assert "ninja" in fuzz.PRESET_NAMES
+    cfg = fuzz.preset("ninja", seed=3)
+    assert cfg.ninja_flood and cfg.ninja_flood_batch > 0
+    cap = _sim.generate(nodes=40, days=1, seed=5, start=1_700_000_000)
+    ch_index = {c: i for i, c in enumerate(cap.channels)}
+    f = fuzz.Fuzzer(cfg, cap.nodes, ch_index)
+    # drive the time-based campaign
+    out = []
+    for i in range(400):
+        out += f.on_tick(1_000_000.0 + i)
+    assert out, "ninja campaign should emit NodeInfo spoofs"
+    real_nums = {n.num for n in cap.nodes}
+    spoofed = 0
+    for mp in out:
+        assert mp.decoded.portnum == 4  # NODEINFO
+        u = mesh_pb2.User()
+        u.ParseFromString(mp.decoded.payload)
+        assert getattr(mp, "from") in real_nums  # uses a real node's number
+        assert not u.public_key  # no key change -> dodges the app's warning
+        if "🥷" in u.long_name or "🥷" in u.short_name:
+            spoofed += 1
+    assert spoofed > 0
+    assert f.status()["counts"].get("ninja_flood", 0) > 0

--- a/tests/unit/test_replay_metrics.py
+++ b/tests/unit/test_replay_metrics.py
@@ -1,0 +1,220 @@
+# SPDX-FileCopyrightText: Meshtastic contributors
+# SPDX-License-Identifier: GPL-3.0-only
+
+"""WS0 realism harness: metrics schema, DEF CON log importer, golden profiles.
+
+1. `metrics.capture_stats` produces the full stat schema, deterministically,
+   over a sim capture.
+2. `tools/import_defcon_logs.py` round-trips a synthetic gateway log (built in
+   the DEF CON str(dict) format from our own protobufs) into the shared SQLite
+   schema that `capture.from_sqlite` loads.
+3. The committed golden profiles (aggregates of the real Burning Man 2025 /
+   DEF CON 33 captures) parse, carry the schema, and contain no payloads.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sqlite3
+from pathlib import Path
+
+import pytest
+from google.protobuf import text_format
+from meshtastic.protobuf import mesh_pb2
+
+from meshtastic_mcp.replay import capture, metrics, sim
+
+REPO = Path(__file__).resolve().parents[2]
+PROFILES = REPO / "src" / "meshtastic_mcp" / "replay" / "profiles"
+
+# The stat profiles are generated locally from private datasets and are NOT
+# committed (see .gitignore); the tests that assert against them skip when the
+# files are absent (e.g. in CI).
+requires_profiles = pytest.mark.skipif(
+    not (PROFILES / "burningman2025.json").exists()
+    or not (PROFILES / "defcon33.json").exists(),
+    reason="locally generated golden profiles not present",
+)
+
+EXPECTED_KEYS = {
+    "schema",
+    "label",
+    "packets",
+    "span_hours",
+    "pkts_per_hour",
+    "nodes",
+    "channels",
+    "portnum_mix",
+    "encrypted_fraction",
+    "want_response_fraction",
+    "hop_limit",
+    "hop_start",
+    "talker_skew",
+    "text",
+    "telemetry",
+    "position",
+    "timing",
+    "rx",
+    "dup_id_multiplicity",
+    "tak_packets",
+}
+
+
+def _load_importer():
+    spec = importlib.util.spec_from_file_location(
+        "import_defcon_logs", REPO / "tools" / "import_defcon_logs.py"
+    )
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+# ── capture_stats over a sim capture ─────────────────────────────────────────
+
+
+def test_capture_stats_schema_and_determinism():
+    cap = sim.generate(nodes=40, days=1, seed=9, start=1_700_000_000)
+    stats_a = metrics.capture_stats(cap)
+    stats_b = metrics.capture_stats(sim.generate(nodes=40, days=1, seed=9, start=1_700_000_000))
+    assert stats_a == stats_b  # seeded generate -> identical stats
+    assert set(stats_a) >= EXPECTED_KEYS
+    assert stats_a["packets"] > 0
+    assert stats_a["nodes"]["count"] == 40
+    # portnum mix uses friendly names and covers the core apps
+    for port in ("TELEMETRY", "POSITION", "NODEINFO", "TEXT_MESSAGE"):
+        assert port in stats_a["portnum_mix"], stats_a["portnum_mix"]
+    # encrypted traffic is measured
+    assert 0 < stats_a["encrypted_fraction"] < 1
+    # text stats populated with percentile summary
+    assert stats_a["text"]["n"] > 0
+    assert stats_a["text"]["len"]["p50"] is not None
+    # telemetry variants seen
+    assert stats_a["telemetry"]["variant_mix"].get("device_metrics", 0) > 0
+    # everything must be JSON-serializable (profile files depend on it)
+    json.dumps(stats_a)
+
+
+def test_summarize_and_skew_helpers():
+    s = metrics.summarize([float(x) for x in range(100)])
+    assert s["n"] == 100 and s["min"] == 0 and s["max"] == 99 and s["p50"] == 50
+    assert metrics.summarize([])["p50"] is None
+    # NaN values are dropped, not propagated (real captures contain NaN humidity)
+    assert metrics.summarize([1.0, float("nan"), 3.0])["n"] == 2
+    from collections import Counter
+
+    skew = metrics.talker_skew(Counter({1: 97, 2: 1, 3: 1, 4: 1}))
+    assert skew["senders"] == 4
+    assert skew["top10pct_share"] == 0.97
+
+
+# ── DEF CON log importer round-trip (synthetic log, real format) ─────────────
+
+
+def _dict_record(mp: mesh_pb2.MeshPacket) -> str:
+    """Render a MeshPacket the way the DEF CON gateway logs do: a str(dict)
+    with a top-level `'raw': <text-format>` block."""
+    raw = text_format.MessageToString(mp)
+    frm = getattr(mp, "from")
+    return (
+        f"{{'from': {frm}, 'to': {mp.to}, 'raw': {raw}, 'fromId': '!{frm:08x}', 'toId': '^all'}}\n"
+    )
+
+
+def _mk_packet(
+    pid: int, frm: int, portnum: int, payload: bytes, rx_time: int
+) -> mesh_pb2.MeshPacket:
+    mp = mesh_pb2.MeshPacket()
+    setattr(mp, "from", frm)
+    mp.to = 0xFFFFFFFF
+    mp.id = pid
+    mp.rx_time = rx_time
+    mp.hop_limit = 2
+    mp.hop_start = 3
+    mp.rx_snr = 9.5
+    mp.rx_rssi = -80
+    mp.decoded.portnum = portnum
+    mp.decoded.payload = payload
+    return mp
+
+
+def test_import_defcon_logs_roundtrip(tmp_path):
+    imp = _load_importer()
+    user = mesh_pb2.User(id="!0000002a", long_name="Synth Node", short_name="SYNT", hw_model=43)
+    text = _mk_packet(101, 42, 1, b"hello synthetic mesh", 1_700_000_100)
+    info = _mk_packet(102, 42, 4, user.SerializeToString(), 1_700_000_050)
+    dup = _mk_packet(101, 42, 1, b"hello synthetic mesh", 1_700_000_130)
+    dup.hop_limit = 1  # rebroadcast copy, one hop later
+    enc = mesh_pb2.MeshPacket()
+    setattr(enc, "from", 77)
+    enc.to = 0xFFFFFFFF
+    enc.id = 103
+    enc.rx_time = 1_700_000_200
+    enc.encrypted = b"\x01\x02\x03\x04"
+
+    log = tmp_path / "synth_ShortTurbo.txt"
+    log.write_text("".join(_dict_record(p) for p in (info, text, dup, enc)))
+    db = tmp_path / "out.db"
+    stats = imp.import_logs(str(db), [log])
+    assert stats["records"] == 4 and stats["parsed"] == 4
+    assert stats["packets"] == 3  # dup id collapses into packet, kept in packet_seen
+    assert stats["seen"] == 4
+
+    conn = sqlite3.connect(db)
+    row = conn.execute(
+        "SELECT long_name, short_name, hw_model FROM node WHERE node_id=42"
+    ).fetchone()
+    assert row == ("Synth Node", "SYNT", "HELTEC_V3")
+    mult = conn.execute("SELECT COUNT(*) FROM packet_seen WHERE packet_id=101").fetchone()[0]
+    assert mult == 2
+    conn.close()
+
+    cap = capture.from_sqlite(db, limit_nodes=0)
+    assert cap.channels == ["ShortTurbo"]
+    got = metrics.capture_stats(cap)
+    assert got["packets"] == 3
+    assert got["portnum_mix"]["TEXT_MESSAGE"] == 1
+    assert got["encrypted_fraction"] == round(1 / 3, 3)
+    extra = metrics.sqlite_extra_stats(str(db))
+    assert extra["observation_multiplicity"] == {"1": 2, "2": 1}
+    assert extra["rx"]["snr"]["n"] == 3  # encrypted record had no snr
+
+
+# ── golden profiles ──────────────────────────────────────────────────────────
+
+
+@requires_profiles
+def test_golden_profiles_present_and_aggregate_only():
+    for name in ("burningman2025", "defcon33"):
+        data = json.loads((PROFILES / f"{name}.json").read_text())
+        assert data["meta"]["name"] == name
+        stats = data["stats"]
+        assert stats["schema"] == metrics.SCHEMA_VERSION
+        assert stats["packets"] > 100_000
+        assert stats["nodes"]["count"] > 1_500
+        # aggregates only: no channel names, no node names, no payload text
+        assert "channels" not in stats
+        assert "channel_count" in stats
+        blob = json.dumps(stats).lower()
+        for forbidden in ("long_name", "short_name", "payload", "psk", "public_key"):
+            assert forbidden not in blob, forbidden
+        # observation-level stats present (dup multiplicity + RX populations)
+        assert stats["observed"]["observation_multiplicity"]["1"] > 0
+        assert stats["observed"]["rx"]["rssi"]["p50"] is not None
+
+
+@requires_profiles
+def test_golden_profiles_capture_the_calibration_targets():
+    """The measured deltas that drive WS1-WS3 stay visible in the fixtures."""
+    dc = json.loads((PROFILES / "defcon33.json").read_text())["stats"]
+    bm = json.loads((PROFILES / "burningman2025.json").read_text())["stats"]
+    # DEF CON: ~44% encrypted, heavy rebroadcast duplication
+    assert 0.35 < dc["encrypted_fraction"] < 0.55
+    dup_multi = sum(v for k, v in dc["observed"]["observation_multiplicity"].items() if k != "1")
+    assert dup_multi / dc["packets"] > 0.2
+    # Burning Man: NODEINFO-dominated portnum mix, ROUTING is a first-class citizen
+    assert bm["portnum_mix"]["NODEINFO"] > bm["portnum_mix"]["TELEMETRY"]
+    assert bm["portnum_mix"]["ROUTING"] > 0.05 * bm["packets"]
+    # both: text has a long tail our sim must reproduce
+    assert dc["text"]["len"]["max"] > 200
+    assert bm["text"]["len"]["max"] > 200

--- a/tests/unit/test_replay_metrics.py
+++ b/tests/unit/test_replay_metrics.py
@@ -32,8 +32,7 @@ PROFILES = REPO / "src" / "meshtastic_mcp" / "replay" / "profiles"
 # committed (see .gitignore); the tests that assert against them skip when the
 # files are absent (e.g. in CI).
 requires_profiles = pytest.mark.skipif(
-    not (PROFILES / "burningman2025.json").exists()
-    or not (PROFILES / "defcon33.json").exists(),
+    not (PROFILES / "burningman2025.json").exists() or not (PROFILES / "defcon33.json").exists(),
     reason="locally generated golden profiles not present",
 )
 

--- a/tests/unit/test_replay_metrics.py
+++ b/tests/unit/test_replay_metrics.py
@@ -378,6 +378,11 @@ def test_profile_accepts_dict_json_and_deep_merges(tmp_path):
     assert merged["observer"]["path_loss_exp"] == 3.5
     assert merged["observer"]["enabled"] is False  # untouched default preserved
     assert merged["venue"]["name"] == _sim.PROFILE["venue"]["name"]
+    # a partial `tak` override keeps the other tak defaults (team_nodes, etc.)
+    tak_merged = _sim._resolve_profile({"tak": {"wire": "v2"}})
+    assert tak_merged["tak"]["wire"] == "v2"
+    assert tak_merged["tak"]["team_nodes"] == _sim.PROFILE["tak"]["team_nodes"]
+    assert tak_merged["tak"]["pli_interval"] == _sim.PROFILE["tak"]["pli_interval"]
     # JSON path load
     import json
 

--- a/tests/unit/test_replay_metrics.py
+++ b/tests/unit/test_replay_metrics.py
@@ -414,3 +414,46 @@ def test_ninja_fuzz_preset_spoofs_nodeinfo_without_key_change():
             spoofed += 1
     assert spoofed > 0
     assert f.status()["counts"].get("ninja_flood", 0) > 0
+
+
+# ── WS-A: opt-in ATAK squad ──────────────────────────────────────────────────
+
+
+def test_tak_squad_is_opt_in_and_well_formed():
+    from meshtastic.protobuf import atak_pb2
+
+    from meshtastic_mcp.replay import sim as _sim
+
+    # off by default and in the fitted event presets
+    for profile in (None, "defcon", "burningman"):
+        cap = _sim.generate(nodes=150, days=1, seed=8, start=1_700_000_000, profile=profile)
+        assert metrics.capture_stats(cap)["tak_packets"] == 0
+
+    prof = {"tak": {"team_nodes": 5, "pli_interval": 45, "chat_per_hour": 3, "team": "Cyan"}}
+    cap = _sim.generate(nodes=200, days=1, seed=8, start=1_700_000_000, profile=prof)
+    stats = metrics.capture_stats(cap)
+    assert stats["tak_packets"] > 0
+    assert "ATAK_PLUGIN" in stats["portnum_mix"]
+
+    pli = chat = 0
+    callsigns = set()
+    teams = set()
+    for _t, raw, _ch in cap.packets:
+        mp = mesh_pb2.MeshPacket()
+        mp.ParseFromString(raw)
+        if mp.WhichOneof("payload_variant") != "decoded" or mp.decoded.portnum != 72:
+            continue
+        tp = atak_pb2.TAKPacket()
+        tp.ParseFromString(mp.decoded.payload)  # must be a valid TAKPacket
+        callsigns.add(tp.contact.callsign)
+        teams.add(tp.group.team)
+        assert tp.status.battery <= 100
+        if tp.HasField("pli"):
+            pli += 1
+            assert -900_000_000 <= tp.pli.latitude_i <= 900_000_000
+        if tp.HasField("chat"):
+            chat += 1
+            assert tp.chat.message
+    assert pli > 0 and chat > 0
+    assert len(callsigns) == 5  # one per squad member
+    assert teams == {atak_pb2.Team.Value("Cyan")}

--- a/tests/unit/test_replay_observer.py
+++ b/tests/unit/test_replay_observer.py
@@ -225,3 +225,26 @@ def test_sim_observer_integration() -> None:
     assert 0 < len(ids) < len(truth_ids)  # loss happened
     assert any(v > 1 for v in ids.values())  # rebroadcast duplicates happened
     assert rf_meta > 0 and mqtt > 0
+
+
+def test_fading_gate_creates_gap_tails() -> None:
+    """The Gilbert-Elliott fading gate produces the heavy inter-arrival tails
+    real gateway captures show (bursts of loss -> long silent gaps)."""
+    packets, positions = _fleet(4000, 100, 800)
+    base = ObserverParams(lat=OBS_LAT, lon=OBS_LON, seed=17)
+    faded = ObserverParams(
+        lat=OBS_LAT, lon=OBS_LON, seed=17, fade_good_s=120.0, fade_bad_s=90.0, fade_bad_loss=0.95
+    )
+    out_base = observe(packets, positions, base)
+    out_faded = observe(packets, positions, faded)
+    assert len(out_faded) < len(out_base)  # fading removes traffic
+
+    def max_gap(rows):
+        import itertools
+
+        ts = [t for t, _b, _c in rows]
+        return max((b - a for a, b in itertools.pairwise(ts)), default=0)
+
+    # bad-state dwells carve visible silences into the stream
+    assert max_gap(out_faded) > max_gap(out_base)
+    assert max_gap(out_faded) >= 30

--- a/tests/unit/test_replay_observer.py
+++ b/tests/unit/test_replay_observer.py
@@ -1,0 +1,227 @@
+# SPDX-FileCopyrightText: Meshtastic contributors
+# SPDX-License-Identifier: GPL-3.0-only
+
+"""Unit tests for the observer / RF gateway model (replay/observer.py)."""
+
+from __future__ import annotations
+
+import math
+from collections import Counter
+
+import pytest
+from meshtastic.protobuf import mesh_pb2
+
+from meshtastic_mcp.replay.observer import (
+    ObserverParams,
+    _synthetic_position,
+    observe,
+)
+
+OBS_LAT, OBS_LON = 40.0, -119.2
+BROADCAST = 0xFFFFFFFF
+T0 = 1_750_000_000
+
+
+def _mk_packet(
+    pkt_id: int,
+    sender: int,
+    t: int,
+    payload: bytes = b"hello",
+    hop_limit: int = 3,
+) -> tuple[int, bytes, str]:
+    mp = mesh_pb2.MeshPacket()
+    setattr(mp, "from", sender)
+    mp.to = BROADCAST
+    mp.id = pkt_id
+    mp.hop_limit = hop_limit
+    mp.hop_start = 3
+    mp.decoded.portnum = 1
+    mp.decoded.payload = payload
+    return (t, mp.SerializeToString(), "LongFast")
+
+
+def _pos_at(dist_m: float, bearing_rad: float = 0.0) -> tuple[float, float]:
+    """A point ``dist_m`` meters from the observer at the given bearing."""
+    earth = 6_371_000.0
+    dlat = dist_m * math.cos(bearing_rad) / earth
+    dlon = dist_m * math.sin(bearing_rad) / (earth * math.cos(math.radians(OBS_LAT)))
+    return OBS_LAT + math.degrees(dlat), OBS_LON + math.degrees(dlon)
+
+
+def _fleet(
+    n: int, dist_lo: float, dist_hi: float
+) -> tuple[list[tuple[int, bytes, str]], dict[int, tuple[float, float]]]:
+    """n packets, unique ids, senders spread deterministically over [lo, hi] m."""
+    packets: list[tuple[int, bytes, str]] = []
+    positions: dict[int, tuple[float, float]] = {}
+    for i in range(n):
+        sender = 0x1000_0000 + (i % 200)
+        frac = (i % 200) / 199.0 if n > 1 else 0.0
+        positions[sender] = _pos_at(dist_lo + frac * (dist_hi - dist_lo), bearing_rad=i * 0.37)
+        packets.append(_mk_packet(pkt_id=1_000_000 + i, sender=sender, t=T0 + i))
+    return packets, positions
+
+
+def _parse(blob: bytes) -> mesh_pb2.MeshPacket:
+    mp = mesh_pb2.MeshPacket()
+    mp.ParseFromString(blob)
+    return mp
+
+
+def test_determinism() -> None:
+    packets, positions = _fleet(300, 100, 1200)
+    params = ObserverParams(lat=OBS_LAT, lon=OBS_LON, seed=0)
+    a = observe(packets, positions, params)
+    b = observe(packets, positions, params)
+    assert a == b  # byte-identical
+
+    other = observe(packets, positions, ObserverParams(lat=OBS_LAT, lon=OBS_LON, seed=1))
+    assert other != a
+
+
+def test_multiplicity_calibration() -> None:
+    packets, positions = _fleet(4000, 50, 1500)
+    params = ObserverParams(lat=OBS_LAT, lon=OBS_LON, mqtt_fraction=0.0, seed=42)
+    out = observe(packets, positions, params)
+
+    copies_per_id: Counter[int] = Counter()
+    rssis: list[int] = []
+    for _, blob, _ in out:
+        mp = _parse(blob)
+        copies_per_id[mp.id] += 1
+        rssis.append(mp.rx_rssi)
+
+    n_ids = len(copies_per_id)
+    assert n_ids > 3000  # most packets at these ranges are heard
+    mult = Counter(copies_per_id.values())
+    expected = dict(params.dup_weights)
+    for k, weight in expected.items():
+        frac = mult.get(k, 0) / n_ids
+        assert abs(frac - weight) <= 0.06, f"multiplicity {k}: {frac:.3f} vs {weight}"
+
+    # Report-worthy sanity on the RSSI population.
+    rssis.sort()
+    p50 = rssis[len(rssis) // 2]
+    assert -128 <= p50 <= -12
+
+
+def test_distance_loss() -> None:
+    near, near_pos = _fleet(2000, 100, 100)
+    params = ObserverParams(lat=OBS_LAT, lon=OBS_LON, seed=7)
+    out = observe(near, near_pos, params)
+    heard_ids = {_parse(blob).id for _, blob, _ in out}
+    assert len(heard_ids) / 2000 >= 0.95
+
+    far, far_pos = _fleet(2000, 80_000, 80_000)
+    out_far = observe(far, far_pos, params)
+    far_ids = {_parse(blob).id for _, blob, _ in out_far}
+    assert len(far_ids) / 2000 < 0.05
+
+
+def test_rx_metadata() -> None:
+    packets, positions = _fleet(800, 50, 1500)
+    params = ObserverParams(lat=OBS_LAT, lon=OBS_LON, seed=3)
+    out = observe(packets, positions, params)
+    assert out
+
+    t_by_id = {_parse(blob).id: t for t, blob, _ in packets}
+    direct_by_id: Counter[int] = Counter()
+    for rx_t, blob, _ in out:
+        mp = _parse(blob)
+        assert -128 <= mp.rx_rssi <= -12
+        assert -20.75 <= mp.rx_snr <= 15.25
+        assert (mp.rx_snr * 4) % 1 == pytest.approx(0.0, abs=1e-6)  # quarter-dB steps
+        assert mp.rx_time >= t_by_id[mp.id]
+        assert rx_t == mp.rx_time
+        assert 0 <= mp.hop_limit <= 3
+        if mp.relay_node == 0:
+            direct_by_id[mp.id] += 1
+
+    # Copies beyond the first carry a nonzero relay_node: at most one
+    # relay-free (direct) copy per packet id.
+    assert all(count <= 1 for count in direct_by_id.values())
+
+
+def test_identity_preservation() -> None:
+    packets, positions = _fleet(500, 50, 1500)
+    originals = {_parse(blob).id: _parse(blob) for _, blob, _ in packets}
+    out = observe(packets, positions, ObserverParams(lat=OBS_LAT, lon=OBS_LON, seed=5))
+    assert out
+    for _, blob, channel in out:
+        mp = _parse(blob)
+        orig = originals[mp.id]
+        assert getattr(mp, "from") == getattr(orig, "from")
+        assert mp.to == orig.to
+        assert mp.id == orig.id
+        assert mp.decoded.portnum == orig.decoded.portnum
+        assert mp.decoded.payload == orig.decoded.payload
+        assert channel == "LongFast"
+
+
+def test_mqtt_mode() -> None:
+    packets, positions = _fleet(300, 100, 1000)
+    params = ObserverParams(lat=OBS_LAT, lon=OBS_LON, mqtt_fraction=1.0, seed=9)
+    out = observe(packets, positions, params)
+
+    mqtt_ids = set()
+    for _, blob, _ in out:
+        mp = _parse(blob)
+        if mp.via_mqtt:
+            assert mp.rx_rssi == 0
+            assert mp.rx_snr == 0.0
+            assert mp.hop_limit == 3  # hop fields untouched on the bridged copy
+            mqtt_ids.add(mp.id)
+    input_ids = {_parse(blob).id for _, blob, _ in packets}
+    assert mqtt_ids == input_ids  # every input yields at least one MQTT copy
+
+
+def test_unknown_sender_fallback() -> None:
+    packets = [
+        _mk_packet(pkt_id=2_000_000 + i, sender=0x2000_0000 + (i % 50), t=T0 + i)
+        for i in range(400)
+    ]
+    params = ObserverParams(lat=OBS_LAT, lon=OBS_LON, seed=11)
+    a = observe(packets, {}, params)
+    b = observe(packets, {}, params)
+    assert a  # synthetic positions are near the observer, so output is nonempty
+    assert a == b  # same synthetic position + same seed → identical output
+
+    # The synthetic position depends only on the node number.
+    p1 = _synthetic_position(0x2000_0000, OBS_LAT, OBS_LON)
+    p2 = _synthetic_position(0x2000_0000, OBS_LAT, OBS_LON)
+    assert p1 == p2
+    assert _synthetic_position(0x2000_0001, OBS_LAT, OBS_LON) != p1
+
+
+def test_sorted_output() -> None:
+    packets, positions = _fleet(1000, 50, 1500)
+    out = observe(packets, positions, ObserverParams(lat=OBS_LAT, lon=OBS_LON, seed=13))
+    times = [t for t, _, _ in out]
+    assert times == sorted(times)
+
+
+def test_sim_observer_integration() -> None:
+    """generate(profile={"observer": {"enabled": True}}) yields a gateway view:
+    fewer unique ids than truth, duplicate copies, RX metadata, deterministic."""
+    from meshtastic_mcp.replay import sim
+
+    truth = sim.generate(nodes=120, days=1, seed=21, start=1_700_000_000)
+    prof = {"observer": {"enabled": True, "mqtt_fraction": 0.2}}
+    obs_a = sim.generate(nodes=120, days=1, seed=21, start=1_700_000_000, profile=prof)
+    obs_b = sim.generate(nodes=120, days=1, seed=21, start=1_700_000_000, profile=prof)
+    assert obs_a.packets == obs_b.packets  # seeded end-to-end
+
+    ids = Counter()
+    rf_meta = mqtt = 0
+    for _, blob, _ in obs_a.packets:
+        mp = _parse(blob)
+        ids[mp.id] += 1
+        if mp.via_mqtt:
+            mqtt += 1
+        elif mp.rx_rssi:
+            assert -128 <= mp.rx_rssi <= -12
+            rf_meta += 1
+    truth_ids = {_parse(blob).id for _, blob, _ in truth.packets}
+    assert 0 < len(ids) < len(truth_ids)  # loss happened
+    assert any(v > 1 for v in ids.values())  # rebroadcast duplicates happened
+    assert rf_meta > 0 and mqtt > 0

--- a/tests/unit/test_replay_tak.py
+++ b/tests/unit/test_replay_tak.py
@@ -1,0 +1,138 @@
+# SPDX-FileCopyrightText: Meshtastic contributors
+# SPDX-License-Identifier: GPL-3.0-only
+
+"""TAKPacketV2 wire-format support (the optional ``[tak]`` extra).
+
+The SDK (meshtastic-tak) is a git-only dependency, so the wire-format tests
+skip when it isn't installed; the availability-gate and error-path tests run
+unconditionally.
+"""
+
+from __future__ import annotations
+
+import pytest
+from meshtastic.protobuf import mesh_pb2
+
+from meshtastic_mcp.replay import metrics, sim, tak
+
+requires_tak = pytest.mark.skipif(not tak.available(), reason="[tak] extra not installed")
+
+
+def _tak_payloads(cap):
+    for _t, raw, _ch in cap.packets:
+        mp = mesh_pb2.MeshPacket()
+        mp.ParseFromString(raw)
+        if mp.WhichOneof("payload_variant") == "decoded" and mp.decoded.portnum == 72:
+            yield mp.decoded.payload
+
+
+def test_available_is_boolean():
+    assert isinstance(tak.available(), bool)
+
+
+def test_v2_requested_without_sdk_raises(monkeypatch):
+    """profile tak.wire='v2' must fail fast with an install hint when the extra
+    is absent — no silent fallback that would confuse an explicit request."""
+    monkeypatch.setattr(tak, "available", lambda: False)
+    prof = {"tak": {"team_nodes": 2, "wire": "v2"}}
+    with pytest.raises(RuntimeError, match=r"\[tak\] extra"):
+        sim.generate(nodes=40, days=1, seed=1, start=1_700_000_000, profile=prof)
+
+
+@requires_tak
+def test_wrapper_round_trips_pli_and_chat():
+    pli = tak.build_pli(
+        callsign="Coyote-1",
+        uid="MESH-deadbeef",
+        team=10,
+        role=1,
+        lat_i=407_864_000,
+        lon_i=-1_192_065_000,
+        altitude=1200,
+        speed=3,
+        course=120,
+        battery=88,
+    )
+    wire = tak.compress(pli)
+    assert isinstance(wire, bytes) and 0 < len(wire) <= 184  # LoRa-sized
+    back = tak.decompress(wire)
+    assert back.callsign == "Coyote-1"
+    assert back.uid == "MESH-deadbeef"
+    assert back.latitude_i == 407_864_000
+    assert back.battery == 88
+
+    chat = tak.build_chat(
+        callsign="Coyote-1",
+        uid="MESH-deadbeef",
+        team=10,
+        role=1,
+        battery=88,
+        message="rally at CP1",
+    )
+    assert tak.decompress(tak.compress(chat)).chat.message == "rally at CP1"
+
+
+@requires_tak
+def test_wire_is_cross_instance_compatible():
+    """A payload our wrapper produces decompresses in an independent SDK
+    compressor — i.e. it's real SDK wire, byte-compatible across platforms."""
+    from meshtastic_tak import TakCompressor
+
+    pli = tak.build_pli(
+        callsign="Sage-2",
+        uid="MESH-0badf00d",
+        team=9,
+        role=2,
+        lat_i=360_000_000,
+        lon_i=-1_150_000_000,
+        altitude=800,
+        speed=0,
+        course=0,
+        battery=55,
+    )
+    wire = tak.compress(pli)
+    native = TakCompressor().decompress(wire)  # fresh instance, no shared state
+    assert native.uid == "MESH-0badf00d"
+    assert native.callsign == "Sage-2"
+
+
+@requires_tak
+def test_sim_v2_emits_valid_lora_sized_wire():
+    from meshtastic_tak import TakCompressor
+
+    prof = {"tak": {"team_nodes": 4, "pli_interval": 60, "chat_per_hour": 3, "wire": "v2"}}
+    cap = sim.generate(nodes=150, days=1, seed=8, start=1_700_000_000, profile=prof)
+    assert metrics.capture_stats(cap)["tak_packets"] > 0
+    decoder = TakCompressor()
+    sizes = []
+    for payload in _tak_payloads(cap):
+        pkt = decoder.decompress(payload)  # SDK-native decode of sim output
+        assert pkt.uid.startswith("MESH-")
+        sizes.append(len(payload))
+    assert sizes
+    sizes.sort()
+    assert sizes[len(sizes) // 2] <= 184  # median within the LoRa MTU budget
+
+
+@requires_tak
+def test_v1_and_v2_wire_differ():
+    """v1 emits legacy uncompressed TAKPacket; v2 emits compressed wire — a v2
+    payload must NOT parse as a legacy TAKPacket with a populated callsign."""
+    from meshtastic.protobuf import atak_pb2
+
+    common = {"team_nodes": 3, "pli_interval": 60, "chat_per_hour": 0}
+    v1 = sim.generate(
+        nodes=80, days=1, seed=4, start=1_700_000_000, profile={"tak": {**common, "wire": "v1"}}
+    )
+    v2 = sim.generate(
+        nodes=80, days=1, seed=4, start=1_700_000_000, profile={"tak": {**common, "wire": "v2"}}
+    )
+    v1_payloads = list(_tak_payloads(v1))
+    v2_payloads = list(_tak_payloads(v2))
+    assert v1_payloads and v2_payloads
+    # legacy payloads parse as V1 TAKPacket with a nested contact callsign
+    legacy = atak_pb2.TAKPacket()
+    legacy.ParseFromString(v1_payloads[0])
+    assert legacy.contact.callsign
+    # the v2 wire is a different byte-shape (1-byte dict id + zstd body)
+    assert v2_payloads[0] != v1_payloads[0]

--- a/tests/unit/test_replay_tak.py
+++ b/tests/unit/test_replay_tak.py
@@ -18,11 +18,20 @@ from meshtastic_mcp.replay import metrics, sim, tak
 requires_tak = pytest.mark.skipif(not tak.available(), reason="[tak] extra not installed")
 
 
-def _tak_payloads(cap):
+# ATAK_PLUGIN (legacy v1) and ATAK_PLUGIN_V2 (compressed v2) portnums.
+TAK_V1_PORT = 72
+TAK_V2_PORT = 78
+
+
+def _tak_payloads(cap, port=None):
+    """Yield decoded TAK payloads; ``port`` filters to a specific TAK portnum."""
     for _t, raw, _ch in cap.packets:
         mp = mesh_pb2.MeshPacket()
         mp.ParseFromString(raw)
-        if mp.WhichOneof("payload_variant") == "decoded" and mp.decoded.portnum == 72:
+        if mp.WhichOneof("payload_variant") != "decoded":
+            continue
+        pn = mp.decoded.portnum
+        if pn in (TAK_V1_PORT, TAK_V2_PORT) and (port is None or pn == port):
             yield mp.decoded.payload
 
 
@@ -103,9 +112,11 @@ def test_sim_v2_emits_valid_lora_sized_wire():
     prof = {"tak": {"team_nodes": 4, "pli_interval": 60, "chat_per_hour": 3, "wire": "v2"}}
     cap = sim.generate(nodes=150, days=1, seed=8, start=1_700_000_000, profile=prof)
     assert metrics.capture_stats(cap)["tak_packets"] > 0
+    # v2 wire must ride ATAK_PLUGIN_V2 (78), not the legacy ATAK_PLUGIN (72)
+    assert not list(_tak_payloads(cap, port=TAK_V1_PORT))
     decoder = TakCompressor()
     sizes = []
-    for payload in _tak_payloads(cap):
+    for payload in _tak_payloads(cap, port=TAK_V2_PORT):
         pkt = decoder.decompress(payload)  # SDK-native decode of sim output
         assert pkt.uid.startswith("MESH-")
         sizes.append(len(payload))
@@ -127,9 +138,12 @@ def test_v1_and_v2_wire_differ():
     v2 = sim.generate(
         nodes=80, days=1, seed=4, start=1_700_000_000, profile={"tak": {**common, "wire": "v2"}}
     )
-    v1_payloads = list(_tak_payloads(v1))
-    v2_payloads = list(_tak_payloads(v2))
+    v1_payloads = list(_tak_payloads(v1, port=TAK_V1_PORT))
+    v2_payloads = list(_tak_payloads(v2, port=TAK_V2_PORT))
     assert v1_payloads and v2_payloads
+    # v1 rides portnum 72, v2 rides 78 (no crossover)
+    assert not list(_tak_payloads(v1, port=TAK_V2_PORT))
+    assert not list(_tak_payloads(v2, port=TAK_V1_PORT))
     # legacy payloads parse as V1 TAKPacket with a nested contact callsign
     legacy = atak_pb2.TAKPacket()
     legacy.ParseFromString(v1_payloads[0])

--- a/tests/unit/test_sim_realism.py
+++ b/tests/unit/test_sim_realism.py
@@ -1,0 +1,128 @@
+# SPDX-FileCopyrightText: Meshtastic contributors
+# SPDX-License-Identifier: GPL-3.0-only
+
+"""WS5 realism regression: keep the generator inside tolerance bands.
+
+These bands are reviewed constants derived from the real event captures
+(Burning Man 2025, DEF CON 33) analysed in docs/sim-realism-plan.md. The
+golden stat profiles themselves are dataset-derived and not committed, so the
+guardrails live here as code — they catch regressions in the generator's
+portnum economy, hop model, text shape, telemetry, and the RF observer without
+needing the private data present.
+
+Scale is kept modest (500 nodes / 2 days) so the suite stays fast; the bands
+are shape/proportion based and hold across scales.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from meshtastic_mcp.replay import metrics, sim
+
+SEED = 99
+START = 1_700_000_000
+
+
+def _stats(profile):
+    cap = sim.generate(nodes=500, days=2, seed=SEED, start=START, profile=profile)
+    return cap, metrics.capture_stats(cap)
+
+
+def _mix_pct(stats):
+    total = sum(stats["portnum_mix"].values()) or 1
+    return {k: 100.0 * v / total for k, v in stats["portnum_mix"].items()}
+
+
+@pytest.fixture(scope="module")
+def preset_stats():
+    return {name: _stats(name) for name in ("meshcon", "burningman", "defcon")}
+
+
+@pytest.mark.parametrize("preset", ["meshcon", "burningman", "defcon"])
+def test_portnum_economy_within_bands(preset, preset_stats):
+    """Real meshes are NODEINFO/POSITION-dominated with a real ROUTING share —
+    the inverse of the pre-calibration generator (which was TELEMETRY-heavy)."""
+    _cap, stats = preset_stats[preset]
+    mix = _mix_pct(stats)
+    assert 25.0 <= mix.get("NODEINFO", 0) <= 45.0, mix
+    assert 22.0 <= mix.get("POSITION", 0) <= 38.0, mix
+    assert 8.0 <= mix.get("TELEMETRY", 0) <= 28.0, mix
+    assert 3.0 <= mix.get("ROUTING", 0) <= 15.0, mix
+    # NODEINFO must lead TELEMETRY (the key inversion the calibration fixed)
+    assert mix["NODEINFO"] > mix["TELEMETRY"]
+
+
+@pytest.mark.parametrize(
+    ("preset", "lo", "hi"),
+    [("meshcon", 0.15, 0.35), ("burningman", 0.05, 0.25), ("defcon", 0.35, 0.55)],
+)
+def test_encrypted_fraction_per_scenario(preset, lo, hi, preset_stats):
+    _cap, stats = preset_stats[preset]
+    assert lo <= stats["encrypted_fraction"] <= hi
+
+
+def test_text_shape(preset_stats):
+    """Short median with a long wall-of-text tail (real p50 17-25, max 227-246)."""
+    for preset in ("meshcon", "burningman", "defcon"):
+        _cap, stats = preset_stats[preset]
+        length = stats["text"]["len"]
+        assert 15 <= length["p50"] <= 40, (preset, length)
+        assert length["max"] >= 150, (preset, length)
+        assert stats["text"]["dm_fraction"] <= 0.10  # DMs are rare on-air
+
+
+def test_talker_skew_and_hop_model(preset_stats):
+    for preset in ("meshcon", "burningman", "defcon"):
+        _cap, stats = preset_stats[preset]
+        assert 0.30 <= stats["talker_skew"]["top10pct_share"] <= 0.85
+        assert "7" in stats["hop_start"]  # the observed hop-7 subpopulation exists
+
+    # DEF CON cranks hop-7 harder than the default MeshCon config
+    def hop7_frac(stats):
+        hs = {int(k): v for k, v in stats["hop_start"].items()}
+        return hs.get(7, 0) / max(sum(hs.values()), 1)
+
+    assert hop7_frac(preset_stats["defcon"][1]) > hop7_frac(preset_stats["meshcon"][1])
+
+
+def test_telemetry_realism(preset_stats):
+    for preset in ("meshcon", "burningman", "defcon"):
+        _cap, stats = preset_stats[preset]
+        tel = stats["telemetry"]
+        # chutil skewed low with a bounded tail (BM p50 7.4, max 39)
+        assert 3.0 <= tel["chutil"]["p50"] <= 20.0, (preset, tel["chutil"])
+        assert tel["chutil"]["max"] < 55.0
+        # battery is bimodal: a plugged (101) mode AND a drained (0) spike
+        batt = dict(tel["battery_top"])
+        assert 101 in batt
+        # device metrics dominate, env + power present
+        vm = tel["variant_mix"]
+        assert vm.get("device_metrics", 0) > vm.get("environment_metrics", 0)
+        assert vm.get("environment_metrics", 0) > 0
+
+
+def test_observer_presets_produce_gateway_view(preset_stats):
+    """burningman/defcon enable the RF observer: RX metadata + rebroadcast
+    duplicates. meshcon leaves it off (omniscient truth)."""
+    for preset in ("burningman", "defcon"):
+        _cap, stats = preset_stats[preset]
+        assert stats["rx"]["rssi"]["n"] > 0
+        assert -128 <= stats["rx"]["rssi"]["p50"] <= -12
+        dup2 = sum(int(v) for k, v in stats["dup_id_multiplicity"].items() if k != "1")
+        assert dup2 > 0, "observer should duplicate rebroadcast packets"
+
+    _cap, mesh = preset_stats["meshcon"]
+    assert mesh["rx"]["rssi"]["n"] == 0  # observer off by default
+
+
+def test_generator_is_byte_deterministic():
+    a = sim.generate(nodes=200, days=1, seed=5, start=START, profile="defcon")
+    b = sim.generate(nodes=200, days=1, seed=5, start=START, profile="defcon")
+    assert a.packets == b.packets
+
+
+def test_presets_are_tak_free_by_default(preset_stats):
+    for preset in ("meshcon", "burningman", "defcon"):
+        _cap, stats = preset_stats[preset]
+        assert stats["tak_packets"] == 0

--- a/tests/unit/test_sim_realism.py
+++ b/tests/unit/test_sim_realism.py
@@ -96,6 +96,7 @@ def test_telemetry_realism(preset_stats):
         # battery is bimodal: a plugged (101) mode AND a drained (0) spike
         batt = dict(tel["battery_top"])
         assert 101 in batt
+        assert 0 in batt
         # device metrics dominate, env + power present
         vm = tel["variant_mix"]
         assert vm.get("device_metrics", 0) > vm.get("environment_metrics", 0)

--- a/tests/unit/test_tak_bridge.py
+++ b/tests/unit/test_tak_bridge.py
@@ -1,0 +1,189 @@
+# SPDX-FileCopyrightText: Meshtastic contributors
+# SPDX-License-Identifier: GPL-3.0-only
+
+"""Bridge-semantics: the CoT an app's TAK server would forward to ATAK/iTAK.
+
+Meshtastic apps (≥2.8) run an in-app local TAK server that bridges mesh TAK
+traffic to a connected ATAK/iTAK client: it decompresses the TAKPacketV2 wire
+(portnum 78) and rebuilds a Cursor-on-Target (CoT) XML event over the TAK
+stream. These tests take the *exact* v2 payloads our sim emits and run them
+through the SDK's decompress → CoT-XML build path — i.e. what the bridge does —
+asserting the resulting CoT is well-formed and carries the right identity,
+type, position, and chat. This validates our TAK stimulus end-to-end without an
+emulator; the full app-plane loop lives in ``scripts/ci_atak_app_loop.py``.
+
+SDK-gated: skips when the ``[tak]`` extra (meshtastic-tak) isn't installed.
+"""
+
+from __future__ import annotations
+
+import xml.etree.ElementTree as ET
+
+import pytest
+from meshtastic.protobuf import mesh_pb2
+
+from meshtastic_mcp.replay import metrics, sim, tak
+
+requires_tak = pytest.mark.skipif(not tak.available(), reason="[tak] extra not installed")
+
+TAK_V2_PORT = 78
+
+
+def _v2_payloads(cap):
+    for _t, raw, _ch in cap.packets:
+        mp = mesh_pb2.MeshPacket()
+        mp.ParseFromString(raw)
+        if mp.WhichOneof("payload_variant") == "decoded" and mp.decoded.portnum == TAK_V2_PORT:
+            yield mp.decoded.payload
+
+
+def _bridge_to_cot(wire: bytes) -> str:
+    """Reproduce the app TAK server's receive path: wire → TAKPacketV2 → CoT XML."""
+    from meshtastic_tak import CotXmlBuilder, TakCompressor
+
+    pkt = TakCompressor().decompress(wire)
+    return CotXmlBuilder().build(pkt)
+
+
+@requires_tak
+def test_wrapper_pli_bridges_to_valid_typed_cot():
+    pli = tak.build_pli(
+        callsign="Coyote-1",
+        uid="MESH-deadbeef",
+        team=10,
+        role=1,
+        lat_i=407_864_000,
+        lon_i=-1_192_065_000,
+        altitude=1200,
+        speed=3,
+        course=90,
+        battery=88,
+    )
+    cot = _bridge_to_cot(tak.compress(pli))
+    root = ET.fromstring(cot)  # well-formed XML
+    assert root.tag == "event"
+    assert root.attrib["uid"] == "MESH-deadbeef"
+    assert root.attrib["type"] == tak.PLI_COT_TYPE  # typed, not empty
+    point = root.find("point")
+    assert point is not None
+    assert abs(float(point.attrib["lat"]) - 40.7864) < 1e-4
+    assert abs(float(point.attrib["lon"]) - -119.2065) < 1e-4
+    contact = root.find("detail/contact")
+    assert contact is not None and contact.attrib["callsign"] == "Coyote-1"
+
+
+@requires_tak
+def test_wrapper_chat_bridges_to_geochat_remarks():
+    chat = tak.build_chat(
+        callsign="Sage-2",
+        uid="MESH-c0ffee",
+        team=9,
+        role=2,
+        battery=70,
+        message="rally at CP1",
+    )
+    cot = _bridge_to_cot(tak.compress(chat))
+    root = ET.fromstring(cot)
+    assert root.attrib["uid"] == "MESH-c0ffee"
+    remarks = root.find("detail/remarks")
+    assert remarks is not None and remarks.text == "rally at CP1"
+
+
+@requires_tak
+def test_sim_v2_squad_bridges_to_renderable_cot():
+    """Every v2 payload the sim streams for a TAK squad bridges to a CoT event
+    ATAK/iTAK would render: valid XML, MESH- uid, and a friendly-ground type on
+    the PLIs. This is the payload-level guarantee behind the app-plane loop."""
+    prof = {"tak": {"team_nodes": 4, "pli_interval": 60, "chat_per_hour": 2, "wire": "v2"}}
+    cap = sim.generate(nodes=150, days=1, seed=8, start=1_700_000_000, profile=prof)
+    assert metrics.capture_stats(cap)["tak_packets"] > 0
+
+    n_pli = n_chat = 0
+    callsigns: set[str] = set()
+    for payload in _v2_payloads(cap):
+        cot = _bridge_to_cot(payload)
+        root = ET.fromstring(cot)  # must be well-formed
+        assert root.tag == "event"
+        assert root.attrib["uid"].startswith("MESH-")
+        contact = root.find("detail/contact")
+        assert contact is not None
+        callsigns.add(contact.attrib.get("callsign", ""))
+        if root.find("detail/remarks") is not None:
+            n_chat += 1
+        else:
+            assert root.attrib["type"] == tak.PLI_COT_TYPE
+            point = root.find("point")
+            assert point is not None and point.attrib["lat"] and point.attrib["lon"]
+            n_pli += 1
+    assert n_pli > 0 and n_chat > 0
+    assert len(callsigns) == 4  # one CoT identity per squad member
+
+
+# A realistic ATAK-authored CoT event (what ATAK-CIV puts on its TAK stream when
+# a user drops a self-PLI / sends chat), including the detail bloat the mesh strips.
+_ATAK_PLI = (
+    '<?xml version="1.0"?><event version="2.0" uid="ANDROID-r1" type="a-f-G-U-C" '
+    'how="m-g" time="2026-01-01T00:00:00Z" start="2026-01-01T00:00:00Z" '
+    'stale="2026-01-01T00:05:00Z"><point lat="40.79" lon="-119.21" hae="1200" '
+    'ce="9.9" le="9.9"/><detail><contact callsign="RANGER-1"/>'
+    '<__group name="Cyan" role="Team Member"/>'
+    '<takv device="Pixel" platform="ATAK-CIV" version="5.5"/>'
+    '<status battery="77"/></detail></event>'
+)
+_ATAK_GEOCHAT = (
+    '<?xml version="1.0"?><event version="2.0" uid="GeoChat.ANDROID-r1.All Chat Rooms.x" '
+    'type="b-t-f" how="m-g" time="2026-01-01T00:00:00Z" start="2026-01-01T00:00:00Z" '
+    'stale="2026-01-01T00:05:00Z"><point lat="40.79" lon="-119.21" hae="1200" ce="9.9" '
+    'le="9.9"/><detail><contact callsign="RANGER-1"/><remarks>moving to OP</remarks>'
+    '<__chat chatroom="All Chat Rooms" senderCallsign="RANGER-1"/></detail></event>'
+)
+
+
+@requires_tak
+def test_atak_cot_converts_to_mesh_wire_send_leg():
+    """Send leg (TAK client -> mesh): an ATAK-authored CoT becomes a valid
+    portnum-78 mesh payload that decompresses back to the same identity/pos."""
+    wire = tak.cot_to_wire(_ATAK_PLI)
+    assert 0 < len(wire) <= 184  # LoRa-sized after mesh stripping
+    pkt = tak.decompress(wire)
+    assert pkt.uid == "ANDROID-r1"
+    assert pkt.callsign == "RANGER-1"
+    assert abs(pkt.latitude_i - 407_900_000) <= 1
+    assert abs(pkt.longitude_i - -1_192_100_000) <= 1
+    # and it rides ATAK_PLUGIN_V2 (78) on the wire
+    mp = mesh_pb2.MeshPacket()
+    setattr(mp, "from", 0x1234)
+    mp.decoded.portnum = 78
+    mp.decoded.payload = wire
+    assert mp.decoded.portnum == 78
+
+
+@requires_tak
+def test_atak_geochat_converts_to_mesh_wire():
+    pkt = tak.parse_cot(_ATAK_GEOCHAT)
+    assert pkt.chat.message == "moving to OP"
+    assert tak.compress(pkt)  # compresses without error
+
+
+@requires_tak
+def test_cot_round_trips_back_through_parser():
+    """The bridge is reversible: the CoT XML we emit parses back to an
+    equivalent TAKPacketV2 (what an inbound ATAK→mesh path would do)."""
+    from meshtastic_tak import CotXmlParser
+
+    pli = tak.build_pli(
+        callsign="Mesa-3",
+        uid="MESH-1234abcd",
+        team=10,
+        role=1,
+        lat_i=360_000_000,
+        lon_i=-1_150_000_000,
+        altitude=800,
+        speed=0,
+        course=0,
+        battery=55,
+    )
+    cot = _bridge_to_cot(tak.compress(pli))
+    back = CotXmlParser().parse(cot)
+    assert back.uid == "MESH-1234abcd"
+    assert back.callsign == "Mesa-3"

--- a/tests/unit/test_tak_server.py
+++ b/tests/unit/test_tak_server.py
@@ -1,0 +1,118 @@
+# SPDX-FileCopyrightText: Meshtastic contributors
+# SPDX-License-Identifier: GPL-3.0-only
+
+"""CoT streaming TAK server — the app-plane stimulus a TAK client connects to.
+
+Exercises the same server the Android ATAK e2e loop drives, but with a local
+socket client instead of ATAK: it asserts the sim's TAK squad is delivered as
+well-formed, live CoT over the TAK TCP stream. SDK-gated ([tak] extra).
+"""
+
+from __future__ import annotations
+
+import socket
+import time
+import xml.etree.ElementTree as ET
+
+import pytest
+
+from meshtastic_mcp.replay import sim, tak, tak_server
+
+requires_tak = pytest.mark.skipif(not tak.available(), reason="[tak] extra not installed")
+
+
+def _squad_capture():
+    prof = {"tak": {"team_nodes": 4, "pli_interval": 60, "chat_per_hour": 2, "wire": "v2"}}
+    return sim.generate(nodes=120, days=1, seed=8, start=1_700_000_000, profile=prof)
+
+
+@requires_tak
+def test_capture_to_cot_events_are_wellformed():
+    events = tak_server.capture_to_cot_events(_squad_capture())
+    assert events
+    # time-ordered, each a bare CoT <event> (no XML declaration)
+    times = [t for t, _ in events]
+    assert times == sorted(times)
+    callsigns = set()
+    for _t, cot in events:
+        assert not cot.lstrip().startswith(b"<?xml")
+        root = ET.fromstring(cot)
+        assert root.tag == "event"
+        assert root.attrib["uid"].startswith("MESH-")
+        contact = root.find("detail/contact")
+        assert contact is not None
+        callsigns.add(contact.attrib.get("callsign", ""))
+    assert len(callsigns) == 4
+
+
+@requires_tak
+def test_server_streams_live_cot_to_a_client():
+    events = tak_server.capture_to_cot_events(_squad_capture())
+    # fast + looped so the client reliably gets several events quickly
+    srv = tak_server.CotTakServer(events, host="127.0.0.1", port=0, speed=100_000.0, loop=True)
+    port = srv.start()
+    try:
+        with socket.create_connection(("127.0.0.1", port), timeout=5) as c:
+            c.settimeout(5)
+            buf = b""
+            deadline = time.time() + 5
+            while b"</event>" not in buf and time.time() < deadline:
+                buf += c.recv(4096)
+        assert b"<event" in buf and b"</event>" in buf
+        # parse the first complete event and check it's live + typed
+        first = buf[buf.index(b"<event") : buf.index(b"</event>") + len(b"</event>")]
+        root = ET.fromstring(first)
+        assert root.attrib["uid"].startswith("MESH-")
+        # restamped to "now" (year matches current UTC), not the 2023 capture epoch
+        assert root.attrib["time"].startswith(time.strftime("%Y", time.gmtime()))
+    finally:
+        srv.stop()
+    assert srv.clients_served >= 1 and srv.events_sent >= 1
+
+
+@requires_tak
+def test_server_is_bidirectional_receives_client_cot():
+    """Send leg (TAK client -> mesh): a client-authored CoT event sent to the
+    server is captured and converts to a mesh TAKPacketV2."""
+    from meshtastic_mcp.replay import tak
+
+    events = tak_server.capture_to_cot_events(_squad_capture())
+    srv = tak_server.CotTakServer(events, host="127.0.0.1", port=0, speed=100_000.0, loop=True)
+    port = srv.start()
+    client_cot = (
+        '<event version="2.0" uid="ANDROID-r1" type="a-f-G-U-C" how="m-g" '
+        'time="2026-01-01T00:00:00Z" start="2026-01-01T00:00:00Z" '
+        'stale="2026-01-01T00:05:00Z"><point lat="40.79" lon="-119.21" hae="1200" '
+        'ce="9.9" le="9.9"/><detail><contact callsign="RANGER-1"/>'
+        '<__group name="Cyan" role="Team Member"/></detail></event>'
+    )
+    try:
+        with socket.create_connection(("127.0.0.1", port), timeout=5) as c:
+            c.settimeout(5)
+            c.recv(4096)  # let the receive leg stream at least once
+            c.sendall(client_cot.encode())
+            deadline = time.time() + 5
+            while not srv.received_cot and time.time() < deadline:
+                time.sleep(0.1)
+        assert srv.received_cot, "server should capture the client's CoT"
+        pkt = tak.parse_cot(srv.received_cot[0].decode())
+        assert pkt.uid == "ANDROID-r1" and pkt.callsign == "RANGER-1"
+        assert tak.compress(pkt)  # converts to a mesh payload
+    finally:
+        srv.stop()
+
+
+@requires_tak
+def test_server_context_manager_and_no_v2_is_empty():
+    # a v1 (legacy) squad yields no CoT-v2 events (server needs wire="v2")
+    v1 = sim.generate(
+        nodes=60, days=1, seed=2, start=1_700_000_000, profile={"tak": {"team_nodes": 3}}
+    )
+    assert tak_server.capture_to_cot_events(v1) == []
+
+
+def test_capture_to_cot_events_requires_extra(monkeypatch):
+    # without the SDK the bridge path fails fast with the install hint
+    monkeypatch.setattr(tak, "available", lambda: False)
+    with pytest.raises(RuntimeError, match=r"\[tak\] extra"):
+        tak_server.capture_to_cot_events(sim.generate(nodes=10, days=1, seed=1))

--- a/tools/import_defcon_logs.py
+++ b/tools/import_defcon_logs.py
@@ -136,6 +136,13 @@ def _upsert_node(conn: sqlite3.Connection, mp: mesh_pb2.MeshPacket) -> None:
         except Exception:
             return
         if pos.latitude_i or pos.longitude_i:
+            # A node's first-seen record is often a POSITION (beacons outnumber
+            # NodeInfo), so ensure a row exists before updating — a bare UPDATE
+            # would silently drop the fix.
+            conn.execute(
+                "INSERT INTO node (id, node_id) VALUES (?,?) ON CONFLICT(node_id) DO NOTHING",
+                (f"!{frm:08x}", frm),
+            )
             conn.execute(
                 "UPDATE node SET last_lat=?, last_long=? WHERE node_id=?",
                 (pos.latitude_i, pos.longitude_i, frm),

--- a/tools/import_defcon_logs.py
+++ b/tools/import_defcon_logs.py
@@ -1,0 +1,209 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Meshtastic contributors
+# SPDX-License-Identifier: GPL-3.0-only
+
+"""Convert DEF CON 33-style gateway text logs into the shared capture SQLite schema.
+
+The darknet-ng DEF CON 33 dataset is ``str(dict)`` dumps from the meshtastic
+Python library — one received packet per record, each carrying a top-level
+``'raw': <text-format MeshPacket>`` block. This tool parses that MeshPacket,
+stores it as ``packet.payload`` (a full serialized MeshPacket — the same shape
+as the Burning Man capture), records every individual reception in
+``packet_seen`` (duplicates = rebroadcast copies the gateway heard), and builds
+the ``node`` table from NODEINFO/POSITION packets. The result loads with
+``meshtastic_mcp.replay.capture.from_sqlite`` and scores with
+``meshtastic_mcp.replay.metrics``.
+
+Usage:
+    python tools/import_defcon_logs.py --out defcon33.db <log.txt> [<log2.txt> ...]
+
+Channel name per record is inferred from the filename's modem preset
+(``LongFast`` / ``ShortTurbo``); override with ``--channel``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sqlite3
+import sys
+import zlib
+from collections.abc import Iterator
+from pathlib import Path
+
+from google.protobuf import text_format
+from meshtastic.protobuf import config_pb2, mesh_pb2
+
+SCHEMA = """
+CREATE TABLE IF NOT EXISTS node (
+    id VARCHAR NOT NULL, node_id BIGINT, long_name VARCHAR, short_name VARCHAR,
+    hw_model VARCHAR, firmware VARCHAR, role VARCHAR, last_lat BIGINT,
+    last_long BIGINT, channel VARCHAR, last_update DATETIME,
+    PRIMARY KEY (id), UNIQUE (node_id));
+CREATE TABLE IF NOT EXISTS packet (
+    id BIGINT NOT NULL, portnum INTEGER, from_node_id BIGINT, to_node_id BIGINT,
+    payload BLOB, import_time DATETIME, channel VARCHAR, PRIMARY KEY (id));
+CREATE TABLE IF NOT EXISTS packet_seen (
+    packet_id BIGINT NOT NULL, node_id BIGINT NOT NULL, rx_time BIGINT NOT NULL,
+    hop_limit INTEGER, hop_start INTEGER, channel VARCHAR, rx_snr FLOAT,
+    rx_rssi INTEGER, topic VARCHAR, import_time DATETIME,
+    PRIMARY KEY (packet_id, node_id, rx_time));
+"""
+
+# The top-level MeshPacket text block always starts at `from:`; nested `raw:`
+# blocks (telemetry starts at `time:`, User starts at `id:`) never do.
+RAW_RE = re.compile(r"'raw': (from:.*?)(?=, 'fromId'|, 'toId'|\}\s*$)", re.S)
+
+
+def _records(path: Path) -> Iterator[str]:
+    """Yield one str(dict) record at a time (records start with ``{'from'``)."""
+    rec: list[str] = []
+    with path.open(errors="replace") as fh:
+        for line in fh:
+            if line.startswith("{'from'") and rec:
+                yield "".join(rec)
+                rec = [line]
+            else:
+                rec.append(line)
+    if rec:
+        yield "".join(rec)
+
+
+def _channel_for(path: Path, override: str | None) -> str:
+    if override:
+        return override
+    name = path.name.lower()
+    if "shortturbo" in name or "short_turbo" in name:
+        return "ShortTurbo"
+    return "LongFast"
+
+
+def _gateway_id(path: Path) -> int:
+    """Stable synthetic node id per source file (0xDF-prefixed, non-colliding)."""
+    return 0xDF000000 | (zlib.crc32(path.name.encode()) & 0x00FFFFFF)
+
+
+def _parse_packet(record: str) -> mesh_pb2.MeshPacket | None:
+    m = RAW_RE.search(record)
+    if not m:
+        return None
+    mp = mesh_pb2.MeshPacket()
+    try:
+        text_format.Parse(m.group(1), mp, allow_unknown_field=True)
+    except text_format.ParseError:
+        return None
+    return mp
+
+
+def _enum_name(enum_type: object, value: int) -> str:
+    """Enum name, falling back to the numeric value for enums newer than our protos."""
+    try:
+        return enum_type.Name(value)  # type: ignore[attr-defined]
+    except ValueError:
+        return str(value)
+
+
+def _upsert_node(conn: sqlite3.Connection, mp: mesh_pb2.MeshPacket) -> None:
+    frm = getattr(mp, "from") & 0xFFFFFFFF
+    pn = mp.decoded.portnum
+    if pn == 4:  # NODEINFO -> User
+        user = mesh_pb2.User()
+        try:
+            user.ParseFromString(mp.decoded.payload)
+        except Exception:
+            return
+        hw = _enum_name(mesh_pb2.HardwareModel, user.hw_model) if user.hw_model else None
+        role = _enum_name(config_pb2.Config.DeviceConfig.Role, user.role) if user.role else "CLIENT"
+        conn.execute(
+            "INSERT INTO node (id, node_id, long_name, short_name, hw_model, role, last_update)"
+            " VALUES (?,?,?,?,?,?,?) ON CONFLICT(node_id) DO UPDATE SET"
+            " long_name=excluded.long_name, short_name=excluded.short_name,"
+            " hw_model=excluded.hw_model, role=excluded.role, last_update=excluded.last_update",
+            (
+                user.id or f"!{frm:08x}",
+                frm,
+                user.long_name,
+                user.short_name,
+                hw,
+                role,
+                mp.rx_time,
+            ),
+        )
+    elif pn == 3:  # POSITION -> last fix
+        pos = mesh_pb2.Position()
+        try:
+            pos.ParseFromString(mp.decoded.payload)
+        except Exception:
+            return
+        if pos.latitude_i or pos.longitude_i:
+            conn.execute(
+                "UPDATE node SET last_lat=?, last_long=? WHERE node_id=?",
+                (pos.latitude_i, pos.longitude_i, frm),
+            )
+
+
+def import_logs(out_db: str, paths: list[Path], channel: str | None = None) -> dict[str, int]:
+    conn = sqlite3.connect(out_db)
+    conn.executescript(SCHEMA)
+    stats = {"records": 0, "parsed": 0, "packets": 0, "seen": 0}
+    try:
+        for path in paths:
+            ch = _channel_for(path, channel)
+            gw = _gateway_id(path)
+            for record in _records(path):
+                stats["records"] += 1
+                mp = _parse_packet(record)
+                if mp is None:
+                    continue
+                stats["parsed"] += 1
+                pn = mp.decoded.portnum if mp.WhichOneof("payload_variant") == "decoded" else None
+                cur = conn.execute(
+                    "INSERT OR IGNORE INTO packet (id, portnum, from_node_id, to_node_id,"
+                    " payload, channel) VALUES (?,?,?,?,?,?)",
+                    (
+                        mp.id,
+                        pn,
+                        getattr(mp, "from") & 0xFFFFFFFF,
+                        mp.to & 0xFFFFFFFF,
+                        mp.SerializeToString(),
+                        ch,
+                    ),
+                )
+                stats["packets"] += cur.rowcount
+                cur = conn.execute(
+                    "INSERT OR IGNORE INTO packet_seen (packet_id, node_id, rx_time,"
+                    " hop_limit, hop_start, channel, rx_snr, rx_rssi) VALUES (?,?,?,?,?,?,?,?)",
+                    (
+                        mp.id,
+                        gw,
+                        mp.rx_time,
+                        mp.hop_limit,
+                        mp.hop_start,
+                        ch,
+                        round(mp.rx_snr, 2) if mp.rx_snr else None,
+                        mp.rx_rssi or None,
+                    ),
+                )
+                stats["seen"] += cur.rowcount
+                if pn in (3, 4):
+                    _upsert_node(conn, mp)
+            conn.commit()
+            print(f"{path.name}: cumulative {stats}", file=sys.stderr)
+        return stats
+    finally:
+        conn.commit()
+        conn.close()
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--out", required=True, help="output SQLite path")
+    ap.add_argument("--channel", help="force a channel name (default: infer from filename)")
+    ap.add_argument("logs", nargs="+", type=Path)
+    args = ap.parse_args()
+    stats = import_logs(args.out, args.logs, channel=args.channel)
+    print(stats)
+
+
+if __name__ == "__main__":
+    main()

--- a/uv.lock
+++ b/uv.lock
@@ -320,7 +320,7 @@ name = "clr-loader"
 version = "0.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cffi", marker = "sys_platform == 'win32'" },
+    { name = "cffi" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/e4/46/7eea92b6aa2d68af78e049cbecec5f757f1aad44ecdecdc16bbad7eead51/clr_loader-0.3.1.tar.gz", hash = "sha256:2e073e9aaf49d1ae2f56ecba27987ad5fb68be4bcd9dd34a5bed8f0e4e128366", size = 86805, upload-time = "2026-04-18T17:49:44.287Z" }
 wheels = [
@@ -486,7 +486,7 @@ name = "cuda-bindings"
 version = "13.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cuda-pathfinder", marker = "sys_platform != 'win32'" },
+    { name = "cuda-pathfinder" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/51/6b/457ca12dad3ee9bfcc9a545cfd6b64b359ba49de40f776f6e028e678f262/cuda_bindings-13.3.1-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c5879712accf6e14bb01aa5e67440eb84998b8d104b509cc7a6dc0b8f656a474", size = 6053539, upload-time = "2026-05-29T23:11:43.19Z" },
@@ -519,34 +519,34 @@ wheels = [
 
 [package.optional-dependencies]
 cudart = [
-    { name = "nvidia-cuda-runtime", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cuda-runtime" },
 ]
 cufft = [
-    { name = "nvidia-cufft", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cufft" },
 ]
 cufile = [
-    { name = "nvidia-cufile", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cufile" },
 ]
 cupti = [
-    { name = "nvidia-cuda-cupti", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cuda-cupti" },
 ]
 curand = [
-    { name = "nvidia-curand", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-curand" },
 ]
 cusolver = [
-    { name = "nvidia-cusolver", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cusolver" },
 ]
 cusparse = [
-    { name = "nvidia-cusparse", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cusparse" },
 ]
 nvjitlink = [
-    { name = "nvidia-nvjitlink", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-nvjitlink" },
 ]
 nvrtc = [
-    { name = "nvidia-cuda-nvrtc", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cuda-nvrtc" },
 ]
 nvtx = [
-    { name = "nvidia-nvtx", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-nvtx" },
 ]
 
 [[package]]
@@ -1081,6 +1081,9 @@ sdr = [
     { name = "pyrtlsdr" },
     { name = "pyrtlsdrlib" },
 ]
+tak = [
+    { name = "meshtastic-tak" },
+]
 test = [
     { name = "coverage", extra = ["toml"] },
     { name = "pytest" },
@@ -1121,6 +1124,7 @@ requires-dist = [
     { name = "fastapi", marker = "extra == 'web'", specifier = ">=0.110" },
     { name = "mcp", specifier = ">=1.2" },
     { name = "meshtastic", specifier = ">=2.7.8" },
+    { name = "meshtastic-tak", marker = "extra == 'tak'", git = "https://github.com/meshtastic/TAKPacket-SDK.git?subdirectory=python" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.10" },
     { name = "numpy", marker = "extra == 'sdr'", specifier = ">=1.26" },
     { name = "numpy", marker = "extra == 'ui'", specifier = ">=1.26" },
@@ -1147,7 +1151,16 @@ requires-dist = [
     { name = "textual", marker = "extra == 'test'", specifier = ">=0.50" },
     { name = "uvicorn", extras = ["standard"], marker = "extra == 'web'", specifier = ">=0.27" },
 ]
-provides-extras = ["dev", "sdr", "test", "ui", "ui-min", "web"]
+provides-extras = ["dev", "sdr", "tak", "test", "ui", "ui-min", "web"]
+
+[[package]]
+name = "meshtastic-tak"
+version = "0.7.0"
+source = { git = "https://github.com/meshtastic/TAKPacket-SDK.git?subdirectory=python#eaa279706c5d8d441a9028a1013c142aa9c799ff" }
+dependencies = [
+    { name = "protobuf" },
+    { name = "zstandard" },
+]
 
 [[package]]
 name = "mpmath"
@@ -1400,7 +1413,7 @@ name = "nvidia-cublas"
 version = "13.1.1.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cuda-nvrtc", marker = "sys_platform != 'win32'" },
+    { name = "nvidia-cuda-nvrtc" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a7/a1/0bd24ee8c8d03adac032fd2909426a00c88f8c57961b1277ded97f91119f/nvidia_cublas-13.1.1.3-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:b7a210458267ac818974c53038fbec2e969d5c99f305ab15c72522fa9f001dd5", size = 542848918, upload-time = "2026-04-08T18:46:22.985Z" },
@@ -1439,7 +1452,7 @@ name = "nvidia-cudnn-cu13"
 version = "9.20.0.48"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas", marker = "sys_platform != 'win32'" },
+    { name = "nvidia-cublas" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/56/c5/83384d846b2fd17c44bd499b36c75a45ed4f095fbbb2252294e89cea5c5c/nvidia_cudnn_cu13-9.20.0.48-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:e31454ae00094b0c55319d9d15b6fa2fc50a9e1c0f5c8c80fb75258234e731e1", size = 444574296, upload-time = "2026-03-09T19:28:27.751Z" },
@@ -1451,7 +1464,7 @@ name = "nvidia-cufft"
 version = "12.0.0.61"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink", marker = "sys_platform != 'win32'" },
+    { name = "nvidia-nvjitlink" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8b/ae/f417a75c0259e85c1d2f83ca4e960289a5f814ed0cea74d18c353d3e989d/nvidia_cufft-12.0.0.61-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:2708c852ef8cd89d1d2068bdbece0aa188813a0c934db3779b9b1faa8442e5f5", size = 214053554, upload-time = "2025-09-04T08:31:38.196Z" },
@@ -1481,9 +1494,9 @@ name = "nvidia-cusolver"
 version = "12.0.4.66"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas", marker = "sys_platform != 'win32'" },
-    { name = "nvidia-cusparse", marker = "sys_platform != 'win32'" },
-    { name = "nvidia-nvjitlink", marker = "sys_platform != 'win32'" },
+    { name = "nvidia-cublas" },
+    { name = "nvidia-cusparse" },
+    { name = "nvidia-nvjitlink" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c8/c3/b30c9e935fc01e3da443ec0116ed1b2a009bb867f5324d3f2d7e533e776b/nvidia_cusolver-12.0.4.66-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:02c2457eaa9e39de20f880f4bd8820e6a1cfb9f9a34f820eb12a155aa5bc92d2", size = 223467760, upload-time = "2025-09-04T08:33:04.222Z" },
@@ -1495,7 +1508,7 @@ name = "nvidia-cusparse"
 version = "12.6.3.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink", marker = "sys_platform != 'win32'" },
+    { name = "nvidia-nvjitlink" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f8/94/5c26f33738ae35276672f12615a64bd008ed5be6d1ebcb23579285d960a9/nvidia_cusparse-12.6.3.3-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:80bcc4662f23f1054ee334a15c72b8940402975e0eab63178fc7e670aa59472c", size = 162155568, upload-time = "2025-09-04T08:33:42.864Z" },
@@ -1931,7 +1944,7 @@ name = "pyobjc-framework-cocoa"
 version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pyobjc-core", marker = "sys_platform != 'win32'" },
+    { name = "pyobjc-core" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/51/34/fbe38a204643aa4e1b91391cdce07a34da565a69171ebcad08de7438a556/pyobjc_framework_cocoa-12.2.1.tar.gz", hash = "sha256:b94b37fe5730e5ae1fb0052912cd174e6ec329b0bfba4a012ae5db1014b5864b", size = 3125751, upload-time = "2026-06-19T16:20:05.159Z" }
 wheels = [
@@ -1950,8 +1963,8 @@ name = "pyobjc-framework-corebluetooth"
 version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pyobjc-core", marker = "sys_platform != 'win32'" },
-    { name = "pyobjc-framework-cocoa", marker = "sys_platform != 'win32'" },
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/d4/91/c76f3c5e8e80c7047e43c4c05b3e6fda9a7cefad5aae85487007674c966c/pyobjc_framework_corebluetooth-12.2.1.tar.gz", hash = "sha256:7dbb285295097205bebbcb11f55161e5faa02111108fb7b17536176e31971eb0", size = 37568, upload-time = "2026-06-19T16:20:12.191Z" }
 wheels = [
@@ -1970,8 +1983,8 @@ name = "pyobjc-framework-libdispatch"
 version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pyobjc-core", marker = "sys_platform != 'win32'" },
-    { name = "pyobjc-framework-cocoa", marker = "sys_platform != 'win32'" },
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/d9/3f/561653aff3f19873457c95c053f0298da517be89fdfc0ec35115ed5b7030/pyobjc_framework_libdispatch-12.2.1.tar.gz", hash = "sha256:0d24eda41c6c258135077f60d410e704bc7b5a67adcb2ca463918896c7363795", size = 40336, upload-time = "2026-06-19T16:20:56.371Z" }
 wheels = [
@@ -1990,8 +2003,8 @@ name = "pyobjc-framework-quartz"
 version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pyobjc-core", marker = "sys_platform != 'win32'" },
-    { name = "pyobjc-framework-cocoa", marker = "sys_platform != 'win32'" },
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/3b/f6/2a8b84dbf1fe7c04dd96ea73d991678d4e09a909f51971ecc51629bb2ab4/pyobjc_framework_quartz-12.2.1.tar.gz", hash = "sha256:b3b8b6f71e66147f8ff9e6213864cc8527e3a0b1ee90835b93ce221f4802d9b0", size = 3215521, upload-time = "2026-06-19T16:21:30.199Z" }
 wheels = [
@@ -2010,8 +2023,8 @@ name = "pyobjc-framework-security"
 version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pyobjc-core", marker = "sys_platform != 'win32'" },
-    { name = "pyobjc-framework-cocoa", marker = "sys_platform != 'win32'" },
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/44/b8/4267b802d8dba6de468e7d0765b05cc4e146fa376ed9f55e0b6461016bef/pyobjc_framework_security-12.2.1.tar.gz", hash = "sha256:d7831b1537f4346892e7f2f0e2b09d79bee98919b0767f4061278d0e03028f2d", size = 181065, upload-time = "2026-06-19T16:21:40.151Z" }
 wheels = [
@@ -2030,8 +2043,8 @@ name = "pyobjc-framework-uniformtypeidentifiers"
 version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pyobjc-core", marker = "sys_platform != 'win32'" },
-    { name = "pyobjc-framework-cocoa", marker = "sys_platform != 'win32'" },
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/74/a1/108fa1e5a3dd8aff626f98fb97de370323b290404b04ffa2ef9420665ed3/pyobjc_framework_uniformtypeidentifiers-12.2.1.tar.gz", hash = "sha256:1fb89d13aa3c2df8e6d6536f6df3493fe5a6caefd2a5adebf17c5af3b29ed4a2", size = 20679, upload-time = "2026-06-19T16:21:55.739Z" }
 wheels = [
@@ -2043,8 +2056,8 @@ name = "pyobjc-framework-webkit"
 version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pyobjc-core", marker = "sys_platform != 'win32'" },
-    { name = "pyobjc-framework-cocoa", marker = "sys_platform != 'win32'" },
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/11/d2/b230c594f70ecb970b4cef67bae2648d1bfa5b381e9b7e3710bf24ec8887/pyobjc_framework_webkit-12.2.1.tar.gz", hash = "sha256:a56acae55b50d549b20dff2921ad1099add8fbc377d0de09ddc2ba50957f7def", size = 332374, upload-time = "2026-06-19T16:22:01.988Z" }
 wheels = [
@@ -2317,7 +2330,7 @@ name = "pythonnet"
 version = "3.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "clr-loader", marker = "sys_platform == 'win32'" },
+    { name = "clr-loader" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/05/57/da1992e44663b71365c6e842c8d7fa453d4ec45fb99a68cfee5b7e944d3c/pythonnet-3.1.0.tar.gz", hash = "sha256:7b34c382905d10a371509ffafd64cae0416305c28817738a9cd138336f4e9991", size = 250599, upload-time = "2026-05-23T20:30:21.578Z" }
 wheels = [
@@ -2429,7 +2442,7 @@ name = "qtpy"
 version = "2.4.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "packaging", marker = "sys_platform != 'win32'" },
+    { name = "packaging" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/70/01/392eba83c8e47b946b929d7c46e0f04b35e9671f8bb6fc36b6f7945b4de8/qtpy-2.4.3.tar.gz", hash = "sha256:db744f7832e6d3da90568ba6ccbca3ee2b3b4a890c3d6fbbc63142f6e4cdf5bb", size = 66982, upload-time = "2025-02-11T15:09:25.759Z" }
 wheels = [
@@ -2731,7 +2744,7 @@ resolution-markers = [
     "python_full_version < '3.12' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/7a/97/5a3609c4f8d58b039179648e62dd220f89864f56f7357f5d4f45c29eb2cc/scipy-1.17.1.tar.gz", hash = "sha256:95d8e012d8cb8816c226aef832200b1d45109ed4464303e997c5b13122b297c0", size = 30573822, upload-time = "2026-02-23T00:26:24.851Z" }
 wheels = [
@@ -2810,7 +2823,7 @@ resolution-markers = [
     "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.5.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "numpy", version = "2.5.0", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a7/25/c2700dfaf6442b4effaa91af24ebce5dc9d31bb4a69706313aae70d72cd0/scipy-1.18.0.tar.gz", hash = "sha256:67b2ad2ad54c72ca6d04975a9b2df8c3638c34ddd5b28738e94fc2b57929d378", size = 30774447, upload-time = "2026-06-19T15:01:43.456Z" }
 wheels = [
@@ -2998,7 +3011,7 @@ resolution-markers = [
     "python_full_version < '3.12' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c5/cb/2f6d79c7576e22c116352a801f4c3c8ace5957e9aced862012430b62e14f/tifffile-2026.3.3.tar.gz", hash = "sha256:d9a1266bed6f2ee1dd0abde2018a38b4f8b2935cb843df381d70ac4eac5458b7", size = 388745, upload-time = "2026-03-03T19:14:38.134Z" }
 wheels = [
@@ -3018,7 +3031,7 @@ resolution-markers = [
     "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.5.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "numpy", version = "2.5.0", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b7/38/5e2ecef5af2f4fd4a89bb8d6240de9458bab4d51a4cbd97aeb3a0cd618e2/tifffile-2026.6.1.tar.gz", hash = "sha256:626c892c0e899d959b9438e7c0e1491dc154a7fead1f1f37a991724a50eceba9", size = 429694, upload-time = "2026-05-31T23:57:12.165Z" }
 wheels = [
@@ -3442,7 +3455,7 @@ name = "winrt-runtime"
 version = "3.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "sys_platform == 'win32'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/16/dd/acdd527c1d890c8f852cc2af644aa6c160974e66631289420aa871b05e65/winrt_runtime-3.2.1.tar.gz", hash = "sha256:c8dca19e12b234ae6c3dadf1a4d0761b51e708457492c13beb666556958801ea", size = 21721, upload-time = "2025-06-06T14:40:27.593Z" }
 wheels = [
@@ -3465,7 +3478,7 @@ name = "winrt-windows-devices-bluetooth"
 version = "3.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "winrt-runtime", marker = "sys_platform == 'win32'" },
+    { name = "winrt-runtime" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b2/a0/1c8a0c469abba7112265c6cb52f0090d08a67c103639aee71fc690e614b8/winrt_windows_devices_bluetooth-3.2.1.tar.gz", hash = "sha256:db496d2d92742006d5a052468fc355bf7bb49e795341d695c374746113d74505", size = 23732, upload-time = "2025-06-06T14:41:20.489Z" }
 wheels = [
@@ -3488,7 +3501,7 @@ name = "winrt-windows-devices-bluetooth-advertisement"
 version = "3.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "winrt-runtime", marker = "sys_platform == 'win32'" },
+    { name = "winrt-runtime" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/06/fc/7ffe66ca4109b9e994b27c00f3d2d506e6e549e268791f755287ad9106d8/winrt_windows_devices_bluetooth_advertisement-3.2.1.tar.gz", hash = "sha256:0223852a7b7fa5c8dea3c6a93473bd783df4439b1ed938d9871f947933e574cc", size = 16906, upload-time = "2025-06-06T14:41:21.448Z" }
 wheels = [
@@ -3511,7 +3524,7 @@ name = "winrt-windows-devices-bluetooth-genericattributeprofile"
 version = "3.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "winrt-runtime", marker = "sys_platform == 'win32'" },
+    { name = "winrt-runtime" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/44/21/aeeddc0eccdfbd25e543360b5cc093233e2eab3cdfb53ad3cabae1b5d04d/winrt_windows_devices_bluetooth_genericattributeprofile-3.2.1.tar.gz", hash = "sha256:cdf6ddc375e9150d040aca67f5a17c41ceaf13a63f3668f96608bc1d045dde71", size = 38896, upload-time = "2025-06-06T14:41:22.687Z" }
 wheels = [
@@ -3534,7 +3547,7 @@ name = "winrt-windows-devices-enumeration"
 version = "3.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "winrt-runtime", marker = "sys_platform == 'win32'" },
+    { name = "winrt-runtime" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/9e/dd/75835bfbd063dffa152109727dedbd80f6e92ea284855f7855d48cdf31c9/winrt_windows_devices_enumeration-3.2.1.tar.gz", hash = "sha256:df316899e39bfc0ffc1f3cb0f5ee54d04e1d167fbbcc1484d2d5121449a935cf", size = 23538, upload-time = "2025-06-06T14:41:26.787Z" }
 wheels = [
@@ -3557,7 +3570,7 @@ name = "winrt-windows-devices-radios"
 version = "3.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "winrt-runtime", marker = "sys_platform == 'win32'" },
+    { name = "winrt-runtime" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/5e/02/9704ea359ad8b0d6faa1011f98fb477e8fb6eac5201f39d19e73c2407e7b/winrt_windows_devices_radios-3.2.1.tar.gz", hash = "sha256:4dc9b9d1501846049eb79428d64ec698d6476c27a357999b78a8331072e18a0b", size = 5908, upload-time = "2025-06-06T14:41:44.868Z" }
 wheels = [
@@ -3580,7 +3593,7 @@ name = "winrt-windows-foundation"
 version = "3.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "winrt-runtime", marker = "sys_platform == 'win32'" },
+    { name = "winrt-runtime" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0c/55/098ce7ea0679efcc1298b269c48768f010b6c68f90c588f654ec874c8a74/winrt_windows_foundation-3.2.1.tar.gz", hash = "sha256:ad2f1fcaa6c34672df45527d7c533731fdf65b67c4638c2b4aca949f6eec0656", size = 30485, upload-time = "2025-06-06T14:41:53.344Z" }
 wheels = [
@@ -3603,7 +3616,7 @@ name = "winrt-windows-foundation-collections"
 version = "3.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "winrt-runtime", marker = "sys_platform == 'win32'" },
+    { name = "winrt-runtime" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ef/62/d21e3f1eeb8d47077887bbf0c3882c49277a84d8f98f7c12bda64d498a07/winrt_windows_foundation_collections-3.2.1.tar.gz", hash = "sha256:0eff1ad0d8d763ad17e9e7bbd0c26a62b27215016393c05b09b046d6503ae6d5", size = 16043, upload-time = "2025-06-06T14:41:53.983Z" }
 wheels = [
@@ -3626,7 +3639,7 @@ name = "winrt-windows-storage-streams"
 version = "3.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "winrt-runtime", marker = "sys_platform == 'win32'" },
+    { name = "winrt-runtime" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/00/50/f4488b07281566e3850fcae1021f0285c9653992f60a915e15567047db63/winrt_windows_storage_streams-3.2.1.tar.gz", hash = "sha256:476f522722751eb0b571bc7802d85a82a3cae8b1cce66061e6e758f525e7b80f", size = 34335, upload-time = "2025-06-06T14:43:23.905Z" }
 wheels = [
@@ -3642,4 +3655,78 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/55/70/2869ea2112c565caace73c9301afd1d7afcc49bdd37fac058f0178ba95d4/winrt_windows_storage_streams-3.2.1-cp314-cp314-win32.whl", hash = "sha256:5cd0dbad86fcc860366f6515fce97177b7eaa7069da261057be4813819ba37ee", size = 131701, upload-time = "2025-09-20T07:17:16.849Z" },
     { url = "https://files.pythonhosted.org/packages/f4/3d/aae50b1d0e37b5a61055759aedd42c6c99d7c17ab8c3e568ab33c0288938/winrt_windows_storage_streams-3.2.1-cp314-cp314-win_amd64.whl", hash = "sha256:3c5bf41d725369b9986e6d64bad7079372b95c329897d684f955d7028c7f27a0", size = 135566, upload-time = "2025-09-20T07:17:17.69Z" },
     { url = "https://files.pythonhosted.org/packages/bb/c3/6d3ce7a58e6c828e0795c9db8790d0593dd7fdf296e513c999150deb98d4/winrt_windows_storage_streams-3.2.1-cp314-cp314-win_arm64.whl", hash = "sha256:293e09825559d0929bbe5de01e1e115f7a6283d8996ab55652e5af365f032987", size = 134393, upload-time = "2025-09-20T07:17:18.802Z" },
+]
+
+[[package]]
+name = "zstandard"
+version = "0.25.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fd/aa/3e0508d5a5dd96529cdc5a97011299056e14c6505b678fd58938792794b1/zstandard-0.25.0.tar.gz", hash = "sha256:7713e1179d162cf5c7906da876ec2ccb9c3a9dcbdffef0cc7f70c3667a205f0b", size = 711513, upload-time = "2025-09-14T22:15:54.002Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/83/c3ca27c363d104980f1c9cee1101cc8ba724ac8c28a033ede6aab89585b1/zstandard-0.25.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:933b65d7680ea337180733cf9e87293cc5500cc0eb3fc8769f4d3c88d724ec5c", size = 795254, upload-time = "2025-09-14T22:16:26.137Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/4d/e66465c5411a7cf4866aeadc7d108081d8ceba9bc7abe6b14aa21c671ec3/zstandard-0.25.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:a3f79487c687b1fc69f19e487cd949bf3aae653d181dfb5fde3bf6d18894706f", size = 640559, upload-time = "2025-09-14T22:16:27.973Z" },
+    { url = "https://files.pythonhosted.org/packages/12/56/354fe655905f290d3b147b33fe946b0f27e791e4b50a5f004c802cb3eb7b/zstandard-0.25.0-cp311-cp311-manylinux2010_i686.manylinux2014_i686.manylinux_2_12_i686.manylinux_2_17_i686.whl", hash = "sha256:0bbc9a0c65ce0eea3c34a691e3c4b6889f5f3909ba4822ab385fab9057099431", size = 5348020, upload-time = "2025-09-14T22:16:29.523Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/13/2b7ed68bd85e69a2069bcc72141d378f22cae5a0f3b353a2c8f50ef30c1b/zstandard-0.25.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:01582723b3ccd6939ab7b3a78622c573799d5d8737b534b86d0e06ac18dbde4a", size = 5058126, upload-time = "2025-09-14T22:16:31.811Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/dd/fdaf0674f4b10d92cb120ccff58bbb6626bf8368f00ebfd2a41ba4a0dc99/zstandard-0.25.0-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:5f1ad7bf88535edcf30038f6919abe087f606f62c00a87d7e33e7fc57cb69fcc", size = 5405390, upload-time = "2025-09-14T22:16:33.486Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/67/354d1555575bc2490435f90d67ca4dd65238ff2f119f30f72d5cde09c2ad/zstandard-0.25.0-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:06acb75eebeedb77b69048031282737717a63e71e4ae3f77cc0c3b9508320df6", size = 5452914, upload-time = "2025-09-14T22:16:35.277Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/1f/e9cfd801a3f9190bf3e759c422bbfd2247db9d7f3d54a56ecde70137791a/zstandard-0.25.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:9300d02ea7c6506f00e627e287e0492a5eb0371ec1670ae852fefffa6164b072", size = 5559635, upload-time = "2025-09-14T22:16:37.141Z" },
+    { url = "https://files.pythonhosted.org/packages/21/88/5ba550f797ca953a52d708c8e4f380959e7e3280af029e38fbf47b55916e/zstandard-0.25.0-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:bfd06b1c5584b657a2892a6014c2f4c20e0db0208c159148fa78c65f7e0b0277", size = 5048277, upload-time = "2025-09-14T22:16:38.807Z" },
+    { url = "https://files.pythonhosted.org/packages/46/c0/ca3e533b4fa03112facbe7fbe7779cb1ebec215688e5df576fe5429172e0/zstandard-0.25.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:f373da2c1757bb7f1acaf09369cdc1d51d84131e50d5fa9863982fd626466313", size = 5574377, upload-time = "2025-09-14T22:16:40.523Z" },
+    { url = "https://files.pythonhosted.org/packages/12/9b/3fb626390113f272abd0799fd677ea33d5fc3ec185e62e6be534493c4b60/zstandard-0.25.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:6c0e5a65158a7946e7a7affa6418878ef97ab66636f13353b8502d7ea03c8097", size = 4961493, upload-time = "2025-09-14T22:16:43.3Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/d3/23094a6b6a4b1343b27ae68249daa17ae0651fcfec9ed4de09d14b940285/zstandard-0.25.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:c8e167d5adf59476fa3e37bee730890e389410c354771a62e3c076c86f9f7778", size = 5269018, upload-time = "2025-09-14T22:16:45.292Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/a7/bb5a0c1c0f3f4b5e9d5b55198e39de91e04ba7c205cc46fcb0f95f0383c1/zstandard-0.25.0-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:98750a309eb2f020da61e727de7d7ba3c57c97cf6213f6f6277bb7fb42a8e065", size = 5443672, upload-time = "2025-09-14T22:16:47.076Z" },
+    { url = "https://files.pythonhosted.org/packages/27/22/503347aa08d073993f25109c36c8d9f029c7d5949198050962cb568dfa5e/zstandard-0.25.0-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:22a086cff1b6ceca18a8dd6096ec631e430e93a8e70a9ca5efa7561a00f826fa", size = 5822753, upload-time = "2025-09-14T22:16:49.316Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/be/94267dc6ee64f0f8ba2b2ae7c7a2df934a816baaa7291db9e1aa77394c3c/zstandard-0.25.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:72d35d7aa0bba323965da807a462b0966c91608ef3a48ba761678cb20ce5d8b7", size = 5366047, upload-time = "2025-09-14T22:16:51.328Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/a3/732893eab0a3a7aecff8b99052fecf9f605cf0fb5fb6d0290e36beee47a4/zstandard-0.25.0-cp311-cp311-win32.whl", hash = "sha256:f5aeea11ded7320a84dcdd62a3d95b5186834224a9e55b92ccae35d21a8b63d4", size = 436484, upload-time = "2025-09-14T22:16:55.005Z" },
+    { url = "https://files.pythonhosted.org/packages/43/a3/c6155f5c1cce691cb80dfd38627046e50af3ee9ddc5d0b45b9b063bfb8c9/zstandard-0.25.0-cp311-cp311-win_amd64.whl", hash = "sha256:daab68faadb847063d0c56f361a289c4f268706b598afbf9ad113cbe5c38b6b2", size = 506183, upload-time = "2025-09-14T22:16:52.753Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/3e/8945ab86a0820cc0e0cdbf38086a92868a9172020fdab8a03ac19662b0e5/zstandard-0.25.0-cp311-cp311-win_arm64.whl", hash = "sha256:22a06c5df3751bb7dc67406f5374734ccee8ed37fc5981bf1ad7041831fa1137", size = 462533, upload-time = "2025-09-14T22:16:53.878Z" },
+    { url = "https://files.pythonhosted.org/packages/82/fc/f26eb6ef91ae723a03e16eddb198abcfce2bc5a42e224d44cc8b6765e57e/zstandard-0.25.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:7b3c3a3ab9daa3eed242d6ecceead93aebbb8f5f84318d82cee643e019c4b73b", size = 795738, upload-time = "2025-09-14T22:16:56.237Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/1c/d920d64b22f8dd028a8b90e2d756e431a5d86194caa78e3819c7bf53b4b3/zstandard-0.25.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:913cbd31a400febff93b564a23e17c3ed2d56c064006f54efec210d586171c00", size = 640436, upload-time = "2025-09-14T22:16:57.774Z" },
+    { url = "https://files.pythonhosted.org/packages/53/6c/288c3f0bd9fcfe9ca41e2c2fbfd17b2097f6af57b62a81161941f09afa76/zstandard-0.25.0-cp312-cp312-manylinux2010_i686.manylinux2014_i686.manylinux_2_12_i686.manylinux_2_17_i686.whl", hash = "sha256:011d388c76b11a0c165374ce660ce2c8efa8e5d87f34996aa80f9c0816698b64", size = 5343019, upload-time = "2025-09-14T22:16:59.302Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/15/efef5a2f204a64bdb5571e6161d49f7ef0fffdbca953a615efbec045f60f/zstandard-0.25.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:6dffecc361d079bb48d7caef5d673c88c8988d3d33fb74ab95b7ee6da42652ea", size = 5063012, upload-time = "2025-09-14T22:17:01.156Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/37/a6ce629ffdb43959e92e87ebdaeebb5ac81c944b6a75c9c47e300f85abdf/zstandard-0.25.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:7149623bba7fdf7e7f24312953bcf73cae103db8cae49f8154dd1eadc8a29ecb", size = 5394148, upload-time = "2025-09-14T22:17:03.091Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/79/2bf870b3abeb5c070fe2d670a5a8d1057a8270f125ef7676d29ea900f496/zstandard-0.25.0-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:6a573a35693e03cf1d67799fd01b50ff578515a8aeadd4595d2a7fa9f3ec002a", size = 5451652, upload-time = "2025-09-14T22:17:04.979Z" },
+    { url = "https://files.pythonhosted.org/packages/53/60/7be26e610767316c028a2cbedb9a3beabdbe33e2182c373f71a1c0b88f36/zstandard-0.25.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:5a56ba0db2d244117ed744dfa8f6f5b366e14148e00de44723413b2f3938a902", size = 5546993, upload-time = "2025-09-14T22:17:06.781Z" },
+    { url = "https://files.pythonhosted.org/packages/85/c7/3483ad9ff0662623f3648479b0380d2de5510abf00990468c286c6b04017/zstandard-0.25.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:10ef2a79ab8e2974e2075fb984e5b9806c64134810fac21576f0668e7ea19f8f", size = 5046806, upload-time = "2025-09-14T22:17:08.415Z" },
+    { url = "https://files.pythonhosted.org/packages/08/b3/206883dd25b8d1591a1caa44b54c2aad84badccf2f1de9e2d60a446f9a25/zstandard-0.25.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:aaf21ba8fb76d102b696781bddaa0954b782536446083ae3fdaa6f16b25a1c4b", size = 5576659, upload-time = "2025-09-14T22:17:10.164Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/31/76c0779101453e6c117b0ff22565865c54f48f8bd807df2b00c2c404b8e0/zstandard-0.25.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:1869da9571d5e94a85a5e8d57e4e8807b175c9e4a6294e3b66fa4efb074d90f6", size = 4953933, upload-time = "2025-09-14T22:17:11.857Z" },
+    { url = "https://files.pythonhosted.org/packages/18/e1/97680c664a1bf9a247a280a053d98e251424af51f1b196c6d52f117c9720/zstandard-0.25.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:809c5bcb2c67cd0ed81e9229d227d4ca28f82d0f778fc5fea624a9def3963f91", size = 5268008, upload-time = "2025-09-14T22:17:13.627Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/73/316e4010de585ac798e154e88fd81bb16afc5c5cb1a72eeb16dd37e8024a/zstandard-0.25.0-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:f27662e4f7dbf9f9c12391cb37b4c4c3cb90ffbd3b1fb9284dadbbb8935fa708", size = 5433517, upload-time = "2025-09-14T22:17:16.103Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/60/dd0f8cfa8129c5a0ce3ea6b7f70be5b33d2618013a161e1ff26c2b39787c/zstandard-0.25.0-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:99c0c846e6e61718715a3c9437ccc625de26593fea60189567f0118dc9db7512", size = 5814292, upload-time = "2025-09-14T22:17:17.827Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/5f/75aafd4b9d11b5407b641b8e41a57864097663699f23e9ad4dbb91dc6bfe/zstandard-0.25.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:474d2596a2dbc241a556e965fb76002c1ce655445e4e3bf38e5477d413165ffa", size = 5360237, upload-time = "2025-09-14T22:17:19.954Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/8d/0309daffea4fcac7981021dbf21cdb2e3427a9e76bafbcdbdf5392ff99a4/zstandard-0.25.0-cp312-cp312-win32.whl", hash = "sha256:23ebc8f17a03133b4426bcc04aabd68f8236eb78c3760f12783385171b0fd8bd", size = 436922, upload-time = "2025-09-14T22:17:24.398Z" },
+    { url = "https://files.pythonhosted.org/packages/79/3b/fa54d9015f945330510cb5d0b0501e8253c127cca7ebe8ba46a965df18c5/zstandard-0.25.0-cp312-cp312-win_amd64.whl", hash = "sha256:ffef5a74088f1e09947aecf91011136665152e0b4b359c42be3373897fb39b01", size = 506276, upload-time = "2025-09-14T22:17:21.429Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/6b/8b51697e5319b1f9ac71087b0af9a40d8a6288ff8025c36486e0c12abcc4/zstandard-0.25.0-cp312-cp312-win_arm64.whl", hash = "sha256:181eb40e0b6a29b3cd2849f825e0fa34397f649170673d385f3598ae17cca2e9", size = 462679, upload-time = "2025-09-14T22:17:23.147Z" },
+    { url = "https://files.pythonhosted.org/packages/35/0b/8df9c4ad06af91d39e94fa96cc010a24ac4ef1378d3efab9223cc8593d40/zstandard-0.25.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:ec996f12524f88e151c339688c3897194821d7f03081ab35d31d1e12ec975e94", size = 795735, upload-time = "2025-09-14T22:17:26.042Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/06/9ae96a3e5dcfd119377ba33d4c42a7d89da1efabd5cb3e366b156c45ff4d/zstandard-0.25.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:a1a4ae2dec3993a32247995bdfe367fc3266da832d82f8438c8570f989753de1", size = 640440, upload-time = "2025-09-14T22:17:27.366Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/14/933d27204c2bd404229c69f445862454dcc101cd69ef8c6068f15aaec12c/zstandard-0.25.0-cp313-cp313-manylinux2010_i686.manylinux2014_i686.manylinux_2_12_i686.manylinux_2_17_i686.whl", hash = "sha256:e96594a5537722fdfb79951672a2a63aec5ebfb823e7560586f7484819f2a08f", size = 5343070, upload-time = "2025-09-14T22:17:28.896Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/db/ddb11011826ed7db9d0e485d13df79b58586bfdec56e5c84a928a9a78c1c/zstandard-0.25.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:bfc4e20784722098822e3eee42b8e576b379ed72cca4a7cb856ae733e62192ea", size = 5063001, upload-time = "2025-09-14T22:17:31.044Z" },
+    { url = "https://files.pythonhosted.org/packages/db/00/87466ea3f99599d02a5238498b87bf84a6348290c19571051839ca943777/zstandard-0.25.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:457ed498fc58cdc12fc48f7950e02740d4f7ae9493dd4ab2168a47c93c31298e", size = 5394120, upload-time = "2025-09-14T22:17:32.711Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/95/fc5531d9c618a679a20ff6c29e2b3ef1d1f4ad66c5e161ae6ff847d102a9/zstandard-0.25.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:fd7a5004eb1980d3cefe26b2685bcb0b17989901a70a1040d1ac86f1d898c551", size = 5451230, upload-time = "2025-09-14T22:17:34.41Z" },
+    { url = "https://files.pythonhosted.org/packages/63/4b/e3678b4e776db00f9f7b2fe58e547e8928ef32727d7a1ff01dea010f3f13/zstandard-0.25.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:8e735494da3db08694d26480f1493ad2cf86e99bdd53e8e9771b2752a5c0246a", size = 5547173, upload-time = "2025-09-14T22:17:36.084Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/d5/ba05ed95c6b8ec30bd468dfeab20589f2cf709b5c940483e31d991f2ca58/zstandard-0.25.0-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:3a39c94ad7866160a4a46d772e43311a743c316942037671beb264e395bdd611", size = 5046736, upload-time = "2025-09-14T22:17:37.891Z" },
+    { url = "https://files.pythonhosted.org/packages/50/d5/870aa06b3a76c73eced65c044b92286a3c4e00554005ff51962deef28e28/zstandard-0.25.0-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:172de1f06947577d3a3005416977cce6168f2261284c02080e7ad0185faeced3", size = 5576368, upload-time = "2025-09-14T22:17:40.206Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/35/398dc2ffc89d304d59bc12f0fdd931b4ce455bddf7038a0a67733a25f550/zstandard-0.25.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:3c83b0188c852a47cd13ef3bf9209fb0a77fa5374958b8c53aaa699398c6bd7b", size = 4954022, upload-time = "2025-09-14T22:17:41.879Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/5c/36ba1e5507d56d2213202ec2b05e8541734af5f2ce378c5d1ceaf4d88dc4/zstandard-0.25.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:1673b7199bbe763365b81a4f3252b8e80f44c9e323fc42940dc8843bfeaf9851", size = 5267889, upload-time = "2025-09-14T22:17:43.577Z" },
+    { url = "https://files.pythonhosted.org/packages/70/e8/2ec6b6fb7358b2ec0113ae202647ca7c0e9d15b61c005ae5225ad0995df5/zstandard-0.25.0-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:0be7622c37c183406f3dbf0cba104118eb16a4ea7359eeb5752f0794882fc250", size = 5433952, upload-time = "2025-09-14T22:17:45.271Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/01/b5f4d4dbc59ef193e870495c6f1275f5b2928e01ff5a81fecb22a06e22fb/zstandard-0.25.0-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:5f5e4c2a23ca271c218ac025bd7d635597048b366d6f31f420aaeb715239fc98", size = 5814054, upload-time = "2025-09-14T22:17:47.08Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/e5/fbd822d5c6f427cf158316d012c5a12f233473c2f9c5fe5ab1ae5d21f3d8/zstandard-0.25.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:4f187a0bb61b35119d1926aee039524d1f93aaf38a9916b8c4b78ac8514a0aaf", size = 5360113, upload-time = "2025-09-14T22:17:48.893Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/e0/69a553d2047f9a2c7347caa225bb3a63b6d7704ad74610cb7823baa08ed7/zstandard-0.25.0-cp313-cp313-win32.whl", hash = "sha256:7030defa83eef3e51ff26f0b7bfb229f0204b66fe18e04359ce3474ac33cbc09", size = 436936, upload-time = "2025-09-14T22:17:52.658Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/82/b9c06c870f3bd8767c201f1edbdf9e8dc34be5b0fbc5682c4f80fe948475/zstandard-0.25.0-cp313-cp313-win_amd64.whl", hash = "sha256:1f830a0dac88719af0ae43b8b2d6aef487d437036468ef3c2ea59c51f9d55fd5", size = 506232, upload-time = "2025-09-14T22:17:50.402Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/57/60c3c01243bb81d381c9916e2a6d9e149ab8627c0c7d7abb2d73384b3c0c/zstandard-0.25.0-cp313-cp313-win_arm64.whl", hash = "sha256:85304a43f4d513f5464ceb938aa02c1e78c2943b29f44a750b48b25ac999a049", size = 462671, upload-time = "2025-09-14T22:17:51.533Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/5c/f8923b595b55fe49e30612987ad8bf053aef555c14f05bb659dd5dbe3e8a/zstandard-0.25.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:e29f0cf06974c899b2c188ef7f783607dbef36da4c242eb6c82dcd8b512855e3", size = 795887, upload-time = "2025-09-14T22:17:54.198Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/09/d0a2a14fc3439c5f874042dca72a79c70a532090b7ba0003be73fee37ae2/zstandard-0.25.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:05df5136bc5a011f33cd25bc9f506e7426c0c9b3f9954f056831ce68f3b6689f", size = 640658, upload-time = "2025-09-14T22:17:55.423Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/7c/8b6b71b1ddd517f68ffb55e10834388d4f793c49c6b83effaaa05785b0b4/zstandard-0.25.0-cp314-cp314-manylinux2010_i686.manylinux_2_12_i686.manylinux_2_28_i686.whl", hash = "sha256:f604efd28f239cc21b3adb53eb061e2a205dc164be408e553b41ba2ffe0ca15c", size = 5379849, upload-time = "2025-09-14T22:17:57.372Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/86/a48e56320d0a17189ab7a42645387334fba2200e904ee47fc5a26c1fd8ca/zstandard-0.25.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:223415140608d0f0da010499eaa8ccdb9af210a543fac54bce15babbcfc78439", size = 5058095, upload-time = "2025-09-14T22:17:59.498Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/ad/eb659984ee2c0a779f9d06dbfe45e2dc39d99ff40a319895df2d3d9a48e5/zstandard-0.25.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:2e54296a283f3ab5a26fc9b8b5d4978ea0532f37b231644f367aa588930aa043", size = 5551751, upload-time = "2025-09-14T22:18:01.618Z" },
+    { url = "https://files.pythonhosted.org/packages/61/b3/b637faea43677eb7bd42ab204dfb7053bd5c4582bfe6b1baefa80ac0c47b/zstandard-0.25.0-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:ca54090275939dc8ec5dea2d2afb400e0f83444b2fc24e07df7fdef677110859", size = 6364818, upload-time = "2025-09-14T22:18:03.769Z" },
+    { url = "https://files.pythonhosted.org/packages/31/dc/cc50210e11e465c975462439a492516a73300ab8caa8f5e0902544fd748b/zstandard-0.25.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e09bb6252b6476d8d56100e8147b803befa9a12cea144bbe629dd508800d1ad0", size = 5560402, upload-time = "2025-09-14T22:18:05.954Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/ae/56523ae9c142f0c08efd5e868a6da613ae76614eca1305259c3bf6a0ed43/zstandard-0.25.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:a9ec8c642d1ec73287ae3e726792dd86c96f5681eb8df274a757bf62b750eae7", size = 4955108, upload-time = "2025-09-14T22:18:07.68Z" },
+    { url = "https://files.pythonhosted.org/packages/98/cf/c899f2d6df0840d5e384cf4c4121458c72802e8bda19691f3b16619f51e9/zstandard-0.25.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:a4089a10e598eae6393756b036e0f419e8c1d60f44a831520f9af41c14216cf2", size = 5269248, upload-time = "2025-09-14T22:18:09.753Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/c0/59e912a531d91e1c192d3085fc0f6fb2852753c301a812d856d857ea03c6/zstandard-0.25.0-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:f67e8f1a324a900e75b5e28ffb152bcac9fbed1cc7b43f99cd90f395c4375344", size = 5430330, upload-time = "2025-09-14T22:18:11.966Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/1d/7e31db1240de2df22a58e2ea9a93fc6e38cc29353e660c0272b6735d6669/zstandard-0.25.0-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:9654dbc012d8b06fc3d19cc825af3f7bf8ae242226df5f83936cb39f5fdc846c", size = 5811123, upload-time = "2025-09-14T22:18:13.907Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/49/fac46df5ad353d50535e118d6983069df68ca5908d4d65b8c466150a4ff1/zstandard-0.25.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:4203ce3b31aec23012d3a4cf4a2ed64d12fea5269c49aed5e4c3611b938e4088", size = 5359591, upload-time = "2025-09-14T22:18:16.465Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/38/f249a2050ad1eea0bb364046153942e34abba95dd5520af199aed86fbb49/zstandard-0.25.0-cp314-cp314-win32.whl", hash = "sha256:da469dc041701583e34de852d8634703550348d5822e66a0c827d39b05365b12", size = 444513, upload-time = "2025-09-14T22:18:20.61Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/43/241f9615bcf8ba8903b3f0432da069e857fc4fd1783bd26183db53c4804b/zstandard-0.25.0-cp314-cp314-win_amd64.whl", hash = "sha256:c19bcdd826e95671065f8692b5a4aa95c52dc7a02a4c5a0cac46deb879a017a2", size = 516118, upload-time = "2025-09-14T22:18:17.849Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/ef/da163ce2450ed4febf6467d77ccb4cd52c4c30ab45624bad26ca0a27260c/zstandard-0.25.0-cp314-cp314-win_arm64.whl", hash = "sha256:d7541afd73985c630bafcd6338d2518ae96060075f9463d7dc14cfb33514383d", size = 476940, upload-time = "2025-09-14T22:18:19.088Z" },
 ]


### PR DESCRIPTION
## Summary

Calibrates the synthetic mesh generator (`replay/sim.py`) against two real ~1,600-node event captures — **Burning Man 2025** (`garthvh/burningmesh-replay`) and **DEF CON 33** (`darknet-ng/DEFCON33-Meshtastic-Traffic`) — so the replayed mesh looks like what a real gateway heard, and makes every axis tunable. See `docs/sim-realism-plan.md` for the full gap analysis and workstream breakdown.

## What changed

| Workstream | Highlights |
|---|---|
| **WS0** metrics harness | `replay/metrics.py` capture-stats schema + `sqlite_extra_stats`; `tools/import_defcon_logs.py` (str(dict) gateway log → shared SQLite schema) |
| **WS1** traffic economy | NODEINFO/POSITION/ROUTING mix calibrated (was TELEMETRY-heavy); NodeInfo exchange storms; ACK economy; per-node hop_start with the DEF CON hop-7 subpopulation; text long-tail |
| **WS2** observer/RF model | `replay/observer.py` — log-distance path loss + shadowing → per-copy SNR/RSSI, reception loss (volume calibration), rebroadcast duplicates, MQTT bridging, Gilbert–Elliott fading. The sim now emits *what a gateway heard*, not mesh truth |
| **WS3 + WS-T** temporal + sensors | Battery state machines, load-derived chutil (ρ≈0.99), conversation bursts, climate model + sensor personas (lux/IAQ/NaN) |
| **WS4** presets + fit | `meshcon`/`burningman`/`defcon` presets; `generate(profile=…)` takes preset name / JSON path / dict (deep-merge); `fit_profile` v2; **`ninja`** DC33 NodeInfo-spoof fuzz preset |
| **WS-A** ATAK | Opt-in TAK squad (portnum 72 PLI/GeoChat/status), off by default |
| **WS5** regression | `tests/unit/test_sim_realism.py` tolerance bands (CI-safe constants) |
| **MCP surface** | `replay_start(sim_profile=…)` exposes every generator knob (observer/tak/spikes/climate) to MCP clients as a dict/JSON override deep-merged over the `source` preset — path-free, so no filesystem access from callers |

## Outcome (1600 nodes / 3 days)

| Axis | Before | After | Real (BM / DC) |
|---|---|---|---|
| Portnum mix | TEL 48%, NODEINFO 1.3% | NODEINFO 35%, POS 29%, TEL 17%, ROUTING 9% | NODEINFO 34-38%, POS 31-34% |
| Observed pkts/hr | 4,919 | 1,036 (defcon) | 643 / 977 |
| Rebroadcast dups | none | 0.29 id-fraction | 0.29 (DC) |
| SNR / RSSI | absent | p50 6.25 / −97 | 3..10 / −84..−100 |
| Text p50 / max | 10 / 66 | 28 / ~235 | 17-25 / 227-246 |
| Battery / chutil | i.i.d. | bimodal / tracks load | bimodal / load-following |

## New capabilities
- `replay_start(source="burningman"|"defcon")` — calibrated event scenarios
- `replay_start(source="defcon", fuzz="ninja")` — the real DC33 🥷 NodeInfo-spoof attack (dodges the app's key-change warning)
- `generate(profile=fit_profile(capture))` — calibrate against any real capture
- Opt-in TAK squad via `profile={"tak": {"team_nodes": N}}`
- `replay_start(source="defcon", sim_profile={"tak": {"team_nodes": 6, "wire": "v2"}})` — tune any scenario from the MCP tool (observer RF model, ATAK squad, spikes, …)
- `meshtastic-mcp capture-stats <db|jsonl|preset> [--json]` — realism stats from bash

## Privacy
No dataset-derived files are committed — the local stat profiles (`replay/profiles/*.json`) are gitignored; preset tunables are reviewed constants in code. Profile-dependent tests skip when absent.

## Deferred stretch items — landed
- [x] `capture-stats` CLI subcommand (`meshtastic-mcp capture-stats <db|jsonl|preset> [--json]`)
- [x] **TAKPacketV2 zstd wire-format** behind the optional `[tak]` extra (meshtastic-tak SDK) — `tak.wire="v2"` emits real dictionary-compressed payloads (median ~59 B, cross-instance byte-compatible with the SDK); new `tak` capability + doctor probe; legacy TAKPacket stays the dependency-free default
- [ ] Re-fit preset constants when fresh captures land — process-only, no code change

## Post-review follow-ups (also on this branch)
- **CodeRabbit review** addressed (`d55b6c4`): importer no longer drops a POSITION-first node's fix; `_resolve_profile` rejects non-preset/non-`.json` strings with a clear error; battery-bimodality test strengthened.
- **`tak` deep-merge fix** (`afceabb`): a partial `{"tak": {...}}` override no longer wipes the other `tak` defaults.
- **MCP tunability** (`628f056`): the `sim_profile` passthrough above — path-free by construction (dict/JSON object only), which is also the security-by-design answer to the reviewer's path-traversal note.
- **`generate()` refactor** (`d814da3`): 501 → 405 lines by extracting `_build_nodes` and `_emit_encrypted`; proven byte-for-byte identical output via SHA-256 fingerprints across all preset/override cases.

_525 unit tests pass (33 skipped); ruff + mypy clean. Ready for review._

## Test plan
```
uv run ruff check . && uv run ruff format --check .
uv run --extra dev mypy
uv run --extra test python -m pytest tests/unit -q   # 525 passed, 33 skipped
```



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `capture-stats` CLI command to generate JSON and human-readable realism statistics from simulator presets, JSONL recordings, or capture databases.
  * Added optional TAKPacketV2 support (capability detection, doctor checks, simulator/CLI validation) and an opt-in ATAK “squad” layer.
  * Added a new “ninja” fuzz preset for adversarial NodeInfo name spoofing.
* **Documentation**
  * Added a full simulation realism calibration plan.
* **Bug Fixes**
  * Improved simulator preset/profile and `sim_profile` handling; expanded DEF CON log importing into SQLite captures.
* **Tests**
  * Added extensive end-to-end tests for metrics, RF observer behavior, realism targets, TAK, and ninja.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
