### PR TITLE
fix(flash): erase_and_flash uses shared esptool resolver (was: esptool not found)

### DIFF
--- a/src/meshtastic_mcp/flash.py
+++ b/src/meshtastic_mcp/flash.py
@@ -12,6 +12,7 @@ artifacts to exist, so these tools build first if needed.
 
 from __future__ import annotations
 
+import os
 import subprocess
 import threading
 import time
@@ -283,6 +284,13 @@ def _check_esp32_env(env: str) -> str:
 
 def _run_install_script(script: Path, port: str, binary: Path) -> dict[str, Any]:
     """Invoke bin/device-install.sh or bin/device-update.sh."""
+    # The scripts invoke `esptool` from PATH, which may not carry the venv /
+    # PlatformIO location our resolver finds — prepend it so they agree.
+    esptool_dir = str(config.esptool_bin().parent)
+    env = os.environ.copy()
+    existing_path = env.get("PATH", "")
+    env["PATH"] = os.pathsep.join(part for part in (esptool_dir, existing_path) if part)
+
     t0 = time.monotonic()
     proc = subprocess.run(
         [str(script), "-p", port, "-f", str(binary)],
@@ -290,6 +298,7 @@ def _run_install_script(script: Path, port: str, binary: Path) -> dict[str, Any]
         capture_output=True,
         text=True,
         timeout=pio.TIMEOUT_UPLOAD,
+        env=env,
     )
     duration = time.monotonic() - t0
     return {

--- a/tests/unit/test_erase_and_flash.py
+++ b/tests/unit/test_erase_and_flash.py
@@ -1,0 +1,116 @@
+# SPDX-FileCopyrightText: Meshtastic contributors
+# SPDX-License-Identifier: GPL-3.0-only
+
+"""Unit tests for erase_and_flash and update_flash esptool resolution.
+
+These functions shell out to bin/device-install.sh and bin/device-update.sh,
+which in turn invoke esptool. The scripts need esptool to be available in their
+subprocess PATH. This test ensures the MCP server pre-resolves esptool and
+injects its directory into the subprocess environment before calling the script.
+"""
+
+from __future__ import annotations
+
+import os
+from contextlib import contextmanager
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from meshtastic_mcp import config, flash, userprefs
+
+
+def test_erase_and_flash_resolves_esptool_and_adds_to_path() -> None:
+    """erase_and_flash must pre-resolve esptool and inject it into subprocess PATH.
+
+    Without this fix, bin/device-install.sh would fail with 'esptool not found'
+    even when esptool exists in the PlatformIO penv or other resolver paths.
+    """
+    captured: dict = {}
+
+    def _stub_subprocess_run(args, **kwargs):
+        captured["env"] = kwargs.get("env", {})
+        captured["args"] = args
+        # Return a successful result
+        result = MagicMock()
+        result.returncode = 0
+        result.stdout = "Device erased and flashed successfully"
+        result.stderr = ""
+        return result
+
+    @contextmanager
+    def _stub_temporary_overrides(overrides=None):
+        """Mock userprefs.temporary_overrides to avoid file I/O."""
+        yield {}
+
+    esptool_path = Path("/fake/penv/bin/esptool")
+    factory_bin = Path("/fake/build/firmware.factory.bin")
+
+    with (
+        patch.object(config, "firmware_root", return_value=Path("/fake/firmware")),
+        patch.object(config, "esptool_bin", return_value=esptool_path),
+        patch.object(flash, "_check_esp32_env", return_value="esp32"),  # mock board check
+        patch.object(flash.Path, "is_file", return_value=True),  # script exists
+        patch.object(flash.subprocess, "run", side_effect=_stub_subprocess_run),
+        patch.object(flash, "_factory_bin_for", return_value=factory_bin),
+        patch.object(userprefs, "temporary_overrides", side_effect=_stub_temporary_overrides),
+    ):
+        flash.erase_and_flash("tbeam", "/dev/ttyUSB0", confirm=True, skip_build=True)
+
+    # Verify the subprocess environment includes esptool's directory in PATH
+    env = captured["env"]
+    assert "PATH" in env
+    assert "/fake/penv/bin" in env["PATH"]
+    # esptool's dir should be at the start of PATH (prepended), using the
+    # platform PATH separator (':' on POSIX, ';' on Windows).
+    assert env["PATH"].startswith("/fake/penv/bin" + os.pathsep)
+
+    # Verify the script was called with correct args
+    args = captured["args"]
+    assert "device-install.sh" in str(args[0])
+    assert "-p" in args
+    assert "/dev/ttyUSB0" in args
+
+
+def test_update_flash_also_resolves_esptool() -> None:
+    """update_flash must also pre-resolve esptool like erase_and_flash."""
+    captured: dict = {}
+
+    def _stub_subprocess_run(args, **kwargs):
+        captured["env"] = kwargs.get("env", {})
+        result = MagicMock()
+        result.returncode = 0
+        result.stdout = "Device OTA updated"
+        result.stderr = ""
+        return result
+
+    @contextmanager
+    def _stub_temporary_overrides(overrides=None):
+        """Mock userprefs.temporary_overrides to avoid file I/O."""
+        yield {}
+
+    esptool_path = Path("/fake/penv/bin/esptool")
+    firmware_bin = Path("/fake/build/firmware.bin")
+
+    with (
+        patch.object(config, "firmware_root", return_value=Path("/fake/firmware")),
+        patch.object(config, "esptool_bin", return_value=esptool_path),
+        patch.object(flash, "_check_esp32_env", return_value="esp32"),  # mock board check
+        patch.object(flash.Path, "is_file", return_value=True),
+        patch.object(flash.subprocess, "run", side_effect=_stub_subprocess_run),
+        patch.object(flash, "_firmware_bin_for", return_value=firmware_bin),
+        patch.object(userprefs, "temporary_overrides", side_effect=_stub_temporary_overrides),
+    ):
+        flash.update_flash("tbeam", "/dev/ttyUSB0", confirm=True, skip_build=True)
+
+    # Verify the subprocess environment includes esptool's directory in PATH
+    env = captured["env"]
+    assert "PATH" in env
+    assert "/fake/penv/bin" in env["PATH"]
+
+
+def test_erase_and_flash_requires_confirm() -> None:
+    """erase_and_flash must require confirm=True (destructive gate)."""
+    with pytest.raises(flash.FlashError, match="confirm=True"):
+        flash.erase_and_flash("tbeam", "/dev/ttyUSB0", confirm=False)


### PR DESCRIPTION
## Problem

`erase_and_flash` (and `update_flash`) fail immediately with:
```json
{"exit_code": 1, "stdout_tail": "Error: esptool not found", "duration_s": 0.04}
```
while the sibling tools `esptool_chip_info` / `esptool_erase_flash` resolve and run esptool fine on the same machine.

## Root cause

`_run_install_script()` (`src/meshtastic_mcp/flash.py`) shells out to `bin/device-install.sh` / `bin/device-update.sh`, which invoke `esptool` from PATH — but the subprocess env was never given the resolved esptool location. The working tools go through the unified `config.esptool_bin()` resolver (env override → firmware .venv → running venv → PATH → PlatformIO penv/packages); the install-script path skipped it entirely.

## Fix

Pre-resolve esptool via the same `config.esptool_bin()` helper and prepend its directory to the subprocess PATH. 12-line diff, no refactoring.

## Tests

New `tests/unit/test_erase_and_flash.py` (3 tests): resolver is used and injected into PATH for both `erase_and_flash` and `update_flash`, and the `confirm=True` destructive gate still holds. ruff + mypy clean.

Found during a live e2e session where the fallback recovery path for a wedged seeed-xiao-s3 hit this error (worked around at the time via `esptool_erase_flash` + `flash_start`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved device installation and firmware update reliability by ensuring the flashing tool is discoverable when the install/update scripts run.
* **Tests**
  * Added unit test coverage for flash erase/update flows, including subprocess environment `PATH` setup for tool discovery and enforcement of the explicit destructive confirmation safeguard.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->