### PR TITLE
fix(connection): linger before close so queued RF TX and flash writes survive

### DIFF
--- a/src/meshtastic_mcp/admin.py
+++ b/src/meshtastic_mcp/admin.py
@@ -59,9 +59,13 @@ def set_owner(
     short_name: str | None = None,
     port: str | None = None,
 ) -> dict[str, Any]:
+    """Set the owner (long and short name).
+
+    Flash write must complete before close/DTR reset, so linger before exit.
+    """
     if short_name is not None and len(short_name) > 4:
         raise AdminError("short_name must be 4 characters or fewer")
-    with connect(port=port) as iface:
+    with connect(port=port, linger_s=2.5) as iface:
         iface.localNode.setOwner(long_name=long_name, short_name=short_name)
     return {
         "ok": True,
@@ -203,13 +207,14 @@ def set_config(path: str, value: Any, port: str | None = None) -> dict[str, Any]
         set_config("mqtt.enabled", True)
         set_config("mqtt.address", "mqtt.example.com")
 
+    Flash write must complete before close/DTR reset, so linger before exit.
     """
     segments = [s for s in path.split(".") if s]
     if not segments:
         raise AdminError("path cannot be empty")
     section = segments[0]
 
-    with connect(port=port) as iface:
+    with connect(port=port, linger_s=2.5) as iface:
         node = iface.localNode
         container, parent_name = _section_container(node, section)
 
@@ -265,7 +270,11 @@ def get_channel_url(include_all: bool = False, port: str | None = None) -> dict[
 
 
 def set_channel_url(url: str, port: str | None = None) -> dict[str, Any]:
-    with connect(port=port) as iface:
+    """Set channels from a URL.
+
+    Flash write must complete before close/DTR reset, so linger before exit.
+    """
+    with connect(port=port, linger_s=2.5) as iface:
         # setURL replaces the channel set from the URL's contents. It does not
         # return a count; we infer by counting non-DISABLED channels after.
         iface.localNode.setURL(url)
@@ -283,9 +292,17 @@ def send_text(
     channel_index: int = 0,
     want_ack: bool = False,
     port: str | None = None,
+    tx_linger_s: float = 8.0,
 ) -> dict[str, Any]:
+    """Send a text message over the mesh.
+
+    `tx_linger_s` delays close after sendText() returns, allowing the firmware's
+    channel-politeness TX delay (~4s for broadcasts) and RF airtime to complete
+    before the connection closes and triggers a DTR reset. Without this, queued
+    broadcasts are lost (verified: 3/3 silent losses with immediate close).
+    """
     destination = to if to is not None else "^all"
-    with connect(port=port) as iface:
+    with connect(port=port, linger_s=tx_linger_s) as iface:
         packet = iface.sendText(
             text,
             destinationId=destination,

--- a/src/meshtastic_mcp/connection.py
+++ b/src/meshtastic_mcp/connection.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 
 import logging
 import threading
+import time
 from collections.abc import Iterator
 from contextlib import contextmanager
 
@@ -35,6 +36,13 @@ log = logging.getLogger("meshtastic_mcp.connection")
 DEFAULT_TCP_PORT = 4403
 TCP_SCHEME = "tcp://"
 TCP_HOST_ENV = "MESHTASTIC_MCP_TCP_HOST"
+
+# Upper bound on `connect(linger_s=...)`. The linger holds the exclusive port
+# lock, so an unbounded caller value would pin the device and fail-fast every
+# other operation for as long as it lasts. Even the most generous real need
+# (broadcast politeness delay + airtime, or a flash-write commit) is a handful
+# of seconds; 60s is comfortably above that and caps the damage from a bad arg.
+_MAX_LINGER_S = 60.0
 
 # Upper bound on a graceful close. `iface.close()` sends a disconnect, and if the
 # device just rebooted (factory_reset / reboot / shutdown) the meshtastic library
@@ -163,7 +171,7 @@ def resolve_port(port: str | None) -> str:
 
 
 @contextmanager
-def connect(port: str | None = None, timeout_s: float = 8.0) -> Iterator:
+def connect(port: str | None = None, timeout_s: float = 8.0, linger_s: float = 0.0) -> Iterator:
     """Open a meshtastic interface (serial or TCP) and always close it.
 
     For serial: raises `ConnectionError` immediately if another serial
@@ -177,9 +185,21 @@ def connect(port: str | None = None, timeout_s: float = 8.0) -> Iterator:
     as the reply-wait deadline for `localNode.waitForConfig()` during
     construction and for any subsequent admin RPC. `int()`-converted at
     the boundary because the upstream API expects whole seconds.
+
+    `linger_s` delays close after a successful yield. Meshtastic firmware queues
+    TX behind a channel-politeness delay (~4s for broadcasts); on immediate close
+    the DTR reset kills the queued RF transmission before it reaches airtime, and
+    can interrupt an admin flash write mid-commit. Set `linger_s` to let those
+    finish. On exception, linger is skipped and close is immediate.
+
+    Note the port lock is held for the whole linger, so a non-zero `linger_s`
+    widens the window in which a concurrent caller gets the fail-fast busy error.
+    Keep it at 0 for read-only ops. Clamped to `_MAX_LINGER_S` so a stray large
+    value can't pin the port indefinitely.
     """
     resolved = resolve_port(port)
     timeout = int(timeout_s)
+    linger_s = max(0.0, min(linger_s, _MAX_LINGER_S))
 
     if is_tcp_port(resolved):
         from meshtastic.tcp_interface import (
@@ -195,6 +215,7 @@ def connect(port: str | None = None, timeout_s: float = 8.0) -> Iterator:
             )
 
         iface = None
+        ok = False
         try:
             iface = TCPInterface(
                 hostname=host,
@@ -204,7 +225,12 @@ def connect(port: str | None = None, timeout_s: float = 8.0) -> Iterator:
                 timeout=timeout,
             )
             yield iface
+            ok = True
         finally:
+            # Linger only on success — a failed body has nothing queued worth
+            # waiting for, and delaying the close would just widen the busy window.
+            if ok and linger_s > 0:
+                time.sleep(linger_s)
             if iface is not None:
                 _close_bounded(iface)
             try:
@@ -230,6 +256,7 @@ def connect(port: str | None = None, timeout_s: float = 8.0) -> Iterator:
         )
 
     iface = None
+    ok = False
     try:
         iface = SerialInterface(
             devPath=resolved,
@@ -238,7 +265,12 @@ def connect(port: str | None = None, timeout_s: float = 8.0) -> Iterator:
             timeout=timeout,
         )
         yield iface
+        ok = True
     finally:
+        # Linger only on success — a failed body has nothing queued worth
+        # waiting for, and delaying the close would just widen the busy window.
+        if ok and linger_s > 0:
+            time.sleep(linger_s)
         if iface is not None:
             _close_bounded(iface)
         try:

--- a/src/meshtastic_mcp/server.py
+++ b/src/meshtastic_mcp/server.py
@@ -1297,12 +1297,17 @@ def send_text(
     port: str | None = None,
     wait_for_tx: bool = False,
     tx_timeout_s: float = 30.0,
+    tx_linger_s: float = 8.0,
 ) -> dict[str, Any]:
     """Send a text message over the mesh.
 
     `to` defaults to broadcast ("^all"). Pass a node ID (hex string like
     "!abcdef01") or node number (int) to direct-message a specific node.
     channel_index picks which configured channel to send on.
+
+    `tx_linger_s` delays the connection close after sendText() returns, allowing
+    the firmware's channel-politeness TX delay (~4s) and RF airtime to complete
+    before the serial port resets. Prevents loss of queued broadcasts.
 
     Delivery is async and best-effort. By default this returns as soon as the
     packet is queued. Set `wait_for_tx=True` to additionally poll the recorder
@@ -1316,7 +1321,12 @@ def send_text(
         {tx_confirmed: bool, tx_latency_s: float | null}
     """
     result = admin.send_text(
-        text=text, to=to, channel_index=channel_index, want_ack=want_ack, port=port
+        text=text,
+        to=to,
+        channel_index=channel_index,
+        want_ack=want_ack,
+        port=port,
+        tx_linger_s=tx_linger_s,
     )
     if not wait_for_tx:
         return result

--- a/tests/unit/test_linger_tx_race.py
+++ b/tests/unit/test_linger_tx_race.py
@@ -1,0 +1,230 @@
+# SPDX-FileCopyrightText: Meshtastic contributors
+# SPDX-License-Identifier: GPL-3.0-only
+
+"""Test linger_s parameter to prevent serial TX race.
+
+When a serial connection closes, DTR reset kills queued RF transmissions.
+Meshtastic firmware queues broadcasts behind ~4s channel-politeness delay.
+The linger_s parameter delays close until queued TX completes.
+
+Tests verify:
+  - send_text() passes tx_linger_s through to connect()
+  - set_owner() uses a nonzero linger
+  - set_config() uses a nonzero linger
+  - set_channel_url() uses a nonzero linger
+"""
+
+from __future__ import annotations
+
+import contextlib
+import sys
+import types
+
+import pytest
+
+from meshtastic_mcp import admin
+from meshtastic_mcp import connection as conn
+
+
+class _FakeNode:
+    def __init__(self):
+        self.owner_set = False
+
+    def setOwner(self, long_name, short_name):
+        self.owner_set = True
+
+    def _sendAdmin(self, msg):
+        pass
+
+
+class _FakeIface:
+    def __init__(self):
+        self.localNode = _FakeNode()
+        self.close_called = False
+
+    def close(self):
+        self.close_called = True
+
+
+def test_send_text_passes_tx_linger_s(monkeypatch):
+    """send_text() must pass tx_linger_s through to connect()."""
+    connect_calls = []
+
+    @contextlib.contextmanager
+    def fake_connect(port=None, linger_s=0.0, **kwargs):
+        connect_calls.append({"port": port, "linger_s": linger_s})
+
+        class FakeIface:
+            def sendText(self, *args, **kwargs):
+                class Packet:
+                    id = 42
+
+                return Packet()
+
+        yield FakeIface()
+
+    monkeypatch.setattr(admin, "connect", fake_connect)
+
+    # Call send_text with a custom tx_linger_s
+    admin.send_text(text="test", port="/dev/ttyUSB0", tx_linger_s=7.5)
+
+    # Verify connect was called with the tx_linger_s value
+    assert len(connect_calls) == 1
+    assert connect_calls[0]["linger_s"] == 7.5, f"Expected linger_s=7.5, got {connect_calls[0]}"
+
+
+def test_send_text_defaults_to_8s_linger(monkeypatch):
+    """send_text() must default to tx_linger_s=8.0."""
+    connect_calls = []
+
+    @contextlib.contextmanager
+    def fake_connect(port=None, linger_s=0.0, **kwargs):
+        connect_calls.append({"port": port, "linger_s": linger_s})
+
+        class FakeIface:
+            def sendText(self, *args, **kwargs):
+                class Packet:
+                    id = 42
+
+                return Packet()
+
+        yield FakeIface()
+
+    monkeypatch.setattr(admin, "connect", fake_connect)
+
+    # Call send_text without specifying tx_linger_s
+    admin.send_text(text="test", port="/dev/ttyUSB0")
+
+    # Verify connect was called with the default 8.0s linger
+    assert len(connect_calls) == 1
+    assert connect_calls[0]["linger_s"] == 8.0, (
+        f"Expected default linger_s=8.0, got {connect_calls[0]}"
+    )
+
+
+def test_set_owner_uses_linger(monkeypatch):
+    """set_owner() must use linger_s > 0 for flash write safety."""
+    connect_calls = []
+
+    @contextlib.contextmanager
+    def fake_connect(port=None, linger_s=0.0, **kwargs):
+        connect_calls.append({"port": port, "linger_s": linger_s})
+
+        class FakeNode:
+            def setOwner(self, long_name, short_name):
+                pass
+
+        class FakeIface:
+            localNode = FakeNode()
+
+        yield FakeIface()
+
+    monkeypatch.setattr(admin, "connect", fake_connect)
+
+    # Call set_owner
+    admin.set_owner(long_name="Test Owner", short_name="TEST")
+
+    # Verify connect was called with a nonzero linger
+    assert len(connect_calls) == 1
+    assert connect_calls[0]["linger_s"] > 0, (
+        f"set_owner must use nonzero linger, got {connect_calls[0]['linger_s']}"
+    )
+
+
+def test_set_config_uses_linger(monkeypatch):
+    """set_config() must use linger_s > 0 for flash write safety."""
+    connect_calls = []
+
+    @contextlib.contextmanager
+    def fake_connect(port=None, linger_s=0.0, **kwargs):
+        connect_calls.append({"port": port, "linger_s": linger_s})
+        # Immediately raise an error before set_config continues
+        # (we just want to verify connect was called with linger)
+        raise admin.AdminError("test error")
+
+    monkeypatch.setattr(admin, "connect", fake_connect)
+
+    # Call set_config — it should fail but we can check connect was called
+    with pytest.raises(admin.AdminError):
+        admin.set_config(path="lora.region", value="US")
+
+    # Verify connect was called with a nonzero linger
+    assert len(connect_calls) == 1
+    assert connect_calls[0]["linger_s"] > 0, (
+        f"set_config must use nonzero linger, got {connect_calls[0]['linger_s']}"
+    )
+
+
+def test_set_channel_url_uses_linger(monkeypatch):
+    """set_channel_url() must use linger_s > 0 for flash write safety."""
+    connect_calls = []
+
+    @contextlib.contextmanager
+    def fake_connect(port=None, linger_s=0.0, **kwargs):
+        connect_calls.append({"port": port, "linger_s": linger_s})
+
+        class FakeNode:
+            channels = []
+
+            def setURL(self, url):
+                pass
+
+        class FakeIface:
+            localNode = FakeNode()
+
+        yield FakeIface()
+
+    monkeypatch.setattr(admin, "connect", fake_connect)
+
+    # Call set_channel_url
+    admin.set_channel_url(url="https://example.com/meshtastic/config")
+
+    # Verify connect was called with a nonzero linger
+    assert len(connect_calls) == 1
+    assert connect_calls[0]["linger_s"] > 0, (
+        f"set_channel_url must use nonzero linger, got {connect_calls[0]['linger_s']}"
+    )
+
+
+def _drive_connect_linger(monkeypatch, requested_linger: float) -> list[float]:
+    """Run the real `connect()` with a mocked serial stack, returning the
+    actual durations passed to `time.sleep` (i.e. the effective linger)."""
+    slept: list[float] = []
+    monkeypatch.setattr(conn.time, "sleep", lambda s: slept.append(s))
+    monkeypatch.setattr(conn, "resolve_port", lambda port: "/dev/ttyFAKE")
+    monkeypatch.setattr(conn.registry, "active_session_for_port", lambda port: None)
+
+    import threading
+
+    monkeypatch.setattr(conn.registry, "port_lock", lambda port: threading.Lock())
+
+    # `connect()` imports SerialInterface from meshtastic.serial_interface at call
+    # time; inject a fake module so no real hardware is touched.
+    fake_mod = types.ModuleType("meshtastic.serial_interface")
+    fake_mod.SerialInterface = lambda **kwargs: _FakeIface()  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "meshtastic.serial_interface", fake_mod)
+
+    with conn.connect(port="/dev/ttyFAKE", linger_s=requested_linger):
+        pass
+    return slept
+
+
+def test_connect_clamps_excessive_linger(monkeypatch):
+    """A caller-supplied linger above the cap is clamped so it can't pin the
+    exclusive port lock indefinitely (CodeRabbit #18, Critical)."""
+    slept = _drive_connect_linger(monkeypatch, 10_000.0)
+    assert slept == [conn._MAX_LINGER_S], (
+        f"expected linger clamped to {conn._MAX_LINGER_S}, slept {slept}"
+    )
+
+
+def test_connect_passes_normal_linger_through(monkeypatch):
+    """A reasonable linger under the cap is used verbatim."""
+    slept = _drive_connect_linger(monkeypatch, 8.0)
+    assert slept == [8.0], f"expected linger 8.0 used as-is, slept {slept}"
+
+
+def test_connect_negative_linger_never_sleeps(monkeypatch):
+    """A negative linger is floored to 0 — no sleep at all."""
+    slept = _drive_connect_linger(monkeypatch, -5.0)
+    assert slept == [], f"expected no sleep for negative linger, slept {slept}"


### PR DESCRIPTION
## Problem (hardware-reproduced, 3/3)

`send_text` reported `{ok: true, packet_id: ...}` but **no packet ever reached the mesh** — nothing on the air, nothing in other radios' recorders, nothing rendered in the Android app. Reproduced 3/3 on a T-Beam S3 (develop @ 8abae90). Separately, `set_owner` changes were silently lost (owner reverted by the very next connection).

## Root cause

`connect()` closes the SerialInterface immediately after the tool body returns. But:
- Meshtastic firmware queues broadcasts behind a **channel-politeness TX delay** (~3.2–3.7s observed on this mesh) before the radio actually transmits. Closing the port (and the DTR reset the *next* connection causes) kills the queued RF TX before airtime.
- Mutating admin ops (set_owner etc.) trigger a synchronous flash write on the device (`AdminModule::saveChanges`), which the immediate close/reset can interrupt mid-write.

**Decisive experiment:** identical `sendText()` with the connection held open 15s before close → delivered to the mesh and rendered on the phone, 1/1. Immediate close → lost, 3/3.

## Fix

- `connect()` gains `linger_s: float = 0.0` — after a successful body, sleep before closing (skipped on exception; close still guaranteed; port lock held throughout).
- `send_text`: `tx_linger_s=8.0` default (politeness delay + airtime + margin), exposed as a tool param.
- `set_owner` / `set_config` / `set_channel_url`: `linger_s=2.5` (flash-write safety).
- Read-only ops unchanged (stay fast).

## Validation

- 5 new unit tests (`tests/unit/test_linger_tx_race.py`), existing connection/admin tests still green, ruff + mypy clean.
- **Hardware:** patched-equivalent flow on the same T-Beam that lost data before — broadcast delivered + rendered in the Android app; `set_owner` survived both a DTR reset and a full reboot (`long='E2E-TESTER-tbeam'` intact both times).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved reliability of message delivery and device configuration updates by allowing pending transmissions and firmware writes to complete before disconnecting.
  * Added an optional transmission wait setting, defaulting to 8 seconds, for greater control over queued message delivery.
* **Bug Fixes**
  * Reduced the risk of lost broadcasts and incomplete device updates caused by connections closing too quickly.
* **Tests**
  * Added coverage for transmission and configuration operations using connection delays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->