### PR TITLE
feat(inject): frame injection into a board's real RX pipeline

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -12,6 +12,10 @@ Key points for Copilot:
 - **Destructive tools require `confirm=True`** (`reboot`, `factory_reset`, `erase_and_flash`,
   `uhubctl_*`). Don't remove or bypass the gate. New destructive tools must add it.
 - **One MCP call per serial port at a time** (exclusive lock): open → act → close.
+- **Frame injection** (`inject_frame` / `inject.py`): delivers a crafted frame into a board's
+  real receive pipeline as if it arrived off LoRa (reaches `from != 0` / decrypt / remote-admin
+  paths the `toRadio` API can't). Needs firmware built with `-D
+  MESHTASTIC_ENABLE_FRAME_INJECTION=1`; sim nodes always. See AGENTS.md § "Frame injection".
 - **No type debt.** mypy runs with no per-module `ignore_errors`; fix types, don't exclude.
 - **Gates before every push:**
   ```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,8 +12,8 @@ decoupled so the device/admin/recorder core works with **no firmware checkout**.
 
 - **core** (always registered): `devices`, `serial_session`, `registry`, `connection`
   (serial + TCP), `info`, `admin`, `recorder/` + `log_query`, `replay/` (simulated-device
-  streaming + `sim` synthetic mesh + `fuzz` adversary layer), `input_events`, `camera`/`ocr`,
-  `uhubctl`, `hw_tools`.
+  streaming + `sim` synthetic mesh + `fuzz` adversary layer), `inject` (frame injection into
+  real hardware — see below), `input_events`, `camera`/`ocr`, `uhubctl`, `hw_tools`.
 - **firmware capability** (needs `MESHTASTIC_FIRMWARE_ROOT` + `pio`): `flash`, `boards`,
   `userprefs`, `pio`, `fixtures`.
 - **android capability** (needs `android` + `adb`): `emulator/` native-node + AVD
@@ -44,6 +44,39 @@ external dependency and emits the exact, platform-aware acquisition command for 
 or degraded. Call it first when a capability tool fails on a missing prerequisite, or to
 self-provision before an e2e run. Keep its hints current — it is the single source of truth for
 "how do I get dep X" (don't scatter stale `brew install` strings).
+
+## Frame injection: testing the off-air receive path
+
+`inject_frame` (module `inject.py`) delivers a crafted frame into a connected board's **real receive
+pipeline as if it arrived off the LoRa radio** — so it gets `from != 0` enforcement, channel/PKC
+decryption, admin authorization, hop handling, dedup, and promiscuous module dispatch. This reaches
+code the phone/`toRadio` API cannot: that path forces `from = 0` (locally-originated), which bypasses
+the session-key gate and every "from a remote node" branch. Use it to reproduce over-the-air-only bugs
+(remote admin, PKC decrypt, the admin session-passkey flow), and to fuzz the decoder on real silicon.
+
+- **Firmware prerequisite.** The target must run firmware built with `-D
+  MESHTASTIC_ENABLE_FRAME_INJECTION=1` (off by default — it forges over-the-air traffic and must never
+  ship enabled). Portduino `sim` nodes support it unconditionally. Firmware seam:
+  `MeshService::injectAsReceived` (extends the existing portduino `SIMULATOR_APP` path to real hardware).
+- **Wire format.** The frame rides in a `Compressed` envelope wrapped in a `MeshPacket` sent on
+  `SIMULATOR_APP` (portnum 69): `Compressed.portnum == UNKNOWN_APP` → `data` is verbatim ciphertext the
+  firmware decrypts; otherwise → `data` is the decoded payload for that portnum. The outer packet carries
+  the forged `from`/`to`/`id`/`channel` (+ `pki_encrypted`/`public_key`). The crafter replicates
+  meshtastic channel crypto (default-PSK expansion, `xorHash` channel hash, AES-CTR with the
+  `packetId|from|0` nonce).
+- **Modes:** `text`, `raw` (portnum + payload), `admin` (set_owner; pair with `pki=true` +
+  `public_key_b64` to hit the PKC-admin path), `ciphertext` (verbatim bytes), `fuzz` (random/malformed
+  frames for decode-path robustness). `encrypt=true` (default) channel-encrypts; `encrypt=false` injects
+  already-decoded (needed with `pki`). A standalone CLI lives at `cli/meshinject.py`.
+- **Example — reproduce remote-admin "no session key":** set the target's `admin_key[0]` to a key you
+  hold, then `inject_frame(mode="admin", from_node="0x...", pki=true, public_key_b64=<that key>,
+  encrypt=false, session_hex="2904b478...")`. The board logs `PKC admin payload with authorized sender
+  key` → `Expected session key: 00…` → `Admin message without session_key!` (capture via
+  `set_debug_log_api` on the same connection).
+- **nRF52 gotcha.** The nRF52 USB CDC wedges under rapid `SerialInterface` open/close churn (unrelated to
+  injection). Keep a single connection for setup + inject + log capture. If it hangs (zero serial
+  output, connect timeout) and `uhubctl` can't power-cycle the port, recover with a 1200 bps-touch DFU
+  reflash (`pio run -e <env> -t upload`) — the bootloader survives the hung app.
 
 ## Rules
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,10 +25,12 @@ dependencies = [
   "pyserial>=3.5",
   "meshtastic>=2.7.8",
   "platformdirs>=4.0",
-  "cryptography>=42.0",  # inject_frame: channel AES-CTR frame crafting
 ]
 
 [project.optional-dependencies]
+# Channel AES-CTR frame crafting for `inject_frame` / `meshinject` (encrypted mode).
+# Lazy-imported (inject.py); decoded/ciphertext/fuzz modes work without it.
+inject = ["cryptography>=42.0"]
 # Hardware test harness (pytest + live TUI).
 test = [
   "pytest>=8",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ dependencies = [
   "pyserial>=3.5",
   "meshtastic>=2.7.8",
   "platformdirs>=4.0",
+  "cryptography>=42.0",  # inject_frame: channel AES-CTR frame crafting
 ]
 
 [project.optional-dependencies]

--- a/src/meshtastic_mcp/cli/meshinject.py
+++ b/src/meshtastic_mcp/cli/meshinject.py
@@ -1,0 +1,223 @@
+#!/usr/bin/env python3
+"""
+meshinject - inject packets into a locally-connected Meshtastic board as if they arrived off the LoRa
+radio. Requires the target to run firmware built with -D MESHTASTIC_ENABLE_FRAME_INJECTION=1 (portduino
+sim nodes support it unconditionally).
+
+A crafted frame rides inside a Compressed envelope wrapped in a MeshPacket sent on the SIMULATOR_APP
+portnum (69). The firmware (MeshService::injectAsReceived) unwraps it and delivers it through the real
+receive pipeline, so it gets from!=0 enforcement, channel/PKC decryption, hop handling, dedup, and
+module dispatch - exactly like an over-the-air packet.
+
+  Compressed.portnum == UNKNOWN_APP -> Compressed.data is verbatim CIPHERTEXT (firmware decrypts it)
+  Compressed.portnum == <portnum>   -> Compressed.data is the DECODED payload for that portnum
+
+Run with the meshtastic-CLI venv python (has meshtastic + cryptography).
+"""
+import argparse, os, random, struct, sys, time
+
+from meshtastic import mesh_pb2, portnums_pb2, admin_pb2
+import meshtastic.serial_interface as ser
+import meshtastic.tcp_interface as tcp
+from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
+
+# The public "default" PSK family (src/mesh/Channels.h). 1-byte PSK index N -> this with last byte += N-1.
+DEFAULT_PSK = bytes([0xd4, 0xf1, 0xbb, 0x3a, 0x20, 0x29, 0x07, 0x59,
+                     0xf0, 0xbc, 0xff, 0xab, 0xcf, 0x4e, 0x69, 0x01])
+SIMULATOR_APP = 69
+UNKNOWN_APP = 0
+
+# Modem preset enum value -> the long display name Channels::getName() hashes for an empty channel name.
+PRESET_LONGNAME = {
+    0: "LongFast", 1: "LongSlow", 2: "LongMod", 3: "MediumSlow", 4: "MediumFast",
+    5: "ShortSlow", 6: "ShortFast", 7: "LongTurbo", 8: "ShortTurbo", 9: "MediumTurbo",
+    # newer presets (values may shift across versions; name resolved from the device is preferred)
+}
+
+
+def xor_hash(b: bytes) -> int:
+    h = 0
+    for x in b:
+        h ^= x
+    return h
+
+
+def expand_psk(psk: bytes) -> bytes:
+    """Mirror Channels::getKey expansion. Returns b'' for 'no encryption'."""
+    if len(psk) == 0:
+        return b""
+    if len(psk) == 1:
+        idx = psk[0]
+        if idx == 0:
+            return b""  # encryption off
+        k = bytearray(DEFAULT_PSK)
+        k[-1] = (k[-1] + idx - 1) & 0xFF
+        return bytes(k)
+    if len(psk) < 16:  # firmware zero-pads a too-short key to AES128
+        return psk + b"\x00" * (16 - len(psk))
+    return psk
+
+
+def channel_hash(name: str, key: bytes) -> int:
+    return xor_hash(name.encode()) ^ xor_hash(key)
+
+
+def aes_ctr(key: bytes, from_node: int, packet_id: int, data: bytes) -> bytes:
+    """Meshtastic channel crypto: AES-CTR, IV = packetId(8 LE) | fromNode(4 LE) | 0(4)."""
+    nonce = struct.pack("<QII", packet_id & 0xFFFFFFFFFFFFFFFF, from_node & 0xFFFFFFFF, 0)
+    algo = algorithms.AES(key)  # 16B->AES128, 32B->AES256
+    enc = Cipher(algo, modes.CTR(nonce)).encryptor()
+    return enc.update(data) + enc.finalize()
+
+
+def connect(args):
+    if args.serial:
+        return ser.SerialInterface(devPath=args.serial)
+    host, _, port = (args.host or "localhost").partition(":")
+    return tcp.TCPInterface(host, portNumber=int(port) if port else 4403)
+
+
+def resolve_channel(iface, ch_index):
+    """Return (resolved_name, expanded_key, hash_byte) for the given channel index on the target."""
+    ch = iface.localNode.getChannelByChannelIndex(ch_index)
+    settings = ch.settings
+    key = expand_psk(bytes(settings.psk))
+    name = settings.name
+    if not name:  # empty -> firmware substitutes the modem-preset long name (if use_preset)
+        lc = iface.localNode.localConfig.lora
+        name = PRESET_LONGNAME.get(int(lc.modem_preset), "LongFast") if lc.use_preset else "Custom"
+    return name, key, channel_hash(name, key)
+
+
+def send_frame(iface, *, from_node, to_node, packet_id, ch_hash, inner_portnum, inner_bytes,
+               encrypted, pki_encrypted=False, public_key=b"", want_ack=False, hop_limit=3):
+    """Wrap inner_bytes (ciphertext if encrypted else decoded payload) and inject via SIMULATOR_APP."""
+    comp = mesh_pb2.Compressed()
+    comp.portnum = UNKNOWN_APP if encrypted else inner_portnum
+    comp.data = inner_bytes
+
+    mp = mesh_pb2.MeshPacket()
+    mp.__setattr__("from", from_node)  # 'from' is a Python keyword
+    mp.to = to_node
+    mp.id = packet_id
+    mp.channel = ch_hash & 0xFF
+    mp.want_ack = want_ack
+    mp.hop_limit = hop_limit
+    mp.hop_start = hop_limit
+    if pki_encrypted:
+        mp.pki_encrypted = True
+        if public_key:
+            mp.public_key = public_key
+    mp.decoded.portnum = SIMULATOR_APP
+    mp.decoded.payload = comp.SerializeToString()
+
+    tr = mesh_pb2.ToRadio()
+    tr.packet.CopyFrom(mp)
+    iface._sendToRadio(tr)
+    kind = "encrypted" if encrypted else "decoded"
+    print(f"injected {kind} frame: from=0x{from_node:08x} to=0x{to_node:08x} id=0x{packet_id:08x} "
+          f"ch={mp.channel} portnum={inner_portnum} len={len(inner_bytes)}"
+          f"{' pki' if pki_encrypted else ''}")
+
+
+def rand_id():
+    return random.getrandbits(32) or 1
+
+
+def build_data(portnum, payload, want_response=False):
+    d = mesh_pb2.Data()
+    d.portnum = portnum
+    d.payload = payload
+    if want_response:
+        d.want_response = True
+    return d.SerializeToString()
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--serial", help="serial device path (e.g. /dev/cu.usbmodem101)")
+    ap.add_argument("--host", help="TCP host or host:port (default localhost:4403)")
+    ap.add_argument("--from", dest="from_node", default="0xdeadbeef",
+                    help="source NodeNum to forge (hex or int). from==0 is dropped like real RX.")
+    ap.add_argument("--to", dest="to_node", default=None, help="destination NodeNum (default: the target's own num)")
+    ap.add_argument("--channel-index", type=int, default=0)
+    ap.add_argument("--id", dest="pid", default=None, help="packet id (default random)")
+    ap.add_argument("--want-response", action="store_true")
+    ap.add_argument("--no-encrypt", action="store_true",
+                    help="inject as already-decoded (skip channel encryption); needed with --pki")
+    ap.add_argument("--pki", action="store_true", help="mark pki_encrypted and attach --public-key")
+    ap.add_argument("--public-key", help="dest/sender public key (base64) for --pki")
+
+    sub = ap.add_subparsers(dest="cmd", required=True)
+    p_text = sub.add_parser("text", help="inject a text message")
+    p_text.add_argument("body")
+    p_raw = sub.add_parser("raw", help="inject arbitrary portnum + payload (hex)")
+    p_raw.add_argument("--portnum", type=int, required=True)
+    p_raw.add_argument("--payload-hex", default="")
+    p_admin = sub.add_parser("admin", help="inject an admin set_owner (reproduces remote-admin scenarios)")
+    p_admin.add_argument("--long", default="INJECTED")
+    p_admin.add_argument("--short", default="INJ")
+    p_admin.add_argument("--session-hex", default="", help="8-byte session_passkey to present (hex)")
+    p_cipher = sub.add_parser("ciphertext", help="inject verbatim ciphertext bytes (hex)")
+    p_cipher.add_argument("--hex", required=True)
+    p_fuzz = sub.add_parser("fuzz", help="inject N random/malformed frames")
+    p_fuzz.add_argument("-n", type=int, default=10)
+    p_fuzz.add_argument("--seed", type=int, default=1)
+    args = ap.parse_args()
+
+    from_node = int(args.from_node, 0)
+    iface = connect(args)
+    my_num = iface.getMyNodeInfo()["num"]
+    to_node = int(args.to_node, 0) if args.to_node else my_num
+    name, key, chash = resolve_channel(iface, args.channel_index)
+    pubkey = None
+    if args.public_key:
+        import base64
+        pubkey = base64.b64decode(args.public_key)
+    print(f"target=0x{my_num:08x} channel[{args.channel_index}]='{name}' hash={chash} keylen={len(key)}")
+
+    encrypt = not args.no_encrypt
+
+    def inject_payload(portnum, payload, want_response=False):
+        pid = int(args.pid, 0) if args.pid else rand_id()
+        if encrypt:
+            if not key:
+                sys.exit("channel has no key; use --no-encrypt or a keyed channel")
+            inner = aes_ctr(key, from_node, pid, build_data(portnum, payload, want_response))
+        else:
+            inner = payload  # decoded path carries the raw app payload
+        send_frame(iface, from_node=from_node, to_node=to_node, packet_id=pid, ch_hash=chash,
+                   inner_portnum=portnum, inner_bytes=inner, encrypted=encrypt,
+                   pki_encrypted=args.pki, public_key=pubkey or b"", want_ack=args.want_response)
+
+    if args.cmd == "text":
+        inject_payload(portnums_pb2.PortNum.TEXT_MESSAGE_APP, args.body.encode(), args.want_response)
+    elif args.cmd == "raw":
+        inject_payload(args.portnum, bytes.fromhex(args.payload_hex), args.want_response)
+    elif args.cmd == "admin":
+        am = admin_pb2.AdminMessage()
+        am.set_owner.long_name = args.long
+        am.set_owner.short_name = args.short
+        if args.session_hex:
+            am.session_passkey = bytes.fromhex(args.session_hex)
+        inject_payload(portnums_pb2.PortNum.ADMIN_APP, am.SerializeToString(), True)
+    elif args.cmd == "ciphertext":
+        pid = int(args.pid, 0) if args.pid else rand_id()
+        send_frame(iface, from_node=from_node, to_node=to_node, packet_id=pid, ch_hash=chash,
+                   inner_portnum=UNKNOWN_APP, inner_bytes=bytes.fromhex(args.hex), encrypted=True,
+                   pki_encrypted=args.pki, public_key=pubkey or b"")
+    elif args.cmd == "fuzz":
+        rng = random.Random(args.seed)
+        for i in range(args.n):
+            blob = bytes(rng.getrandbits(8) for _ in range(rng.randint(0, 240)))
+            pid = rand_id()
+            send_frame(iface, from_node=from_node or 0x1000 + i, to_node=to_node, packet_id=pid,
+                       ch_hash=rng.randint(0, 255), inner_portnum=UNKNOWN_APP, inner_bytes=blob, encrypted=True)
+            time.sleep(0.05)
+
+    time.sleep(1.5)
+    iface.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/meshtastic_mcp/cli/meshinject.py
+++ b/src/meshtastic_mcp/cli/meshinject.py
@@ -14,23 +14,36 @@ module dispatch - exactly like an over-the-air packet.
 
 Run with the meshtastic-CLI venv python (has meshtastic + cryptography).
 """
-import argparse, os, random, struct, sys, time
 
-from meshtastic import mesh_pb2, portnums_pb2, admin_pb2
+import argparse
+import random
+import struct
+import sys
+import time
+
 import meshtastic.serial_interface as ser
 import meshtastic.tcp_interface as tcp
-from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
+from meshtastic import admin_pb2, mesh_pb2, portnums_pb2
 
 # The public "default" PSK family (src/mesh/Channels.h). 1-byte PSK index N -> this with last byte += N-1.
-DEFAULT_PSK = bytes([0xd4, 0xf1, 0xbb, 0x3a, 0x20, 0x29, 0x07, 0x59,
-                     0xf0, 0xbc, 0xff, 0xab, 0xcf, 0x4e, 0x69, 0x01])
+DEFAULT_PSK = bytes(
+    [0xD4, 0xF1, 0xBB, 0x3A, 0x20, 0x29, 0x07, 0x59, 0xF0, 0xBC, 0xFF, 0xAB, 0xCF, 0x4E, 0x69, 0x01]
+)
 SIMULATOR_APP = 69
 UNKNOWN_APP = 0
 
 # Modem preset enum value -> the long display name Channels::getName() hashes for an empty channel name.
 PRESET_LONGNAME = {
-    0: "LongFast", 1: "LongSlow", 2: "LongMod", 3: "MediumSlow", 4: "MediumFast",
-    5: "ShortSlow", 6: "ShortFast", 7: "LongTurbo", 8: "ShortTurbo", 9: "MediumTurbo",
+    0: "LongFast",
+    1: "LongSlow",
+    2: "LongMod",
+    3: "MediumSlow",
+    4: "MediumFast",
+    5: "ShortSlow",
+    6: "ShortFast",
+    7: "LongTurbo",
+    8: "ShortTurbo",
+    9: "MediumTurbo",
     # newer presets (values may shift across versions; name resolved from the device is preferred)
 }
 
@@ -55,6 +68,8 @@ def expand_psk(psk: bytes) -> bytes:
         return bytes(k)
     if len(psk) < 16:  # firmware zero-pads a too-short key to AES128
         return psk + b"\x00" * (16 - len(psk))
+    if len(psk) < 32 and len(psk) != 16:  # firmware pads a 17-31 byte key up to AES256
+        return psk + b"\x00" * (32 - len(psk))
     return psk
 
 
@@ -64,6 +79,8 @@ def channel_hash(name: str, key: bytes) -> int:
 
 def aes_ctr(key: bytes, from_node: int, packet_id: int, data: bytes) -> bytes:
     """Meshtastic channel crypto: AES-CTR, IV = packetId(8 LE) | fromNode(4 LE) | 0(4)."""
+    from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
+
     nonce = struct.pack("<QII", packet_id & 0xFFFFFFFFFFFFFFFF, from_node & 0xFFFFFFFF, 0)
     algo = algorithms.AES(key)  # 16B->AES128, 32B->AES256
     enc = Cipher(algo, modes.CTR(nonce)).encryptor()
@@ -80,6 +97,8 @@ def connect(args):
 def resolve_channel(iface, ch_index):
     """Return (resolved_name, expanded_key, hash_byte) for the given channel index on the target."""
     ch = iface.localNode.getChannelByChannelIndex(ch_index)
+    if ch is None:
+        raise SystemExit(f"channel index {ch_index} is not configured on this node")
     settings = ch.settings
     key = expand_psk(bytes(settings.psk))
     name = settings.name
@@ -89,13 +108,28 @@ def resolve_channel(iface, ch_index):
     return name, key, channel_hash(name, key)
 
 
-def send_frame(iface, *, from_node, to_node, packet_id, ch_hash, inner_portnum, inner_bytes,
-               encrypted, pki_encrypted=False, public_key=b"", want_ack=False, hop_limit=3):
+def send_frame(
+    iface,
+    *,
+    from_node,
+    to_node,
+    packet_id,
+    ch_hash,
+    inner_portnum,
+    inner_bytes,
+    encrypted,
+    pki_encrypted=False,
+    public_key=b"",
+    want_ack=False,
+    hop_limit=3,
+):
     """Wrap inner_bytes (ciphertext if encrypted else decoded payload) and inject via SIMULATOR_APP."""
     comp = mesh_pb2.Compressed()
     comp.portnum = UNKNOWN_APP if encrypted else inner_portnum
     comp.data = inner_bytes
 
+    from_node &= 0xFFFFFFFF  # wrap to uint32 so a bad value doesn't raise a protobuf range error
+    to_node &= 0xFFFFFFFF
     mp = mesh_pb2.MeshPacket()
     mp.__setattr__("from", from_node)  # 'from' is a Python keyword
     mp.to = to_node
@@ -115,9 +149,11 @@ def send_frame(iface, *, from_node, to_node, packet_id, ch_hash, inner_portnum, 
     tr.packet.CopyFrom(mp)
     iface._sendToRadio(tr)
     kind = "encrypted" if encrypted else "decoded"
-    print(f"injected {kind} frame: from=0x{from_node:08x} to=0x{to_node:08x} id=0x{packet_id:08x} "
-          f"ch={mp.channel} portnum={inner_portnum} len={len(inner_bytes)}"
-          f"{' pki' if pki_encrypted else ''}")
+    print(
+        f"injected {kind} frame: from=0x{from_node:08x} to=0x{to_node:08x} id=0x{packet_id:08x} "
+        f"ch={mp.channel} portnum={inner_portnum} len={len(inner_bytes)}"
+        f"{' pki' if pki_encrypted else ''}"
+    )
 
 
 def rand_id():
@@ -134,17 +170,31 @@ def build_data(portnum, payload, want_response=False):
 
 
 def main():
-    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
     ap.add_argument("--serial", help="serial device path (e.g. /dev/cu.usbmodem101)")
     ap.add_argument("--host", help="TCP host or host:port (default localhost:4403)")
-    ap.add_argument("--from", dest="from_node", default="0xdeadbeef",
-                    help="source NodeNum to forge (hex or int). from==0 is dropped like real RX.")
-    ap.add_argument("--to", dest="to_node", default=None, help="destination NodeNum (default: the target's own num)")
+    ap.add_argument(
+        "--from",
+        dest="from_node",
+        default="0xdeadbeef",
+        help="source NodeNum to forge (hex or int). from==0 is dropped like real RX.",
+    )
+    ap.add_argument(
+        "--to",
+        dest="to_node",
+        default=None,
+        help="destination NodeNum (default: the target's own num)",
+    )
     ap.add_argument("--channel-index", type=int, default=0)
     ap.add_argument("--id", dest="pid", default=None, help="packet id (default random)")
     ap.add_argument("--want-response", action="store_true")
-    ap.add_argument("--no-encrypt", action="store_true",
-                    help="inject as already-decoded (skip channel encryption); needed with --pki")
+    ap.add_argument(
+        "--no-encrypt",
+        action="store_true",
+        help="inject as already-decoded (skip channel encryption); needed with --pki",
+    )
     ap.add_argument("--pki", action="store_true", help="mark pki_encrypted and attach --public-key")
     ap.add_argument("--public-key", help="dest/sender public key (base64) for --pki")
 
@@ -154,10 +204,14 @@ def main():
     p_raw = sub.add_parser("raw", help="inject arbitrary portnum + payload (hex)")
     p_raw.add_argument("--portnum", type=int, required=True)
     p_raw.add_argument("--payload-hex", default="")
-    p_admin = sub.add_parser("admin", help="inject an admin set_owner (reproduces remote-admin scenarios)")
+    p_admin = sub.add_parser(
+        "admin", help="inject an admin set_owner (reproduces remote-admin scenarios)"
+    )
     p_admin.add_argument("--long", default="INJECTED")
     p_admin.add_argument("--short", default="INJ")
-    p_admin.add_argument("--session-hex", default="", help="8-byte session_passkey to present (hex)")
+    p_admin.add_argument(
+        "--session-hex", default="", help="8-byte session_passkey to present (hex)"
+    )
     p_cipher = sub.add_parser("ciphertext", help="inject verbatim ciphertext bytes (hex)")
     p_cipher.add_argument("--hex", required=True)
     p_fuzz = sub.add_parser("fuzz", help="inject N random/malformed frames")
@@ -173,8 +227,11 @@ def main():
     pubkey = None
     if args.public_key:
         import base64
+
         pubkey = base64.b64decode(args.public_key)
-    print(f"target=0x{my_num:08x} channel[{args.channel_index}]='{name}' hash={chash} keylen={len(key)}")
+    print(
+        f"target=0x{my_num:08x} channel[{args.channel_index}]='{name}' hash={chash} keylen={len(key)}"
+    )
 
     encrypt = not args.no_encrypt
 
@@ -186,12 +243,24 @@ def main():
             inner = aes_ctr(key, from_node, pid, build_data(portnum, payload, want_response))
         else:
             inner = payload  # decoded path carries the raw app payload
-        send_frame(iface, from_node=from_node, to_node=to_node, packet_id=pid, ch_hash=chash,
-                   inner_portnum=portnum, inner_bytes=inner, encrypted=encrypt,
-                   pki_encrypted=args.pki, public_key=pubkey or b"", want_ack=args.want_response)
+        send_frame(
+            iface,
+            from_node=from_node,
+            to_node=to_node,
+            packet_id=pid,
+            ch_hash=chash,
+            inner_portnum=portnum,
+            inner_bytes=inner,
+            encrypted=encrypt,
+            pki_encrypted=args.pki,
+            public_key=pubkey or b"",
+            want_ack=args.want_response,
+        )
 
     if args.cmd == "text":
-        inject_payload(portnums_pb2.PortNum.TEXT_MESSAGE_APP, args.body.encode(), args.want_response)
+        inject_payload(
+            portnums_pb2.PortNum.TEXT_MESSAGE_APP, args.body.encode(), args.want_response
+        )
     elif args.cmd == "raw":
         inject_payload(args.portnum, bytes.fromhex(args.payload_hex), args.want_response)
     elif args.cmd == "admin":
@@ -203,16 +272,33 @@ def main():
         inject_payload(portnums_pb2.PortNum.ADMIN_APP, am.SerializeToString(), True)
     elif args.cmd == "ciphertext":
         pid = int(args.pid, 0) if args.pid else rand_id()
-        send_frame(iface, from_node=from_node, to_node=to_node, packet_id=pid, ch_hash=chash,
-                   inner_portnum=UNKNOWN_APP, inner_bytes=bytes.fromhex(args.hex), encrypted=True,
-                   pki_encrypted=args.pki, public_key=pubkey or b"")
+        send_frame(
+            iface,
+            from_node=from_node,
+            to_node=to_node,
+            packet_id=pid,
+            ch_hash=chash,
+            inner_portnum=UNKNOWN_APP,
+            inner_bytes=bytes.fromhex(args.hex),
+            encrypted=True,
+            pki_encrypted=args.pki,
+            public_key=pubkey or b"",
+        )
     elif args.cmd == "fuzz":
         rng = random.Random(args.seed)
         for i in range(args.n):
             blob = bytes(rng.getrandbits(8) for _ in range(rng.randint(0, 240)))
             pid = rand_id()
-            send_frame(iface, from_node=from_node or 0x1000 + i, to_node=to_node, packet_id=pid,
-                       ch_hash=rng.randint(0, 255), inner_portnum=UNKNOWN_APP, inner_bytes=blob, encrypted=True)
+            send_frame(
+                iface,
+                from_node=from_node or 0x1000 + i,
+                to_node=to_node,
+                packet_id=pid,
+                ch_hash=rng.randint(0, 255),
+                inner_portnum=UNKNOWN_APP,
+                inner_bytes=blob,
+                encrypted=True,
+            )
             time.sleep(0.05)
 
     time.sleep(1.5)

--- a/src/meshtastic_mcp/cli/meshinject.py
+++ b/src/meshtastic_mcp/cli/meshinject.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python3
+# SPDX-FileCopyrightText: Meshtastic contributors
+# SPDX-License-Identifier: GPL-3.0-only
 """
 meshinject - inject packets into a locally-connected Meshtastic board as if they arrived off the LoRa
 radio. Requires the target to run firmware built with -D MESHTASTIC_ENABLE_FRAME_INJECTION=1 (portduino

--- a/src/meshtastic_mcp/inject.py
+++ b/src/meshtastic_mcp/inject.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Meshtastic contributors
+# SPDX-License-Identifier: GPL-3.0-only
+
 """Inject packets into a locally-connected board as if they arrived off the LoRa radio.
 
 Requires the target to run firmware built with ``-D MESHTASTIC_ENABLE_FRAME_INJECTION=1``

--- a/src/meshtastic_mcp/inject.py
+++ b/src/meshtastic_mcp/inject.py
@@ -1,0 +1,275 @@
+"""Inject packets into a locally-connected board as if they arrived off the LoRa radio.
+
+Requires the target to run firmware built with ``-D MESHTASTIC_ENABLE_FRAME_INJECTION=1``
+(portduino sim nodes support it unconditionally). A crafted frame rides inside a ``Compressed``
+envelope wrapped in a ``MeshPacket`` sent on the ``SIMULATOR_APP`` portnum (69); the firmware
+unwraps it and delivers it through the real receive pipeline, so it gets ``from!=0`` enforcement,
+channel/PKC decryption, hop handling, dedup, and module dispatch - like an over-the-air packet.
+
+    Compressed.portnum == UNKNOWN_APP -> Compressed.data is verbatim CIPHERTEXT (firmware decrypts)
+    Compressed.portnum == <portnum>   -> Compressed.data is the DECODED payload for that portnum
+
+Firmware seam: ``MeshService::injectAsReceived`` (src/mesh/MeshService.cpp).
+"""
+
+from __future__ import annotations
+
+import random
+import struct
+from typing import Any
+
+from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
+from meshtastic import admin_pb2, mesh_pb2, portnums_pb2
+
+from .connection import connect
+
+# Public "default" PSK family (src/mesh/Channels.h). 1-byte PSK index N -> this, last byte += N-1.
+DEFAULT_PSK = bytes(
+    [0xD4, 0xF1, 0xBB, 0x3A, 0x20, 0x29, 0x07, 0x59, 0xF0, 0xBC, 0xFF, 0xAB, 0xCF, 0x4E, 0x69, 0x01]
+)
+SIMULATOR_APP = 69
+UNKNOWN_APP = 0
+
+# Modem-preset enum -> the long display name Channels::getName() hashes for an empty channel name.
+PRESET_LONGNAME = {
+    0: "LongFast",
+    1: "LongSlow",
+    2: "LongMod",
+    3: "MediumSlow",
+    4: "MediumFast",
+    5: "ShortSlow",
+    6: "ShortFast",
+    7: "LongTurbo",
+    8: "ShortTurbo",
+    9: "MediumTurbo",
+}
+
+
+def _xor_hash(b: bytes) -> int:
+    h = 0
+    for x in b:
+        h ^= x
+    return h
+
+
+def _expand_psk(psk: bytes) -> bytes:
+    """Mirror Channels::getKey expansion. Returns b'' for 'no encryption'."""
+    if len(psk) == 0:
+        return b""
+    if len(psk) == 1:
+        idx = psk[0]
+        if idx == 0:
+            return b""
+        k = bytearray(DEFAULT_PSK)
+        k[-1] = (k[-1] + idx - 1) & 0xFF
+        return bytes(k)
+    if len(psk) < 16:
+        return psk + b"\x00" * (16 - len(psk))
+    return psk
+
+
+def _channel_hash(name: str, key: bytes) -> int:
+    return _xor_hash(name.encode()) ^ _xor_hash(key)
+
+
+def _aes_ctr(key: bytes, from_node: int, packet_id: int, data: bytes) -> bytes:
+    """Meshtastic channel crypto: AES-CTR, IV = packetId(8 LE) | fromNode(4 LE) | 0(4)."""
+    nonce = struct.pack("<QII", packet_id & 0xFFFFFFFFFFFFFFFF, from_node & 0xFFFFFFFF, 0)
+    enc = Cipher(algorithms.AES(key), modes.CTR(nonce)).encryptor()
+    return enc.update(data) + enc.finalize()
+
+
+def _resolve_channel(iface, ch_index: int) -> tuple[str, bytes, int]:
+    ch = iface.localNode.getChannelByChannelIndex(ch_index)
+    key = _expand_psk(bytes(ch.settings.psk))
+    name = ch.settings.name
+    if not name:
+        lc = iface.localNode.localConfig.lora
+        name = PRESET_LONGNAME.get(int(lc.modem_preset), "LongFast") if lc.use_preset else "Custom"
+    return name, key, _channel_hash(name, key)
+
+
+def _build_data(portnum: int, payload: bytes, want_response: bool) -> bytes:
+    d = mesh_pb2.Data()
+    d.portnum = portnum
+    d.payload = payload
+    if want_response:
+        d.want_response = True
+    return d.SerializeToString()
+
+
+def _rand_id() -> int:
+    return random.getrandbits(32) or 1
+
+
+def _send(
+    iface,
+    *,
+    from_node,
+    to_node,
+    packet_id,
+    ch_hash,
+    inner_portnum,
+    inner_bytes,
+    encrypted,
+    pki_encrypted=False,
+    public_key=b"",
+    want_ack=False,
+    hop_limit=3,
+) -> dict[str, Any]:
+    comp = mesh_pb2.Compressed()
+    comp.portnum = UNKNOWN_APP if encrypted else inner_portnum
+    comp.data = inner_bytes
+
+    mp = mesh_pb2.MeshPacket()
+    setattr(mp, "from", from_node)  # 'from' is a Python keyword
+    mp.to = to_node
+    mp.id = packet_id
+    mp.channel = ch_hash & 0xFF
+    mp.want_ack = want_ack
+    mp.hop_limit = hop_limit
+    mp.hop_start = hop_limit
+    if pki_encrypted:
+        mp.pki_encrypted = True
+        if public_key:
+            mp.public_key = public_key
+    mp.decoded.portnum = SIMULATOR_APP
+    mp.decoded.payload = comp.SerializeToString()
+
+    tr = mesh_pb2.ToRadio()
+    tr.packet.CopyFrom(mp)
+    iface._sendToRadio(tr)
+    return {
+        "from": f"0x{from_node:08x}",
+        "to": f"0x{to_node:08x}",
+        "id": f"0x{packet_id:08x}",
+        "channel_hash": mp.channel,
+        "portnum": inner_portnum,
+        "bytes": len(inner_bytes),
+        "encrypted": encrypted,
+        "pki_encrypted": pki_encrypted,
+    }
+
+
+def inject_frame(
+    mode: str = "text",
+    body: str | None = None,
+    portnum: int | None = None,
+    payload_hex: str = "",
+    ciphertext_hex: str = "",
+    long_name: str = "INJECTED",
+    short_name: str = "INJ",
+    session_hex: str = "",
+    from_node: str | int = "0xdeadbeef",
+    to: str | int | None = None,
+    channel_index: int = 0,
+    packet_id: str | int | None = None,
+    want_response: bool = False,
+    encrypt: bool = True,
+    pki: bool = False,
+    public_key_b64: str | None = None,
+    fuzz_count: int = 10,
+    fuzz_seed: int = 1,
+    port: str | None = None,
+) -> dict[str, Any]:
+    """Craft frame(s) and inject via SIMULATOR_APP. See module docstring for the wire format."""
+    frm = int(from_node, 0) if isinstance(from_node, str) else int(from_node)
+    pubkey = None
+    if public_key_b64:
+        import base64
+
+        pubkey = base64.b64decode(public_key_b64)
+
+    with connect(port=port) as iface:
+        my_num = iface.getMyNodeInfo()["num"]
+        to_node = (int(to, 0) if isinstance(to, str) else int(to)) if to is not None else my_num
+        name, key, chash = _resolve_channel(iface, channel_index)
+
+        def _pid() -> int:
+            return (
+                (int(packet_id, 0) if isinstance(packet_id, str) else int(packet_id))
+                if packet_id
+                else _rand_id()
+            )
+
+        def _inject_payload(pn: int, payload: bytes) -> dict[str, Any]:
+            pid = _pid()
+            if encrypt:
+                if not key:
+                    raise ValueError(
+                        "channel has no key; set encrypt=false or target a keyed channel"
+                    )
+                inner = _aes_ctr(key, frm, pid, _build_data(pn, payload, want_response))
+            else:
+                inner = payload
+            return _send(
+                iface,
+                from_node=frm,
+                to_node=to_node,
+                packet_id=pid,
+                ch_hash=chash,
+                inner_portnum=pn,
+                inner_bytes=inner,
+                encrypted=encrypt,
+                pki_encrypted=pki,
+                public_key=pubkey or b"",
+                want_ack=want_response,
+            )
+
+        target = {
+            "target": f"0x{my_num:08x}",
+            "channel": name,
+            "channel_hash": chash,
+            "keylen": len(key),
+        }
+
+        if mode == "text":
+            sent = [_inject_payload(portnums_pb2.PortNum.TEXT_MESSAGE_APP, (body or "").encode())]
+        elif mode == "raw":
+            if portnum is None:
+                raise ValueError("mode=raw requires portnum")
+            sent = [_inject_payload(int(portnum), bytes.fromhex(payload_hex))]
+        elif mode == "admin":
+            am = admin_pb2.AdminMessage()
+            am.set_owner.long_name = long_name
+            am.set_owner.short_name = short_name
+            if session_hex:
+                am.session_passkey = bytes.fromhex(session_hex)
+            sent = [_inject_payload(portnums_pb2.PortNum.ADMIN_APP, am.SerializeToString())]
+        elif mode == "ciphertext":
+            pid = _pid()
+            sent = [
+                _send(
+                    iface,
+                    from_node=frm,
+                    to_node=to_node,
+                    packet_id=pid,
+                    ch_hash=chash,
+                    inner_portnum=UNKNOWN_APP,
+                    inner_bytes=bytes.fromhex(ciphertext_hex),
+                    encrypted=True,
+                    pki_encrypted=pki,
+                    public_key=pubkey or b"",
+                )
+            ]
+        elif mode == "fuzz":
+            rng = random.Random(fuzz_seed)
+            sent = []
+            for i in range(fuzz_count):
+                blob = bytes(rng.getrandbits(8) for _ in range(rng.randint(0, 240)))
+                sent.append(
+                    _send(
+                        iface,
+                        from_node=frm or (0x1000 + i),
+                        to_node=to_node,
+                        packet_id=_rand_id(),
+                        ch_hash=rng.randint(0, 255),
+                        inner_portnum=UNKNOWN_APP,
+                        inner_bytes=blob,
+                        encrypted=True,
+                    )
+                )
+        else:
+            raise ValueError(f"unknown mode {mode!r}")
+
+    return {"ok": True, **target, "injected": len(sent), "frames": sent}

--- a/src/meshtastic_mcp/inject.py
+++ b/src/meshtastic_mcp/inject.py
@@ -18,10 +18,15 @@ import random
 import struct
 from typing import Any
 
-from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
 from meshtastic import admin_pb2, mesh_pb2, portnums_pb2
 
 from .connection import connect
+
+
+def _require_confirm(confirm: bool) -> None:
+    if not confirm:
+        raise ValueError("inject_frame forges over-the-air traffic and requires confirm=True.")
+
 
 # Public "default" PSK family (src/mesh/Channels.h). 1-byte PSK index N -> this, last byte += N-1.
 DEFAULT_PSK = bytes(
@@ -63,8 +68,10 @@ def _expand_psk(psk: bytes) -> bytes:
         k = bytearray(DEFAULT_PSK)
         k[-1] = (k[-1] + idx - 1) & 0xFF
         return bytes(k)
-    if len(psk) < 16:
+    if len(psk) < 16:  # firmware pads a short AES128 key with zeros
         return psk + b"\x00" * (16 - len(psk))
+    if len(psk) < 32 and len(psk) != 16:  # firmware pads a 17-31 byte key up to AES256
+        return psk + b"\x00" * (32 - len(psk))
     return psk
 
 
@@ -74,6 +81,13 @@ def _channel_hash(name: str, key: bytes) -> int:
 
 def _aes_ctr(key: bytes, from_node: int, packet_id: int, data: bytes) -> bytes:
     """Meshtastic channel crypto: AES-CTR, IV = packetId(8 LE) | fromNode(4 LE) | 0(4)."""
+    try:
+        from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
+    except ImportError as e:  # cryptography is an optional extra (see pyproject `[inject]`)
+        raise RuntimeError(
+            "encrypted injection needs the 'cryptography' package: "
+            "pip install 'meshtastic-mcp[inject]' (or use encrypt=false / a raw ciphertext)"
+        ) from e
     nonce = struct.pack("<QII", packet_id & 0xFFFFFFFFFFFFFFFF, from_node & 0xFFFFFFFF, 0)
     enc = Cipher(algorithms.AES(key), modes.CTR(nonce)).encryptor()
     return enc.update(data) + enc.finalize()
@@ -81,6 +95,8 @@ def _aes_ctr(key: bytes, from_node: int, packet_id: int, data: bytes) -> bytes:
 
 def _resolve_channel(iface, ch_index: int) -> tuple[str, bytes, int]:
     ch = iface.localNode.getChannelByChannelIndex(ch_index)
+    if ch is None:
+        raise ValueError(f"channel index {ch_index} is not configured on this node")
     key = _expand_psk(bytes(ch.settings.psk))
     name = ch.settings.name
     if not name:
@@ -121,6 +137,8 @@ def _send(
     comp.portnum = UNKNOWN_APP if encrypted else inner_portnum
     comp.data = inner_bytes
 
+    from_node &= 0xFFFFFFFF  # wrap to uint32 like replay/build.py, so a bad value doesn't raise
+    to_node &= 0xFFFFFFFF
     mp = mesh_pb2.MeshPacket()
     setattr(mp, "from", from_node)  # 'from' is a Python keyword
     mp.to = to_node
@@ -170,9 +188,11 @@ def inject_frame(
     public_key_b64: str | None = None,
     fuzz_count: int = 10,
     fuzz_seed: int = 1,
+    confirm: bool = False,
     port: str | None = None,
 ) -> dict[str, Any]:
     """Craft frame(s) and inject via SIMULATOR_APP. See module docstring for the wire format."""
+    _require_confirm(confirm)
     frm = int(from_node, 0) if isinstance(from_node, str) else int(from_node)
     pubkey = None
     if public_key_b64:
@@ -186,11 +206,9 @@ def inject_frame(
         name, key, chash = _resolve_channel(iface, channel_index)
 
         def _pid() -> int:
-            return (
-                (int(packet_id, 0) if isinstance(packet_id, str) else int(packet_id))
-                if packet_id
-                else _rand_id()
-            )
+            if packet_id is None:  # not `if packet_id` - an explicit 0/"0x0" is a valid id
+                return _rand_id()
+            return int(packet_id, 0) if isinstance(packet_id, str) else int(packet_id)
 
         def _inject_payload(pn: int, payload: bytes) -> dict[str, Any]:
             pid = _pid()

--- a/src/meshtastic_mcp/inject.py
+++ b/src/meshtastic_mcp/inject.py
@@ -119,19 +119,19 @@ def _rand_id() -> int:
 
 
 def _send(
-    iface,
+    iface: Any,
     *,
-    from_node,
-    to_node,
-    packet_id,
-    ch_hash,
-    inner_portnum,
-    inner_bytes,
-    encrypted,
-    pki_encrypted=False,
-    public_key=b"",
-    want_ack=False,
-    hop_limit=3,
+    from_node: int,
+    to_node: int,
+    packet_id: int,
+    ch_hash: int,
+    inner_portnum: int,
+    inner_bytes: bytes,
+    encrypted: bool,
+    pki_encrypted: bool = False,
+    public_key: bytes = b"",
+    want_ack: bool = False,
+    hop_limit: int = 3,
 ) -> dict[str, Any]:
     comp = mesh_pb2.Compressed()
     comp.portnum = UNKNOWN_APP if encrypted else inner_portnum

--- a/src/meshtastic_mcp/server.py
+++ b/src/meshtastic_mcp/server.py
@@ -1364,9 +1364,12 @@ def inject_frame(
     public_key_b64: str | None = None,
     fuzz_count: int = 10,
     fuzz_seed: int = 1,
+    confirm: bool = False,
     port: str | None = None,
 ) -> dict[str, Any]:
     """Inject a packet into a connected board AS IF it arrived off the LoRa radio.
+
+    Destructive/`confirm=True`-gated: it forges over-the-air traffic (incl. admin) into the target.
 
     The target must run firmware built with `-D MESHTASTIC_ENABLE_FRAME_INJECTION=1` (portduino
     sim nodes support it unconditionally). The frame enters the real receive pipeline, so it gets
@@ -1407,6 +1410,7 @@ def inject_frame(
         public_key_b64=public_key_b64,
         fuzz_count=fuzz_count,
         fuzz_seed=fuzz_seed,
+        confirm=confirm,
         port=port,
     )
 

--- a/src/meshtastic_mcp/server.py
+++ b/src/meshtastic_mcp/server.py
@@ -39,6 +39,9 @@ from . import (
 from . import (
     doctor as doctor_mod,
 )
+from . import (
+    inject as inject_mod,
+)
 from . import sdk_cli as sdk_cli_mod
 from . import userprefs as userprefs_mod
 from .recorder import get_recorder
@@ -1342,6 +1345,73 @@ def send_text(
 
 
 @app.tool()
+def inject_frame(
+    mode: str = "text",
+    body: str | None = None,
+    portnum: int | None = None,
+    payload_hex: str = "",
+    ciphertext_hex: str = "",
+    long_name: str = "INJECTED",
+    short_name: str = "INJ",
+    session_hex: str = "",
+    from_node: str = "0xdeadbeef",
+    to: str | None = None,
+    channel_index: int = 0,
+    packet_id: str | None = None,
+    want_response: bool = False,
+    encrypt: bool = True,
+    pki: bool = False,
+    public_key_b64: str | None = None,
+    fuzz_count: int = 10,
+    fuzz_seed: int = 1,
+    port: str | None = None,
+) -> dict[str, Any]:
+    """Inject a packet into a connected board AS IF it arrived off the LoRa radio.
+
+    The target must run firmware built with `-D MESHTASTIC_ENABLE_FRAME_INJECTION=1` (portduino
+    sim nodes support it unconditionally). The frame enters the real receive pipeline, so it gets
+    from!=0 enforcement, channel/PKC decryption, hop handling, dedup, and module dispatch — just
+    like an over-the-air packet. Firmware seam: `MeshService::injectAsReceived`.
+
+    `mode`:
+      - "text":       inject a text message `body` from `from_node`.
+      - "raw":        inject `payload_hex` on `portnum`.
+      - "admin":      inject a set_owner admin (`long_name`/`short_name`, optional `session_hex`);
+                      pair with pki=true + public_key_b64 to exercise the PKC-admin path.
+      - "ciphertext": inject `ciphertext_hex` verbatim as encrypted bytes (fed to the decoder).
+      - "fuzz":       inject `fuzz_count` random/malformed frames (decode-path robustness testing).
+
+    `from_node` is the sender to forge (from==0 is dropped like real RX). `to` defaults to the
+    target's own num. `encrypt` (default true) channel-AES-CTR-encrypts the payload so the firmware
+    decrypts it as if received; set false to inject already-decoded (needed with `pki`).
+    `channel_index` selects which configured channel's key/hash to use.
+
+    Returns: {ok, target, channel, channel_hash, injected, frames:[{from,to,id,portnum,bytes,...}]}
+    """
+    return inject_mod.inject_frame(
+        mode=mode,
+        body=body,
+        portnum=portnum,
+        payload_hex=payload_hex,
+        ciphertext_hex=ciphertext_hex,
+        long_name=long_name,
+        short_name=short_name,
+        session_hex=session_hex,
+        from_node=from_node,
+        to=to,
+        channel_index=channel_index,
+        packet_id=packet_id,
+        want_response=want_response,
+        encrypt=encrypt,
+        pki=pki,
+        public_key_b64=public_key_b64,
+        fuzz_count=fuzz_count,
+        fuzz_seed=fuzz_seed,
+        port=port,
+    )
+
+
+@app.tool()
 def reboot(port: str | None = None, confirm: bool = False, seconds: int = 10) -> dict[str, Any]:
     """Reboot the connected node in `seconds` seconds. Requires confirm=True.
 
@@ -2467,6 +2537,7 @@ _DESTRUCTIVE = {
     "set_channel_url",
     "set_debug_log_api",
     "send_text",  # injects a mesh packet; cannot be recalled
+    "inject_frame",  # injects a forged frame into the RX pipeline; cannot be recalled
     "rf_confirm_tx",  # calls send_text internally; injects a mesh packet
     "send_input_event",  # drives device button/GPIO; side-effect on hardware
     "reboot",
@@ -2534,6 +2605,7 @@ _OPEN_WORLD = {
     "set_owner",
     "set_debug_log_api",
     "send_text",
+    "inject_frame",
     "reboot",
     "shutdown",
     "factory_reset",

--- a/uv.lock
+++ b/uv.lock
@@ -1063,7 +1063,6 @@ wheels = [
 name = "meshtastic-mcp"
 source = { editable = "." }
 dependencies = [
-    { name = "cryptography" },
     { name = "mcp" },
     { name = "meshtastic" },
     { name = "platformdirs" },
@@ -1075,6 +1074,9 @@ dev = [
     { name = "mypy" },
     { name = "pytest" },
     { name = "ruff" },
+]
+inject = [
+    { name = "cryptography" },
 ]
 sdr = [
     { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
@@ -1121,7 +1123,7 @@ web = [
 requires-dist = [
     { name = "aiosqlite", marker = "extra == 'web'", specifier = ">=0.19" },
     { name = "coverage", extras = ["toml"], marker = "extra == 'test'", specifier = ">=7" },
-    { name = "cryptography", specifier = ">=42.0" },
+    { name = "cryptography", marker = "extra == 'inject'", specifier = ">=42.0" },
     { name = "easyocr", marker = "(platform_machine != 'x86_64' and extra == 'ui') or (sys_platform != 'darwin' and extra == 'ui')", specifier = ">=1.7" },
     { name = "fastapi", marker = "extra == 'web'", specifier = ">=0.110" },
     { name = "mcp", specifier = ">=1.2" },
@@ -1153,7 +1155,7 @@ requires-dist = [
     { name = "textual", marker = "extra == 'test'", specifier = ">=0.50" },
     { name = "uvicorn", extras = ["standard"], marker = "extra == 'web'", specifier = ">=0.27" },
 ]
-provides-extras = ["dev", "sdr", "tak", "test", "ui", "ui-min", "web"]
+provides-extras = ["dev", "inject", "sdr", "tak", "test", "ui", "ui-min", "web"]
 
 [[package]]
 name = "meshtastic-tak"

--- a/uv.lock
+++ b/uv.lock
@@ -320,7 +320,7 @@ name = "clr-loader"
 version = "0.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cffi" },
+    { name = "cffi", marker = "sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/e4/46/7eea92b6aa2d68af78e049cbecec5f757f1aad44ecdecdc16bbad7eead51/clr_loader-0.3.1.tar.gz", hash = "sha256:2e073e9aaf49d1ae2f56ecba27987ad5fb68be4bcd9dd34a5bed8f0e4e128366", size = 86805, upload-time = "2026-04-18T17:49:44.287Z" }
 wheels = [
@@ -486,7 +486,7 @@ name = "cuda-bindings"
 version = "13.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cuda-pathfinder" },
+    { name = "cuda-pathfinder", marker = "sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/51/6b/457ca12dad3ee9bfcc9a545cfd6b64b359ba49de40f776f6e028e678f262/cuda_bindings-13.3.1-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c5879712accf6e14bb01aa5e67440eb84998b8d104b509cc7a6dc0b8f656a474", size = 6053539, upload-time = "2026-05-29T23:11:43.19Z" },
@@ -519,34 +519,34 @@ wheels = [
 
 [package.optional-dependencies]
 cudart = [
-    { name = "nvidia-cuda-runtime" },
+    { name = "nvidia-cuda-runtime", marker = "sys_platform == 'linux'" },
 ]
 cufft = [
-    { name = "nvidia-cufft" },
+    { name = "nvidia-cufft", marker = "sys_platform == 'linux'" },
 ]
 cufile = [
-    { name = "nvidia-cufile" },
+    { name = "nvidia-cufile", marker = "sys_platform == 'linux'" },
 ]
 cupti = [
-    { name = "nvidia-cuda-cupti" },
+    { name = "nvidia-cuda-cupti", marker = "sys_platform == 'linux'" },
 ]
 curand = [
-    { name = "nvidia-curand" },
+    { name = "nvidia-curand", marker = "sys_platform == 'linux'" },
 ]
 cusolver = [
-    { name = "nvidia-cusolver" },
+    { name = "nvidia-cusolver", marker = "sys_platform == 'linux'" },
 ]
 cusparse = [
-    { name = "nvidia-cusparse" },
+    { name = "nvidia-cusparse", marker = "sys_platform == 'linux'" },
 ]
 nvjitlink = [
-    { name = "nvidia-nvjitlink" },
+    { name = "nvidia-nvjitlink", marker = "sys_platform == 'linux'" },
 ]
 nvrtc = [
-    { name = "nvidia-cuda-nvrtc" },
+    { name = "nvidia-cuda-nvrtc", marker = "sys_platform == 'linux'" },
 ]
 nvtx = [
-    { name = "nvidia-nvtx" },
+    { name = "nvidia-nvtx", marker = "sys_platform == 'linux'" },
 ]
 
 [[package]]
@@ -1063,6 +1063,7 @@ wheels = [
 name = "meshtastic-mcp"
 source = { editable = "." }
 dependencies = [
+    { name = "cryptography" },
     { name = "mcp" },
     { name = "meshtastic" },
     { name = "platformdirs" },
@@ -1120,6 +1121,7 @@ web = [
 requires-dist = [
     { name = "aiosqlite", marker = "extra == 'web'", specifier = ">=0.19" },
     { name = "coverage", extras = ["toml"], marker = "extra == 'test'", specifier = ">=7" },
+    { name = "cryptography", specifier = ">=42.0" },
     { name = "easyocr", marker = "(platform_machine != 'x86_64' and extra == 'ui') or (sys_platform != 'darwin' and extra == 'ui')", specifier = ">=1.7" },
     { name = "fastapi", marker = "extra == 'web'", specifier = ">=0.110" },
     { name = "mcp", specifier = ">=1.2" },
@@ -1413,7 +1415,7 @@ name = "nvidia-cublas"
 version = "13.1.1.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cuda-nvrtc" },
+    { name = "nvidia-cuda-nvrtc", marker = "sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a7/a1/0bd24ee8c8d03adac032fd2909426a00c88f8c57961b1277ded97f91119f/nvidia_cublas-13.1.1.3-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:b7a210458267ac818974c53038fbec2e969d5c99f305ab15c72522fa9f001dd5", size = 542848918, upload-time = "2026-04-08T18:46:22.985Z" },
@@ -1452,7 +1454,7 @@ name = "nvidia-cudnn-cu13"
 version = "9.20.0.48"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas" },
+    { name = "nvidia-cublas", marker = "sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/56/c5/83384d846b2fd17c44bd499b36c75a45ed4f095fbbb2252294e89cea5c5c/nvidia_cudnn_cu13-9.20.0.48-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:e31454ae00094b0c55319d9d15b6fa2fc50a9e1c0f5c8c80fb75258234e731e1", size = 444574296, upload-time = "2026-03-09T19:28:27.751Z" },
@@ -1464,7 +1466,7 @@ name = "nvidia-cufft"
 version = "12.0.0.61"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink" },
+    { name = "nvidia-nvjitlink", marker = "sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8b/ae/f417a75c0259e85c1d2f83ca4e960289a5f814ed0cea74d18c353d3e989d/nvidia_cufft-12.0.0.61-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:2708c852ef8cd89d1d2068bdbece0aa188813a0c934db3779b9b1faa8442e5f5", size = 214053554, upload-time = "2025-09-04T08:31:38.196Z" },
@@ -1494,9 +1496,9 @@ name = "nvidia-cusolver"
 version = "12.0.4.66"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas" },
-    { name = "nvidia-cusparse" },
-    { name = "nvidia-nvjitlink" },
+    { name = "nvidia-cublas", marker = "sys_platform != 'win32'" },
+    { name = "nvidia-cusparse", marker = "sys_platform != 'win32'" },
+    { name = "nvidia-nvjitlink", marker = "sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c8/c3/b30c9e935fc01e3da443ec0116ed1b2a009bb867f5324d3f2d7e533e776b/nvidia_cusolver-12.0.4.66-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:02c2457eaa9e39de20f880f4bd8820e6a1cfb9f9a34f820eb12a155aa5bc92d2", size = 223467760, upload-time = "2025-09-04T08:33:04.222Z" },
@@ -1508,7 +1510,7 @@ name = "nvidia-cusparse"
 version = "12.6.3.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink" },
+    { name = "nvidia-nvjitlink", marker = "sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f8/94/5c26f33738ae35276672f12615a64bd008ed5be6d1ebcb23579285d960a9/nvidia_cusparse-12.6.3.3-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:80bcc4662f23f1054ee334a15c72b8940402975e0eab63178fc7e670aa59472c", size = 162155568, upload-time = "2025-09-04T08:33:42.864Z" },
@@ -1944,7 +1946,7 @@ name = "pyobjc-framework-cocoa"
 version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pyobjc-core" },
+    { name = "pyobjc-core", marker = "sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/51/34/fbe38a204643aa4e1b91391cdce07a34da565a69171ebcad08de7438a556/pyobjc_framework_cocoa-12.2.1.tar.gz", hash = "sha256:b94b37fe5730e5ae1fb0052912cd174e6ec329b0bfba4a012ae5db1014b5864b", size = 3125751, upload-time = "2026-06-19T16:20:05.159Z" }
 wheels = [
@@ -1963,8 +1965,8 @@ name = "pyobjc-framework-corebluetooth"
 version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pyobjc-core" },
-    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-core", marker = "sys_platform != 'win32'" },
+    { name = "pyobjc-framework-cocoa", marker = "sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/d4/91/c76f3c5e8e80c7047e43c4c05b3e6fda9a7cefad5aae85487007674c966c/pyobjc_framework_corebluetooth-12.2.1.tar.gz", hash = "sha256:7dbb285295097205bebbcb11f55161e5faa02111108fb7b17536176e31971eb0", size = 37568, upload-time = "2026-06-19T16:20:12.191Z" }
 wheels = [
@@ -1983,8 +1985,8 @@ name = "pyobjc-framework-libdispatch"
 version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pyobjc-core" },
-    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-core", marker = "sys_platform != 'win32'" },
+    { name = "pyobjc-framework-cocoa", marker = "sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/d9/3f/561653aff3f19873457c95c053f0298da517be89fdfc0ec35115ed5b7030/pyobjc_framework_libdispatch-12.2.1.tar.gz", hash = "sha256:0d24eda41c6c258135077f60d410e704bc7b5a67adcb2ca463918896c7363795", size = 40336, upload-time = "2026-06-19T16:20:56.371Z" }
 wheels = [
@@ -2003,8 +2005,8 @@ name = "pyobjc-framework-quartz"
 version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pyobjc-core" },
-    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-core", marker = "sys_platform != 'win32'" },
+    { name = "pyobjc-framework-cocoa", marker = "sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/3b/f6/2a8b84dbf1fe7c04dd96ea73d991678d4e09a909f51971ecc51629bb2ab4/pyobjc_framework_quartz-12.2.1.tar.gz", hash = "sha256:b3b8b6f71e66147f8ff9e6213864cc8527e3a0b1ee90835b93ce221f4802d9b0", size = 3215521, upload-time = "2026-06-19T16:21:30.199Z" }
 wheels = [
@@ -2023,8 +2025,8 @@ name = "pyobjc-framework-security"
 version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pyobjc-core" },
-    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-core", marker = "sys_platform != 'win32'" },
+    { name = "pyobjc-framework-cocoa", marker = "sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/44/b8/4267b802d8dba6de468e7d0765b05cc4e146fa376ed9f55e0b6461016bef/pyobjc_framework_security-12.2.1.tar.gz", hash = "sha256:d7831b1537f4346892e7f2f0e2b09d79bee98919b0767f4061278d0e03028f2d", size = 181065, upload-time = "2026-06-19T16:21:40.151Z" }
 wheels = [
@@ -2043,8 +2045,8 @@ name = "pyobjc-framework-uniformtypeidentifiers"
 version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pyobjc-core" },
-    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-core", marker = "sys_platform != 'win32'" },
+    { name = "pyobjc-framework-cocoa", marker = "sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/74/a1/108fa1e5a3dd8aff626f98fb97de370323b290404b04ffa2ef9420665ed3/pyobjc_framework_uniformtypeidentifiers-12.2.1.tar.gz", hash = "sha256:1fb89d13aa3c2df8e6d6536f6df3493fe5a6caefd2a5adebf17c5af3b29ed4a2", size = 20679, upload-time = "2026-06-19T16:21:55.739Z" }
 wheels = [
@@ -2056,8 +2058,8 @@ name = "pyobjc-framework-webkit"
 version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pyobjc-core" },
-    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-core", marker = "sys_platform != 'win32'" },
+    { name = "pyobjc-framework-cocoa", marker = "sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/11/d2/b230c594f70ecb970b4cef67bae2648d1bfa5b381e9b7e3710bf24ec8887/pyobjc_framework_webkit-12.2.1.tar.gz", hash = "sha256:a56acae55b50d549b20dff2921ad1099add8fbc377d0de09ddc2ba50957f7def", size = 332374, upload-time = "2026-06-19T16:22:01.988Z" }
 wheels = [
@@ -2330,7 +2332,7 @@ name = "pythonnet"
 version = "3.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "clr-loader" },
+    { name = "clr-loader", marker = "sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/05/57/da1992e44663b71365c6e842c8d7fa453d4ec45fb99a68cfee5b7e944d3c/pythonnet-3.1.0.tar.gz", hash = "sha256:7b34c382905d10a371509ffafd64cae0416305c28817738a9cd138336f4e9991", size = 250599, upload-time = "2026-05-23T20:30:21.578Z" }
 wheels = [
@@ -2442,7 +2444,7 @@ name = "qtpy"
 version = "2.4.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "packaging" },
+    { name = "packaging", marker = "sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/70/01/392eba83c8e47b946b929d7c46e0f04b35e9671f8bb6fc36b6f7945b4de8/qtpy-2.4.3.tar.gz", hash = "sha256:db744f7832e6d3da90568ba6ccbca3ee2b3b4a890c3d6fbbc63142f6e4cdf5bb", size = 66982, upload-time = "2025-02-11T15:09:25.759Z" }
 wheels = [
@@ -2744,7 +2746,7 @@ resolution-markers = [
     "python_full_version < '3.12' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" } },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/7a/97/5a3609c4f8d58b039179648e62dd220f89864f56f7357f5d4f45c29eb2cc/scipy-1.17.1.tar.gz", hash = "sha256:95d8e012d8cb8816c226aef832200b1d45109ed4464303e997c5b13122b297c0", size = 30573822, upload-time = "2026-02-23T00:26:24.851Z" }
 wheels = [
@@ -2823,7 +2825,7 @@ resolution-markers = [
     "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.5.0", source = { registry = "https://pypi.org/simple" } },
+    { name = "numpy", version = "2.5.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a7/25/c2700dfaf6442b4effaa91af24ebce5dc9d31bb4a69706313aae70d72cd0/scipy-1.18.0.tar.gz", hash = "sha256:67b2ad2ad54c72ca6d04975a9b2df8c3638c34ddd5b28738e94fc2b57929d378", size = 30774447, upload-time = "2026-06-19T15:01:43.456Z" }
 wheels = [
@@ -3011,7 +3013,7 @@ resolution-markers = [
     "python_full_version < '3.12' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" } },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c5/cb/2f6d79c7576e22c116352a801f4c3c8ace5957e9aced862012430b62e14f/tifffile-2026.3.3.tar.gz", hash = "sha256:d9a1266bed6f2ee1dd0abde2018a38b4f8b2935cb843df381d70ac4eac5458b7", size = 388745, upload-time = "2026-03-03T19:14:38.134Z" }
 wheels = [
@@ -3031,7 +3033,7 @@ resolution-markers = [
     "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.5.0", source = { registry = "https://pypi.org/simple" } },
+    { name = "numpy", version = "2.5.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b7/38/5e2ecef5af2f4fd4a89bb8d6240de9458bab4d51a4cbd97aeb3a0cd618e2/tifffile-2026.6.1.tar.gz", hash = "sha256:626c892c0e899d959b9438e7c0e1491dc154a7fead1f1f37a991724a50eceba9", size = 429694, upload-time = "2026-05-31T23:57:12.165Z" }
 wheels = [
@@ -3455,7 +3457,7 @@ name = "winrt-runtime"
 version = "3.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions" },
+    { name = "typing-extensions", marker = "sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/16/dd/acdd527c1d890c8f852cc2af644aa6c160974e66631289420aa871b05e65/winrt_runtime-3.2.1.tar.gz", hash = "sha256:c8dca19e12b234ae6c3dadf1a4d0761b51e708457492c13beb666556958801ea", size = 21721, upload-time = "2025-06-06T14:40:27.593Z" }
 wheels = [
@@ -3478,7 +3480,7 @@ name = "winrt-windows-devices-bluetooth"
 version = "3.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "winrt-runtime" },
+    { name = "winrt-runtime", marker = "sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b2/a0/1c8a0c469abba7112265c6cb52f0090d08a67c103639aee71fc690e614b8/winrt_windows_devices_bluetooth-3.2.1.tar.gz", hash = "sha256:db496d2d92742006d5a052468fc355bf7bb49e795341d695c374746113d74505", size = 23732, upload-time = "2025-06-06T14:41:20.489Z" }
 wheels = [
@@ -3501,7 +3503,7 @@ name = "winrt-windows-devices-bluetooth-advertisement"
 version = "3.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "winrt-runtime" },
+    { name = "winrt-runtime", marker = "sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/06/fc/7ffe66ca4109b9e994b27c00f3d2d506e6e549e268791f755287ad9106d8/winrt_windows_devices_bluetooth_advertisement-3.2.1.tar.gz", hash = "sha256:0223852a7b7fa5c8dea3c6a93473bd783df4439b1ed938d9871f947933e574cc", size = 16906, upload-time = "2025-06-06T14:41:21.448Z" }
 wheels = [
@@ -3524,7 +3526,7 @@ name = "winrt-windows-devices-bluetooth-genericattributeprofile"
 version = "3.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "winrt-runtime" },
+    { name = "winrt-runtime", marker = "sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/44/21/aeeddc0eccdfbd25e543360b5cc093233e2eab3cdfb53ad3cabae1b5d04d/winrt_windows_devices_bluetooth_genericattributeprofile-3.2.1.tar.gz", hash = "sha256:cdf6ddc375e9150d040aca67f5a17c41ceaf13a63f3668f96608bc1d045dde71", size = 38896, upload-time = "2025-06-06T14:41:22.687Z" }
 wheels = [
@@ -3547,7 +3549,7 @@ name = "winrt-windows-devices-enumeration"
 version = "3.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "winrt-runtime" },
+    { name = "winrt-runtime", marker = "sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/9e/dd/75835bfbd063dffa152109727dedbd80f6e92ea284855f7855d48cdf31c9/winrt_windows_devices_enumeration-3.2.1.tar.gz", hash = "sha256:df316899e39bfc0ffc1f3cb0f5ee54d04e1d167fbbcc1484d2d5121449a935cf", size = 23538, upload-time = "2025-06-06T14:41:26.787Z" }
 wheels = [
@@ -3570,7 +3572,7 @@ name = "winrt-windows-devices-radios"
 version = "3.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "winrt-runtime" },
+    { name = "winrt-runtime", marker = "sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/5e/02/9704ea359ad8b0d6faa1011f98fb477e8fb6eac5201f39d19e73c2407e7b/winrt_windows_devices_radios-3.2.1.tar.gz", hash = "sha256:4dc9b9d1501846049eb79428d64ec698d6476c27a357999b78a8331072e18a0b", size = 5908, upload-time = "2025-06-06T14:41:44.868Z" }
 wheels = [
@@ -3593,7 +3595,7 @@ name = "winrt-windows-foundation"
 version = "3.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "winrt-runtime" },
+    { name = "winrt-runtime", marker = "sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0c/55/098ce7ea0679efcc1298b269c48768f010b6c68f90c588f654ec874c8a74/winrt_windows_foundation-3.2.1.tar.gz", hash = "sha256:ad2f1fcaa6c34672df45527d7c533731fdf65b67c4638c2b4aca949f6eec0656", size = 30485, upload-time = "2025-06-06T14:41:53.344Z" }
 wheels = [
@@ -3616,7 +3618,7 @@ name = "winrt-windows-foundation-collections"
 version = "3.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "winrt-runtime" },
+    { name = "winrt-runtime", marker = "sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ef/62/d21e3f1eeb8d47077887bbf0c3882c49277a84d8f98f7c12bda64d498a07/winrt_windows_foundation_collections-3.2.1.tar.gz", hash = "sha256:0eff1ad0d8d763ad17e9e7bbd0c26a62b27215016393c05b09b046d6503ae6d5", size = 16043, upload-time = "2025-06-06T14:41:53.983Z" }
 wheels = [
@@ -3639,7 +3641,7 @@ name = "winrt-windows-storage-streams"
 version = "3.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "winrt-runtime" },
+    { name = "winrt-runtime", marker = "sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/00/50/f4488b07281566e3850fcae1021f0285c9653992f60a915e15567047db63/winrt_windows_storage_streams-3.2.1.tar.gz", hash = "sha256:476f522722751eb0b571bc7802d85a82a3cae8b1cce66061e6e758f525e7b80f", size = 34335, upload-time = "2025-06-06T14:43:23.905Z" }
 wheels = [


### PR DESCRIPTION
## Summary

Adds `inject_frame` — deliver a crafted frame into a connected board's **real receive pipeline as if it arrived off the LoRa radio**, reaching code the `toRadio` API can't (it forces `from=0`, bypassing every "from a remote node" branch and the admin session-key gate).

- `inject.py` — crafter + tool logic. Wraps the frame in a `Compressed`/`SIMULATOR_APP` envelope so firmware built with `-D MESHTASTIC_ENABLE_FRAME_INJECTION=1` delivers it via the real RX path (`from!=0` enforcement, channel/PKC decryption, remote-admin auth, hop/dedup/module dispatch). Portduino `sim` nodes support it unconditionally. Replicates meshtastic channel crypto (default-PSK expansion, `xorHash` channel hash, AES-CTR `packetId|from|0` nonce). Firmware seam: `MeshService::injectAsReceived` (companion firmware PR).
- Modes: `text`, `raw`, `admin` (+ `pki`/`public_key_b64` for the PKC-admin path), `ciphertext`, `fuzz`.
- Standalone CLI at `cli/meshinject.py`.
- Docs: AGENTS.md § "Frame injection" + copilot-instructions bullet (the new testing method).
- `inject_frame` annotated like `send_text` (injects a packet; not recallable). `cryptography` added to core deps.

## Test plan

Gates: `ruff check .`, `ruff format --check .`, `mypy`, `pytest tests/unit` (424 passed, 66 skipped) — all green. Hardware: validated on a RAK4631 flashed with the injection build — an injected channel-encrypted text decodes end-to-end (forged `from` lands in NodeDB); reproduces the remote-admin `PKC admin payload with authorized sender key` → `Expected session key: 00…` → `Admin message without session_key!` sequence; survives a malformed-frame `fuzz` run.

> Note: needs the firmware build flag (companion firmware PR). nRF52 USB CDC wedges under rapid connect/disconnect churn — keep injection to a single connection; recover a hung board via a 1200 bps-touch DFU reflash.

## Checklist

- [x] Gates pass (ruff, mypy — no new ignores/noqa, pytest unit tier)
- [x] New MCP tools have annotations; `inject_frame` mirrors `send_text` (destructive/non-recallable; no `confirm`, matching `send_text`)
- [x] Core changes import/run with no firmware checkout
- [x] DCO sign-off

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added frame injection through the MCP interface and command-line tool.
  * Supports text, raw payload, administrative, ciphertext, and fuzz-testing injection modes.
  * Added channel encryption, PKI options, routing controls, acknowledgments, and serial/TCP connections.
  * Added detailed documentation for configuring firmware and testing the receive pipeline.

* **Documentation**
  * Documented frame formats, injection workflows, supported modes, and connection recovery guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->