### PR TITLE
feat(fleet): forget a decommissioned device from the registry

### DIFF
--- a/src/meshtastic_mcp/web/app.py
+++ b/src/meshtastic_mcp/web/app.py
@@ -343,6 +343,23 @@ def _mount_devices(api: APIRouter) -> None:
         await hub.publish("device.update", dev)
         return dev
 
+    @api.delete("/devices/{serial}", status_code=204)
+    async def forget_device(serial: str, request: Request):
+        """Forget a device: drop its registry row + attached history. Guarded to
+        OFFLINE devices — an online one would just be re-added by the next
+        discovery sweep, so we 409 rather than silently no-op. The deletion
+        broadcasts ``device.update {deleted: true}`` so open Fleet pages drop the
+        card live (same shape as the native/camera removals)."""
+        db, hub = request.app.state.db, request.app.state.hub
+        row = await _device_or_404(db, serial)
+        if row.get("online"):
+            raise HTTPException(
+                status_code=409,
+                detail="device is online — unplug it first (it would be re-discovered otherwise)",
+            )
+        await rd.delete(db, serial)
+        await hub.publish("device.update", {"serial_number": serial, "deleted": True})
+
     @api.put("/devices/{serial}/env")
     async def set_env(serial: str, request: Request, body: dict = Body(...)):
         db, hub = request.app.state.db, request.app.state.hub

--- a/src/meshtastic_mcp/web/db/repo_devices.py
+++ b/src/meshtastic_mcp/web/db/repo_devices.py
@@ -6,7 +6,9 @@
 A device is keyed by its USB serial number so its row (and everything attached
 to it — friendly name, camera, pinned env, flash/test history) *follows* it
 across ports and reboots. Discovery never deletes rows; it only flips ``online``
-so a unplugged device greys out instead of vanishing.
+so a unplugged device greys out instead of vanishing. The sole removal path is an
+operator-initiated ``delete`` (forget) — used to drop a decommissioned or
+swapped-out board and everything attached to it.
 """
 
 from __future__ import annotations
@@ -205,6 +207,28 @@ async def record_flashed(db: Database, serial: str, *, branch: str | None, sha: 
         "WHERE serial_number=?",
         (branch, sha, time.time(), serial),
     )
+
+
+async def delete(db: Database, serial: str) -> bool:
+    """Operator *forget*: drop a device row and everything attached to it. The
+    registry is otherwise append-only (discovery only greys rows), so this is
+    the one path that removes one — for a decommissioned or swapped-out board.
+
+    Flash + test history keyed on the serial is deleted (nothing enforces those
+    FKs, and a reused serial must not inherit a dead board's history); an
+    assigned camera is *unassigned*, not deleted — it's bench hardware that
+    outlives the node it pointed at. Returns True if a row was removed, False if
+    the serial was unknown. Idempotent."""
+    if await get(db, serial) is None:
+        return False
+    await db.execute("DELETE FROM flash_events WHERE device_serial=?", (serial,))
+    await db.execute("DELETE FROM results WHERE device_serial=?", (serial,))
+    await db.execute(
+        "UPDATE cameras SET device_serial=NULL, assigned_at=NULL WHERE device_serial=?",
+        (serial,),
+    )
+    await db.execute("DELETE FROM devices WHERE serial_number=?", (serial,))
+    return True
 
 
 async def mark_offline_except(db: Database, keep: set[str]) -> list[str]:

--- a/tests/unit/test_web_registry.py
+++ b/tests/unit/test_web_registry.py
@@ -88,6 +88,79 @@ def test_offline_marking_keeps_row(tmp_path):
     asyncio.run(go())
 
 
+def test_forget_device_removes_row_and_attached_data(tmp_path):
+    """Operator forget drops the row + its flash/test history and *unassigns*
+    (does not delete) any camera; a second device is untouched. Idempotent."""
+
+    async def go():
+        db = _fresh_db(tmp_path)
+        await db.connect()
+        try:
+            # The board to forget, plus a keeper that must survive.
+            await rd.upsert_from_discovery(
+                db,
+                serial_number="GONE",
+                current_port="/dev/a",
+                vid="0x239a",
+                pid="0x1",
+                role="nrf52",
+            )
+            await rd.upsert_from_discovery(
+                db,
+                serial_number="KEEP",
+                current_port="/dev/b",
+                vid="0x239a",
+                pid="0x1",
+                role="nrf52",
+            )
+            # Attach flash history, a test result, and a camera to the doomed board.
+            await rf.record(
+                db,
+                device_serial="GONE",
+                env="rak4631",
+                fw_sha="abc",
+                from_artifact=False,
+                duration_s=100.0,
+                ok=True,
+            )
+            run_id = await rr.create_run(
+                db, args=[], seed="s", fw_branch="develop", fw_sha="abc", fw_dirty=False
+            )
+            await rr.add_result(
+                db,
+                run_id,
+                nodeid="tests/mesh/test_x.py::test_y[nrf52]",
+                tier="mesh",
+                outcome="passed",
+                duration_s=1.0,
+                device_serial="GONE",
+                longrepr=None,
+            )
+            cid = await rc.add(db, name="cam", device_index="0")
+            await rc.assign(db, cid, "GONE")
+
+            assert await rd.delete(db, "GONE") is True
+
+            # Row gone, keeper intact.
+            assert await rd.get(db, "GONE") is None
+            assert [d["serial_number"] for d in await rd.list_all(db)] == ["KEEP"]
+            # Attached history swept.
+            fe = await db.fetchone(
+                "SELECT COUNT(*) AS c FROM flash_events WHERE device_serial=?", ("GONE",)
+            )
+            assert fe["c"] == 0
+            assert await rr.results_for_device(db, "GONE") == []
+            # Camera survives but is unassigned (bench hardware outlives the node).
+            assert await rc.for_device(db, "GONE") is None
+            assert (await rc.get(db, cid))["device_serial"] is None
+            # Idempotent — forgetting an unknown serial is a no-op returning False.
+            assert await rd.delete(db, "GONE") is False
+        finally:
+            await db.close()
+
+    asyncio.run(go())
+
+
 def test_camera_assignment_survives_port_change(tmp_path):
     async def go():
         db = _fresh_db(tmp_path)

--- a/web-ui/src/components/DeviceCard.vue
+++ b/web-ui/src/components/DeviceCard.vue
@@ -74,6 +74,18 @@ async function saveName() {
   await devices.setFriendlyName(props.device.serial_number, nameDraft.value);
 }
 
+// Forget an offline (swapped-out / decommissioned) device. Guarded by the
+// backend to offline devices; the button only shows when offline anyway.
+async function forget() {
+  const label = props.device.friendly_name || props.device.serial_number;
+  if (
+    confirm(
+      `Forget "${label}"?\n\nRemoves it from the fleet along with its flash and test history. It will reappear if reconnected.`,
+    )
+  )
+    await devices.forget(props.device.serial_number);
+}
+
 async function onAssign(e: Event) {
   const val = (e.target as HTMLSelectElement).value;
   // find camera currently assigned and reassign; here we assign the picked
@@ -220,6 +232,27 @@ async function onAssign(e: Event) {
             <polyline points="1 20 1 14 7 14" />
             <path
               d="M3.51 9a9 9 0 0 1 14.85-3.36L23 10M1 14l4.64 4.36A9 9 0 0 0 20.49 15"
+            />
+          </svg>
+        </button>
+        <button
+          v-if="!device.online"
+          @click="forget"
+          class="p-1 rounded text-slate-500 hover:text-rose-400 transition hover:bg-slate-800"
+          title="forget this device — remove it from the fleet (offline only)"
+        >
+          <svg
+            viewBox="0 0 24 24"
+            class="w-4 h-4"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          >
+            <polyline points="3 6 5 6 21 6" />
+            <path
+              d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"
             />
           </svg>
         </button>

--- a/web-ui/src/stores/devices.ts
+++ b/web-ui/src/stores/devices.ts
@@ -49,6 +49,14 @@ export const useDevicesStore = defineStore("devices", () => {
     bySerial[serial] = res.device;
   }
 
+  // Forget an offline device: drop its registry row + attached history. The
+  // backend also broadcasts device.update {deleted}, but we remove it locally
+  // too so the card vanishes instantly (deleting a missing key is a no-op).
+  async function forget(serial: string) {
+    await api.del(`/api/devices/${serial}`);
+    delete bySerial[serial];
+  }
+
   // Pin a pio env (manual override) or release to auto-detect (env=null).
   async function setEnv(serial: string, env: string | null) {
     const updated = await api.put<Device>(`/api/devices/${serial}/env`, {
@@ -130,6 +138,7 @@ export const useDevicesStore = defineStore("devices", () => {
     init,
     setFriendlyName,
     refresh,
+    forget,
     setEnv,
     setHubPort,
     locate,


### PR DESCRIPTION
## Problem

The device registry is append-only — discovery only flips `online`, never deletes (`repo_devices.py`: *"Discovery never deletes rows"*). There is no delete endpoint or DB primitive for USB devices (only cameras/native have one). So every hardware swap leaves a permanent offline **zombie** on the Fleet page with no way to remove it. Hit in practice swapping a T-Echo Plus for a T-Echo.

## Change

- **`repo_devices.delete()`** — drops the row plus its `flash_events`/`results` history, and *unassigns* (does not delete) any camera; idempotent, returns whether a row existed.
- **`DELETE /api/devices/{serial}`** — `409` when the device is online (it would just be re-discovered), else delete + broadcast `device.update {deleted:true}` so open Fleet pages drop the card live (same shape as the native/camera removals the store already handles).
- **Fleet UI** — an offline-only "forget" (trash) button on the device card, with a confirm; `devices` store gains `forget()`.
- **Test** — `test_forget_device_removes_row_and_attached_data`: history sweep, camera unassign, keeper isolation, idempotency.

## Verification

`ruff` ✅ · `mypy` ✅ (no issues) · `pytest tests/unit` ✅ (594 passed, 51 skipped) · SPA build ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)
