### PR TITLE
feat(menubar): macOS menu-bar controller for the FleetSuite service

### DIFF
--- a/docs/nightly.md
+++ b/docs/nightly.md
@@ -38,8 +38,13 @@ even when the pipeline itself breaks (`PIPELINE FAILED at <step>` issues).
 # one-time
 gh auth login                       # the report posts via your gh keyring auth
 ./scripts/install-launchd.sh        # LaunchAgent: KeepAlive + RunAtLoad + supervisor
+./scripts/install-menubar.sh        # optional: 🟢/🟡/🔴 menu-bar start/stop/status ([menubar] extra)
 open http://127.0.0.1:8765          # Nightly tab → enable, set time, set report repo
 ```
+
+The menu-bar controller (`meshtastic-mcp-menubar`, macOS-only) is a convenience,
+not part of the service — it just drives the same `com.meshtastic.fleetsuite`
+agent. "Stop" *unloads* the agent (a plain kill would be respawned by `KeepAlive`).
 
 The LaunchAgent runs `scripts/fleetsuite-supervisor.sh`, which wraps
 `fleetsuite.sh --browser` with **crash-loop rollback**: three consecutive starts dying

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,9 @@ ui = [
   "rich-pixels>=3.0",
 ]
 ui-min = ["opencv-python-headless>=4.9", "numpy>=1.26"]
+# macOS menu-bar controller for the FleetSuite service (start/stop/status).
+# macOS-only; the service and nightly run fine without it. See scripts/install-menubar.sh.
+menubar = ["rumps>=0.4; sys_platform == 'darwin'"]
 # FleetSuite: the FastAPI web backend + Vue SPA (the bench control plane). The
 # desktop window uses pywebview; `--browser` mode serves headless without it.
 web = [
@@ -91,6 +94,7 @@ dev = ["ruff>=0.6", "mypy>=1.10", "pytest>=8"]
 meshtastic-mcp = "meshtastic_mcp.__main__:main"
 meshtastic-mcp-test-tui = "meshtastic_mcp.cli.test_tui:main"
 meshtastic-mcp-web = "meshtastic_mcp.web.__main__:main"
+meshtastic-mcp-menubar = "meshtastic_mcp.menubar:main"
 
 [project.urls]
 Homepage = "https://github.com/meshtastic/meshtastic-mcp"

--- a/scripts/com.meshtastic.fleetsuite.menubar.plist
+++ b/scripts/com.meshtastic.fleetsuite.menubar.plist
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- SPDX-FileCopyrightText: Meshtastic contributors -->
+<!-- SPDX-License-Identifier: GPL-3.0-only -->
+<!--
+  Companion menu-bar controller for FleetSuite — installed by install-menubar.sh,
+  which substitutes @ROOT@ (this repo) and @HOME@ (the user's home).
+
+  Runs in the Aqua (GUI login) session only — a status-bar item has no meaning
+  in a background session. KeepAlive + RunAtLoad so the icon returns after a
+  crash, logout, or reboot-then-login. This controls the *service* agent
+  (com.meshtastic.fleetsuite); it is independent of it.
+-->
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Label</key>
+	<string>com.meshtastic.fleetsuite.menubar</string>
+
+	<key>ProgramArguments</key>
+	<array>
+		<string>@ROOT@/.venv/bin/meshtastic-mcp-menubar</string>
+	</array>
+
+	<key>RunAtLoad</key>
+	<true/>
+	<key>KeepAlive</key>
+	<true/>
+	<key>ThrottleInterval</key>
+	<integer>10</integer>
+
+	<!-- A menu-bar app only makes sense in the GUI login session. -->
+	<key>LimitLoadToSessionType</key>
+	<string>Aqua</string>
+
+	<key>EnvironmentVariables</key>
+	<dict>
+		<!-- launchd jobs get a bare PATH; launchctl lives in /bin, homebrew python deps beyond. -->
+		<key>PATH</key>
+		<string>/bin:/usr/bin:/opt/homebrew/bin:/usr/local/bin</string>
+	</dict>
+
+	<key>WorkingDirectory</key>
+	<string>@ROOT@</string>
+	<key>StandardOutPath</key>
+	<string>@HOME@/Library/Logs/fleetsuite-menubar.log</string>
+	<key>StandardErrorPath</key>
+	<string>@HOME@/Library/Logs/fleetsuite-menubar.log</string>
+</dict>
+</plist>

--- a/scripts/com.meshtastic.fleetsuite.menubar.plist
+++ b/scripts/com.meshtastic.fleetsuite.menubar.plist
@@ -23,8 +23,13 @@
 
 	<key>RunAtLoad</key>
 	<true/>
+	<!-- Respawn on a crash, but NOT on a clean "Quit Menu Bar App" (exit 0) —
+	     otherwise the Quit menu item could never actually dismiss the icon. -->
 	<key>KeepAlive</key>
-	<true/>
+	<dict>
+		<key>SuccessfulExit</key>
+		<false/>
+	</dict>
 	<key>ThrottleInterval</key>
 	<integer>10</integer>
 

--- a/scripts/install-menubar.sh
+++ b/scripts/install-menubar.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Meshtastic contributors
+# SPDX-License-Identifier: GPL-3.0-only
+
+# Install the FleetSuite menu-bar controller as a macOS login LaunchAgent, so a
+# 🟢/🟡/🔴 status item with start/stop/restart sits in your menu bar and returns
+# after logout/reboot. Companion to install-launchd.sh (the service itself).
+#
+#   ./scripts/install-menubar.sh              # install + (re)start
+#   ./scripts/install-menubar.sh --uninstall  # stop + remove
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+LABEL="com.meshtastic.fleetsuite.menubar"
+DEST="$HOME/Library/LaunchAgents/$LABEL.plist"
+DOMAIN="gui/$(id -u)"
+
+if [[ "${1:-}" == "--uninstall" ]]; then
+	launchctl bootout "$DOMAIN" "$DEST" 2>/dev/null || true
+	rm -f "$DEST"
+	echo "removed $DEST"
+	exit 0
+fi
+
+if [[ "$(uname)" != "Darwin" ]]; then
+	echo "the menu-bar controller is macOS-only" >&2
+	exit 1
+fi
+
+PY="$ROOT/.venv/bin/python"
+if [[ ! -x "$PY" ]]; then
+	echo "no venv at $ROOT/.venv — run scripts/fleetsuite.sh once first" >&2
+	exit 1
+fi
+
+# Ensure the entry point + rumps are present in the venv.
+if [[ ! -x "$ROOT/.venv/bin/meshtastic-mcp-menubar" ]]; then
+	echo "installing the [menubar] extra (rumps)…"
+	"$PY" -m pip install --quiet -e "$ROOT[menubar]"
+fi
+
+mkdir -p "$HOME/Library/LaunchAgents" "$HOME/Library/Logs"
+
+sed -e "s|@ROOT@|$ROOT|g" -e "s|@HOME@|$HOME|g" \
+	"$ROOT/scripts/com.meshtastic.fleetsuite.menubar.plist" >"$DEST"
+
+# Re-bootstrap cleanly whether or not it was already loaded.
+launchctl bootout "$DOMAIN" "$DEST" 2>/dev/null || true
+launchctl bootstrap "$DOMAIN" "$DEST"
+
+echo "installed: $DEST"
+echo "logs:      $HOME/Library/Logs/fleetsuite-menubar.log"
+echo "A 🟢/🟡/🔴 'FleetSuite' item should appear in your menu bar."

--- a/src/meshtastic_mcp/menubar.py
+++ b/src/meshtastic_mcp/menubar.py
@@ -1,0 +1,173 @@
+# SPDX-FileCopyrightText: Meshtastic contributors
+# SPDX-License-Identifier: GPL-3.0-only
+
+"""macOS menu-bar controller for the FleetSuite service.
+
+A tiny status-bar app (``rumps``) that shows whether the launchd-managed
+FleetSuite service is up (🟢 running · 🟡 starting · 🔴 stopped) and lets you
+start / stop / restart it and open the web UI — one click each.
+
+Optional and macOS-only (the ``[menubar]`` extra). The service runs perfectly
+well without it. Launch by hand with ``meshtastic-mcp-menubar``, or install it
+as a login LaunchAgent with ``scripts/install-menubar.sh``.
+
+The controller keeps no state of its own: it drives the very same launchd agent
+the service is managed by (``com.meshtastic.fleetsuite``). "Stop" means *bootout*
+(unload the agent) rather than a kill — the agent's ``KeepAlive`` would respawn a
+plain kill immediately, so a kill could never actually stop the service.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import webbrowser
+from urllib.error import URLError
+from urllib.request import urlopen
+
+LABEL = "com.meshtastic.fleetsuite"
+UI_URL = "http://127.0.0.1:8765"
+HEALTH_URL = f"{UI_URL}/api/nightly"
+POLL_SECONDS = 5.0
+_LAUNCHCTL_TIMEOUT = 10.0
+_HEALTH_TIMEOUT = 2.0
+
+# The menu-bar title *is* the icon — a status glyph, no image asset required.
+GLYPH_RUNNING = "🟢"
+GLYPH_PENDING = "🟡"
+GLYPH_STOPPED = "🔴"
+
+
+def _domain() -> str:
+    return f"gui/{os.getuid()}"
+
+
+def _service_target() -> str:
+    return f"{_domain()}/{LABEL}"
+
+
+def _plist_path() -> str:
+    return os.path.expanduser(f"~/Library/LaunchAgents/{LABEL}.plist")
+
+
+def _launchctl(*args: str) -> subprocess.CompletedProcess[str]:
+    """Run ``launchctl`` and never raise — a control click must not crash the
+    app if launchd is momentarily uncooperative; the next poll re-reads truth."""
+    try:
+        return subprocess.run(
+            ["launchctl", *args],
+            capture_output=True,
+            text=True,
+            timeout=_LAUNCHCTL_TIMEOUT,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError) as exc:  # pragma: no cover - defensive
+        return subprocess.CompletedProcess(args, returncode=1, stdout="", stderr=str(exc))
+
+
+def parse_service_state(print_output: str) -> tuple[bool, int | None]:
+    """Extract ``(running, pid)`` from ``launchctl print`` output.
+
+    ``running`` is True only when the job reports ``state = running``. ``pid`` is
+    the live PID when the job has one (absent while merely loaded/scheduled).
+    Pure — unit-tested directly, no launchd required.
+    """
+    running = False
+    pid: int | None = None
+    for raw in print_output.splitlines():
+        line = raw.strip()
+        if line.startswith("state ="):
+            running = "running" in line
+        elif line.startswith("pid ="):
+            value = line.split("=", 1)[1].strip()
+            pid = int(value) if value.isdigit() else None
+    return running, pid
+
+
+def service_pid() -> int | None:
+    """The FleetSuite service PID if it is loaded *and* running, else None."""
+    result = _launchctl("print", _service_target())
+    if result.returncode != 0:  # not bootstrapped at all
+        return None
+    running, pid = parse_service_state(result.stdout)
+    return pid if running else None
+
+
+def http_healthy() -> bool:
+    """True when the service answers on :8765 (running vs. still starting up)."""
+    try:
+        with urlopen(HEALTH_URL, timeout=_HEALTH_TIMEOUT) as resp:
+            return 200 <= resp.status < 400
+    except (URLError, OSError, ValueError):
+        return False
+
+
+def status_line() -> tuple[str, str]:
+    """(glyph, human status) for the current service state."""
+    pid = service_pid()
+    if pid is None:
+        return GLYPH_STOPPED, "FleetSuite: stopped"
+    if http_healthy():
+        return GLYPH_RUNNING, f"FleetSuite: running · pid {pid}"
+    return GLYPH_PENDING, f"FleetSuite: starting… · pid {pid}"
+
+
+def start_service() -> None:
+    """Load the agent (``RunAtLoad`` then starts it); kickstart covers the case
+    where it was already loaded but idle. Both are no-ops if already running."""
+    _launchctl("bootstrap", _domain(), _plist_path())
+    _launchctl("kickstart", _service_target())
+
+
+def stop_service() -> None:
+    """Unload the agent. Bootout — not kill — because ``KeepAlive`` respawns a
+    killed job; unloading is the only thing that actually keeps it down."""
+    _launchctl("bootout", _domain(), _plist_path())
+
+
+def restart_service() -> None:
+    """Kill-and-restart the running job (``KeepAlive`` keeps it, so -k cycles)."""
+    _launchctl("kickstart", "-k", _service_target())
+
+
+def open_ui() -> None:
+    webbrowser.open(UI_URL)
+
+
+def main() -> None:
+    # rumps is imported lazily so this module stays importable (and unit-testable)
+    # on non-macOS / without the [menubar] extra installed.
+    import rumps
+
+    app = rumps.App("FleetSuite", title=GLYPH_PENDING, quit_button=None)
+    status = rumps.MenuItem("Checking…")
+
+    def refresh(_sender: object | None = None) -> None:
+        app.title, status.title = status_line()
+
+    def act(action):
+        def _callback(_sender: object) -> None:
+            action()
+            refresh()
+
+        return _callback
+
+    app.menu = [
+        status,
+        None,
+        rumps.MenuItem("Open FleetSuite…", callback=lambda _s: open_ui()),
+        None,
+        rumps.MenuItem("Start", callback=act(start_service)),
+        rumps.MenuItem("Stop", callback=act(stop_service)),
+        rumps.MenuItem("Restart", callback=act(restart_service)),
+        None,
+        rumps.MenuItem("Quit Menu Bar App", callback=rumps.quit_application),
+    ]
+
+    refresh()
+    rumps.Timer(refresh, POLL_SECONDS).start()
+    app.run()
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/tests/unit/test_menubar.py
+++ b/tests/unit/test_menubar.py
@@ -1,0 +1,52 @@
+# SPDX-FileCopyrightText: Meshtastic contributors
+# SPDX-License-Identifier: GPL-3.0-only
+
+"""Unit tests for the macOS menu-bar controller's pure helpers.
+
+``menubar`` imports only stdlib at module scope (rumps is lazy-imported inside
+``main``), so these run on any platform without the ``[menubar]`` extra.
+"""
+
+from __future__ import annotations
+
+from meshtastic_mcp import menubar
+
+
+def test_parse_running_with_pid():
+    out = "\tstate = running\n\tpid = 4242\n\tprogram = /bin/bash\n"
+    assert menubar.parse_service_state(out) == (True, 4242)
+
+
+def test_parse_loaded_but_idle_has_no_pid():
+    assert menubar.parse_service_state("\tstate = waiting\n") == (False, None)
+
+
+def test_parse_spawn_scheduled_is_not_running():
+    # e.g. moments after a crash, before KeepAlive respawns it
+    assert menubar.parse_service_state("\tstate = spawn scheduled\n") == (False, None)
+
+
+def test_parse_empty_output():
+    assert menubar.parse_service_state("") == (False, None)
+
+
+def test_status_line_running(monkeypatch):
+    monkeypatch.setattr(menubar, "service_pid", lambda: 4242)
+    monkeypatch.setattr(menubar, "http_healthy", lambda: True)
+    glyph, line = menubar.status_line()
+    assert glyph == menubar.GLYPH_RUNNING
+    assert "4242" in line
+
+
+def test_status_line_pending_when_up_but_not_answering(monkeypatch):
+    monkeypatch.setattr(menubar, "service_pid", lambda: 99)
+    monkeypatch.setattr(menubar, "http_healthy", lambda: False)
+    glyph, _line = menubar.status_line()
+    assert glyph == menubar.GLYPH_PENDING
+
+
+def test_status_line_stopped_when_no_pid(monkeypatch):
+    monkeypatch.setattr(menubar, "service_pid", lambda: None)
+    glyph, line = menubar.status_line()
+    assert glyph == menubar.GLYPH_STOPPED
+    assert "stopped" in line


### PR DESCRIPTION
## What

An optional macOS menu-bar controller for the FleetSuite service — a 🟢/🟡/🔴 status-bar item with **Start / Stop / Restart / Open FleetSuite**, so you don't drop to a terminal for `launchctl`.

- **`meshtastic_mcp/menubar.py`** — self-contained (`rumps` lazy-imported, so the module imports and unit-tests on any platform). Status = `launchctl print` state/pid + a `:8765` health probe → running / starting / stopped. **Stop = `bootout`**, because the service agent's `KeepAlive` respawns a plain kill.
- **`[menubar]` extra** (`rumps`, darwin marker) + **`meshtastic-mcp-menubar`** entry point.
- **`scripts/com.meshtastic.fleetsuite.menubar.plist`** — login LaunchAgent, `LimitLoadToSessionType=Aqua` (a status item needs the GUI session), `KeepAlive`+`RunAtLoad`.
- **`scripts/install-menubar.sh`** — installs the extra + agent (mirrors `install-launchd.sh`; `--uninstall` removes it).
- Unit test for the pure launchctl-state parser + status-glyph selection; one-line docs note.

## Verification

`ruff` ✅ · `mypy` ✅ · `pytest tests/unit/test_menubar.py` ✅ (7 passed) · live smoke test against the running service → `('🟢', 'FleetSuite: running · pid …')`. Installed + running on a Mac Mini.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
