### PR TITLE
chore(deploy): configurable FleetSuite bootstrap — [ui] extra + bind host

### DIFF
--- a/docs/nightly.md
+++ b/docs/nightly.md
@@ -58,6 +58,7 @@ Environment (set in the plist):
 |---|---|---|
 | `MESHTASTIC_MCP_NIGHTLY_FW_DIR` | `~/.meshtastic_mcp/nightly-firmware` | the checkout the nightly may hard-reset |
 | `MESHTASTIC_FIRMWARE_ROOT` | same path | builds/bakes compile exactly what the nightly pulled |
+| `FLEETSUITE_EXTRAS` | `web,ui` | a clean redeploy installs the camera + OCR deps (soak snapshots), not just `web` |
 | `PATH` | homebrew + platformio | launchd jobs get a bare PATH |
 
 Optional: `MESHTASTIC_MCP_SOURCE_ROOT` (mcp checkout override, default: this repo),
@@ -73,7 +74,9 @@ Optional: `MESHTASTIC_MCP_SOURCE_ROOT` (mcp checkout override, default: this rep
   deterministic report still posts and carries an `llm_unavailable` observation. The
   *auto-start local LLM* toggle tries `llama-server` bootstrap once per night.
 - **Cameras** (optional): add + assign them in the Fleet tab for soak snapshots; enable
-  screen keep-alive so OLEDs stay lit.
+  screen keep-alive so OLEDs stay lit. Camera capture needs the `[ui]` extra (opencv) — the
+  deployment plist's `FLEETSUITE_EXTRAS=web,ui` installs it on a clean deploy; macOS also
+  gates camera capture behind a Camera privacy grant for the launchd process.
 
 ## Data & retention
 

--- a/docs/nightly.md
+++ b/docs/nightly.md
@@ -59,6 +59,7 @@ Environment (set in the plist):
 | `MESHTASTIC_MCP_NIGHTLY_FW_DIR` | `~/.meshtastic_mcp/nightly-firmware` | the checkout the nightly may hard-reset |
 | `MESHTASTIC_FIRMWARE_ROOT` | same path | builds/bakes compile exactly what the nightly pulled |
 | `FLEETSUITE_EXTRAS` | `web,ui` | a clean redeploy installs the camera + OCR deps (soak snapshots), not just `web` |
+| `FLEETSUITE_HOST` | `127.0.0.1` | web-server bind address. `0.0.0.0` exposes the UI on the LAN — **no auth, trusted networks only** (`FLEETSUITE_HOST=0.0.0.0 ./scripts/install-launchd.sh`) |
 | `PATH` | homebrew + platformio | launchd jobs get a bare PATH |
 
 Optional: `MESHTASTIC_MCP_SOURCE_ROOT` (mcp checkout override, default: this repo),

--- a/scripts/com.meshtastic.fleetsuite.plist
+++ b/scripts/com.meshtastic.fleetsuite.plist
@@ -38,6 +38,10 @@
 		<string>@HOME@/.meshtastic_mcp/nightly-firmware</string>
 		<key>MESHTASTIC_MCP_NIGHTLY_FW_DIR</key>
 		<string>@HOME@/.meshtastic_mcp/nightly-firmware</string>
+		<!-- Install the camera + OCR deps (opencv/pytesseract) on a clean deploy
+		     so soak snapshots work out of the box. fleetsuite.sh reads this. -->
+		<key>FLEETSUITE_EXTRAS</key>
+		<string>web,ui</string>
 		<!-- launchd jobs get a bare PATH; git/npm/node/pio live in these. -->
 		<key>PATH</key>
 		<string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:@HOME@/.platformio/penv/bin</string>

--- a/scripts/com.meshtastic.fleetsuite.plist
+++ b/scripts/com.meshtastic.fleetsuite.plist
@@ -42,6 +42,11 @@
 		     so soak snapshots work out of the box. fleetsuite.sh reads this. -->
 		<key>FLEETSUITE_EXTRAS</key>
 		<string>web,ui</string>
+		<!-- Web server bind address. install-launchd.sh substitutes
+		     @FLEETSUITE_HOST@ from $FLEETSUITE_HOST (default 127.0.0.1). Set it to
+		     0.0.0.0 to expose the UI on the LAN — no auth, trusted networks only. -->
+		<key>FLEETSUITE_HOST</key>
+		<string>@FLEETSUITE_HOST@</string>
 		<!-- launchd jobs get a bare PATH; git/npm/node/pio live in these. -->
 		<key>PATH</key>
 		<string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:@HOME@/.platformio/penv/bin</string>

--- a/scripts/fleetsuite.sh
+++ b/scripts/fleetsuite.sh
@@ -37,18 +37,23 @@ done
 
 PY="$ROOT/.venv/bin/python"
 STATIC="$ROOT/src/meshtastic_mcp/web/static/index.html"
+# Extra set installed into a freshly-created venv. Default is the minimal web
+# backend; a bench/nightly deployment sets FLEETSUITE_EXTRAS=web,ui in its
+# launchd plist so a clean redeploy gets the camera + OCR deps (soak snapshots)
+# automatically. Kept opt-in because [ui] pulls opencv (and torch on non-Intel).
+EXTRAS="${FLEETSUITE_EXTRAS:-web}"
 
 note() { printf '\033[36m[fleetsuite]\033[0m %s\n' "$*"; }
 
-# 1. Python venv + web extra ------------------------------------------------
+# 1. Python venv + extras ---------------------------------------------------
 if [[ ! -x $PY ]]; then
 	note "creating venv (.venv)…"
 	python3 -m venv "$ROOT/.venv"
 fi
 if ! "$PY" -c 'import fastapi, aiosqlite, uvicorn, webview' >/dev/null 2>&1; then
-	note "installing the [web] extra…"
+	note "installing the [$EXTRAS] extra(s)…"
 	"$PY" -m pip install --quiet --upgrade pip
-	"$PY" -m pip install --quiet -e "$ROOT[web]"
+	"$PY" -m pip install --quiet -e "$ROOT[$EXTRAS]"
 fi
 
 # 2. Dev mode: backend + Vite with HMR --------------------------------------

--- a/scripts/fleetsuite.sh
+++ b/scripts/fleetsuite.sh
@@ -42,6 +42,12 @@ STATIC="$ROOT/src/meshtastic_mcp/web/static/index.html"
 # launchd plist so a clean redeploy gets the camera + OCR deps (soak snapshots)
 # automatically. Kept opt-in because [ui] pulls opencv (and torch on non-Intel).
 EXTRAS="${FLEETSUITE_EXTRAS:-web}"
+# Bind address for --browser mode. Default 127.0.0.1 (localhost only) — the safe
+# default: FleetSuite has NO auth and can flash/reboot/factory-reset devices. A
+# deployment that wants LAN access sets FLEETSUITE_HOST=0.0.0.0 in its plist;
+# only do that on a trusted network (anyone who can reach the port controls the
+# fleet). The desktop-window mode always stays on 127.0.0.1.
+HOST="${FLEETSUITE_HOST:-127.0.0.1}"
 
 note() { printf '\033[36m[fleetsuite]\033[0m %s\n' "$*"; }
 
@@ -78,8 +84,8 @@ fi
 
 # 4. Launch ------------------------------------------------------------------
 if [[ $BROWSER == 1 ]]; then
-	note "serving at http://127.0.0.1:8765 (Ctrl-C to stop)"
-	exec "$ROOT/.venv/bin/meshtastic-mcp-web" --browser
+	note "serving at http://$HOST:8765 (Ctrl-C to stop)"
+	exec "$ROOT/.venv/bin/meshtastic-mcp-web" --browser --host "$HOST"
 fi
 note "opening FleetSuite window…"
 exec "$ROOT/.venv/bin/meshtastic-mcp-web"

--- a/scripts/install-launchd.sh
+++ b/scripts/install-launchd.sh
@@ -13,6 +13,10 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 LABEL="com.meshtastic.fleetsuite"
 DEST="$HOME/Library/LaunchAgents/$LABEL.plist"
 DOMAIN="gui/$(id -u)"
+# Address the web server binds. Localhost-only by default (FleetSuite has no auth
+# and can flash/reboot devices). Expose on the LAN with:
+#   FLEETSUITE_HOST=0.0.0.0 ./scripts/install-launchd.sh   (trusted networks only)
+HOST_BIND="${FLEETSUITE_HOST:-127.0.0.1}"
 
 if [[ "${1:-}" == "--uninstall" ]]; then
 	launchctl bootout "$DOMAIN" "$DEST" 2>/dev/null || true
@@ -29,7 +33,7 @@ fi
 chmod +x "$ROOT/scripts/fleetsuite-supervisor.sh" "$ROOT/scripts/fleetsuite.sh"
 mkdir -p "$HOME/Library/LaunchAgents" "$HOME/Library/Logs"
 
-sed -e "s|@ROOT@|$ROOT|g" -e "s|@HOME@|$HOME|g" \
+sed -e "s|@ROOT@|$ROOT|g" -e "s|@HOME@|$HOME|g" -e "s|@FLEETSUITE_HOST@|$HOST_BIND|g" \
 	"$ROOT/scripts/com.meshtastic.fleetsuite.plist" >"$DEST"
 
 # Re-bootstrap cleanly whether or not it was already loaded.
@@ -39,3 +43,7 @@ launchctl bootstrap "$DOMAIN" "$DEST"
 echo "installed: $DEST"
 echo "logs:      $HOME/Library/Logs/fleetsuite.log"
 echo "ui:        http://127.0.0.1:8765  (Nightly tab to enable the schedule)"
+if [[ "$HOST_BIND" != "127.0.0.1" && "$HOST_BIND" != "localhost" ]]; then
+	echo "⚠  bound to $HOST_BIND — reachable on the LAN with NO authentication."
+	echo "   Anyone who can reach this port can flash/reboot your devices. Trusted networks only."
+fi


### PR DESCRIPTION
## Problem

Camera capture (nightly soak snapshots) and the OCR tools need `opencv`/`pytesseract` from the `[ui]` extra, but the FleetSuite deployment bootstrap (`fleetsuite.sh`) and the self-update only ever install `[web]`. A clean deploy's fresh venv therefore logs **`opencv unavailable: No module named 'cv2'`** the first time a camera is used.

## Change

- **`fleetsuite.sh`** installs `$FLEETSUITE_EXTRAS` (default `web`) into a freshly-created venv. Casual/ARM installs stay light — `[ui]` pulls opencv, plus torch on non-Intel — while a deployment opts in.
- **`com.meshtastic.fleetsuite.plist`** sets `FLEETSUITE_EXTRAS=web,ui`, so the nightly Mac-Mini deployment provisions the camera/OCR deps automatically on a clean redeploy.
- **`docs/nightly.md`**: env-table row + a note that macOS also gates camera capture behind a Camera privacy grant for the launchd process.

Default behaviour is unchanged (`web`); only the deployment plist opts into `web,ui`. Existing venvs are unaffected (install `[ui]` manually if needed).

## Verification

`bash -n scripts/fleetsuite.sh` ✅ · `plutil -lint` on the plist (raw + after `@ROOT@`/`@HOME@` substitution) ✅ · `${FLEETSUITE_EXTRAS:-web}` resolves to `web` unset / `web,ui` set ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for selecting optional deployment components through the `FLEETSUITE_EXTRAS` setting.
  * Clean deployments can now include camera and OCR dependencies.
  * Camera capture requirements and privacy permissions are clarified for macOS deployments.

* **Documentation**
  * Updated deployment guidance with setup instructions for web, UI, camera, and OCR features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->