### PR TITLE
fix(web): keep device-settings controls from overflowing the card

### DIFF
--- a/web-ui/src/components/DeviceSettings.vue
+++ b/web-ui/src/components/DeviceSettings.vue
@@ -190,7 +190,7 @@ const setConfig = () => {
       <div class="flex gap-1.5 mt-1">
         <input
           v-model="name"
-          class="flex-1 bg-slate-900 border border-slate-700 rounded px-2 py-1 outline-none focus:border-emerald-700"
+          class="flex-1 min-w-0 bg-slate-900 border border-slate-700 rounded px-2 py-1 outline-none focus:border-emerald-700"
         />
         <button
           @click="saveName"
@@ -221,7 +221,7 @@ const setConfig = () => {
           v-model="envInput"
           list="envlist"
           placeholder="e.g. heltec-v4"
-          class="flex-1 bg-slate-900 border border-slate-700 rounded px-2 py-1 outline-none focus:border-emerald-700"
+          class="flex-1 min-w-0 bg-slate-900 border border-slate-700 rounded px-2 py-1 outline-none focus:border-emerald-700"
         />
         <datalist id="envlist">
           <option v-for="e in envList" :key="e" :value="e" />
@@ -255,7 +255,7 @@ const setConfig = () => {
         <input
           v-model="cfgPath"
           placeholder="path e.g. lora.region"
-          class="flex-1 bg-slate-900 border border-slate-700 rounded px-2 py-1 outline-none focus:border-emerald-700"
+          class="flex-1 min-w-0 bg-slate-900 border border-slate-700 rounded px-2 py-1 outline-none focus:border-emerald-700"
         />
         <input
           v-model="cfgValue"
@@ -292,7 +292,7 @@ const setConfig = () => {
       <div v-else class="flex gap-1.5 mt-1">
         <select
           v-model="selectedSlot"
-          class="flex-1 bg-slate-900 border border-slate-700 rounded px-2 py-1 outline-none focus:border-emerald-700"
+          class="flex-1 min-w-0 bg-slate-900 border border-slate-700 rounded px-2 py-1 outline-none focus:border-emerald-700"
         >
           <option value="">— select hub:port —</option>
           <option v-for="s in slots" :key="s.value" :value="s.value">


### PR DESCRIPTION
## Bug

In a device card's settings panel, the **USB power port (uhubctl)** `<select>` overflowed its card and slid **behind the next card**. A hub-slot option label can be long — e.g. `20-3:7 — RAKwireless WisCore RAK4631 Board <serial>` — and the `<select>` sat in a `flex` row as a `flex-1` child with no `min-w-0`. A flex child's default `min-width: auto` refuses to shrink below its intrinsic content width, so the row grew wider than the card and the text bled over the neighbour.

## Fix

Add `min-w-0` to the `flex-1` form controls in `DeviceSettings.vue` (the uhubctl select plus the name / env / config-path inputs — same latent pattern). The controls now shrink to their flex allocation and the select truncates within the card.

## Verification

Ran the Vite dev server against the live backend and opened two device settings panels side by side:

- **Heltec T114** (has a right-neighbour): `20-3:2 — Heltec▾  [assign][auto][identify][clear]` — truncated, no bleed into the middle card.
- **RAK 4631**: `20-3:7 — RAKw▾  …` — contained.

`min-w-0` is the standard fix for flexbox content-overflow; scoped to the 4 identical control classes in this component only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved the appearance and sizing of device settings form fields.
  * Added consistent borders and improved handling of narrow layouts for name, environment, configuration path, and USB power controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->