### PR TITLE
feat(web): live nightly-run panel (timeline, soak progress, activity feed)

### DIFF
--- a/web-ui/src/components/NightlyPanel.vue
+++ b/web-ui/src/components/NightlyPanel.vue
@@ -2,11 +2,73 @@
 <!-- SPDX-License-Identifier: GPL-3.0-only -->
 
 <script setup lang="ts">
-import { computed, reactive, ref, watch } from "vue";
+import { computed, onMounted, onUnmounted, reactive, ref, watch } from "vue";
 import { useNightlyStore } from "../stores/nightly";
 import NightlyReportCard from "./NightlyReportCard.vue";
 
 const nightly = useNightlyStore();
+
+// The ordered pipeline (mirrors STEPS in web/services/nightly.py). Anything not
+// in this list (bench_recover/handoff/done) is post-soak → the "report" chip.
+const STEPS = [
+  { key: "self_update", label: "self-update" },
+  { key: "firmware_update", label: "firmware" },
+  { key: "prebuild", label: "prebuild" },
+  { key: "bench_check", label: "bench check" },
+  { key: "suite", label: "suite" },
+  { key: "soak", label: "soak" },
+];
+
+// A 1 Hz clock so the elapsed + soak-progress meters advance smoothly even while
+// the soak runs quiet for hours (no WS traffic to drive re-renders otherwise).
+const now = ref(Date.now());
+let timer: number | undefined;
+onMounted(() => {
+  timer = window.setInterval(() => (now.value = Date.now()), 1000);
+});
+onUnmounted(() => {
+  if (timer) window.clearInterval(timer);
+});
+
+const active = computed(() => !!nightly.status?.state.active);
+const curStep = computed(() => nightly.status?.state.step ?? null);
+const stepIdx = computed(() => {
+  const i = STEPS.findIndex((s) => s.key === curStep.value);
+  return i === -1 ? STEPS.length : i; // unknown/post-soak → all main steps done
+});
+const runElapsed = computed(() =>
+  nightly.activeStart != null ? Math.max(0, now.value / 1000 - nightly.activeStart) : null,
+);
+const soakTotal = computed(() => (nightly.status?.config.soak_hours ?? 0) * 3600);
+const soakElapsed = computed(() =>
+  nightly.soakStart != null ? Math.max(0, now.value / 1000 - nightly.soakStart) : null,
+);
+const soakPct = computed(() =>
+  soakElapsed.value != null && soakTotal.value > 0
+    ? Math.min(100, (soakElapsed.value / soakTotal.value) * 100)
+    : null,
+);
+const feed = computed(() => [...nightly.activity].reverse()); // newest first
+
+function fmtDur(s: number | null): string {
+  if (s == null) return "—";
+  const t = Math.floor(s);
+  const h = Math.floor(t / 3600);
+  const m = Math.floor((t % 3600) / 60);
+  const sec = t % 60;
+  if (h) return `${h}h ${m}m`;
+  if (m) return `${m}m ${sec}s`;
+  return `${sec}s`;
+}
+function fmtTime(ts: number): string {
+  return new Date(ts * 1000).toLocaleTimeString();
+}
+const SEV: Record<string, string> = {
+  error: "text-rose-400",
+  warn: "text-amber-400",
+  info: "text-slate-400",
+};
+const sevColor = (sev: string): string => SEV[sev] ?? "text-slate-400";
 
 const draft = reactive({
   enabled: false,
@@ -226,6 +288,89 @@ async function testDelivery() {
         <code>McpTest</code> channel, run the full suite, soak the mesh while collecting logs +
         camera snapshots, analyze (local LLM when reachable), then post the report.
       </p>
+    </div>
+
+    <!-- live run -->
+    <div
+      v-if="active"
+      class="card-rail rounded-xl border border-indigo-700/50 bg-indigo-950/20 p-4"
+    >
+      <div class="flex items-center gap-3 mb-3">
+        <span class="w-2 h-2 rounded-full bg-indigo-400 animate-pulse" />
+        <h3 class="section-label text-indigo-200">Run in progress</h3>
+        <span class="text-xs text-slate-400">elapsed {{ fmtDur(runElapsed) }}</span>
+        <span class="flex-1" />
+        <span class="text-xs text-slate-600 mono">#{{ nightly.status?.state.nightly_id }}</span>
+      </div>
+
+      <!-- phase timeline -->
+      <div class="flex flex-wrap items-center gap-1.5 mb-3">
+        <template v-for="(s, i) in STEPS" :key="s.key">
+          <span
+            class="text-[10px] px-2 py-0.5 rounded-full border flex items-center gap-1"
+            :class="
+              i < stepIdx
+                ? 'border-emerald-700/50 bg-emerald-950/40 text-emerald-300/90'
+                : i === stepIdx
+                  ? 'border-indigo-500 bg-indigo-700/30 text-indigo-200'
+                  : 'border-slate-800 text-slate-600'
+            "
+          >
+            <span v-if="i < stepIdx">✓</span>
+            <span
+              v-else-if="i === stepIdx"
+              class="w-1.5 h-1.5 rounded-full bg-indigo-400 animate-pulse"
+            />
+            {{ s.label }}
+          </span>
+          <span v-if="i < STEPS.length - 1" class="text-slate-700 text-[10px]">›</span>
+        </template>
+        <span class="text-slate-700 text-[10px]">›</span>
+        <span
+          class="text-[10px] px-2 py-0.5 rounded-full border"
+          :class="
+            stepIdx >= STEPS.length
+              ? 'border-indigo-500 bg-indigo-700/30 text-indigo-200'
+              : 'border-slate-800 text-slate-600'
+          "
+          >report</span
+        >
+      </div>
+
+      <!-- soak progress -->
+      <div v-if="soakPct != null" class="mb-3">
+        <div class="flex items-center justify-between text-[11px] text-slate-400 mb-1">
+          <span>soak · {{ fmtDur(soakElapsed) }} / {{ fmtDur(soakTotal) }}</span>
+          <span>{{ Math.round(soakPct) }}% · ~{{ fmtDur(soakTotal - (soakElapsed ?? 0)) }} left</span>
+        </div>
+        <div class="h-2 rounded-full bg-slate-800 overflow-hidden">
+          <div class="h-full bg-indigo-500 transition-all duration-1000" :style="{ width: soakPct + '%' }" />
+        </div>
+      </div>
+
+      <!-- activity feed -->
+      <div class="text-[11px] text-slate-500 mb-1">activity</div>
+      <div
+        class="rounded-lg border border-slate-800 bg-slate-950/50 max-h-52 overflow-y-auto divide-y divide-slate-800/60"
+      >
+        <div
+          v-for="o in feed"
+          :key="o.id"
+          class="flex items-start gap-2 px-2 py-1 text-[11px]"
+        >
+          <span class="text-slate-600 mono shrink-0">{{ fmtTime(o.ts) }}</span>
+          <span class="text-slate-600 shrink-0 uppercase text-[9px] mt-0.5">{{ o.step }}</span>
+          <span
+            class="mono truncate min-w-0"
+            :class="sevColor(o.severity)"
+            :title="o.message"
+            >{{ o.message }}</span
+          >
+        </div>
+        <div v-if="feed.length === 0" class="px-2 py-2 text-[11px] text-slate-600">
+          waiting for the first observation…
+        </div>
+      </div>
     </div>
 
     <!-- reporting card -->

--- a/web-ui/src/stores/nightly.ts
+++ b/web-ui/src/stores/nightly.ts
@@ -6,6 +6,7 @@ import { ref } from "vue";
 import { api } from "../api/client";
 import { useWsStore } from "./ws";
 import type {
+  NightlyObservation,
   NightlyReportConfig,
   NightlyRun,
   NightlyRunDetail,
@@ -16,6 +17,13 @@ export const useNightlyStore = defineStore("nightly", () => {
   const status = ref<NightlyStatus | null>(null);
   const reportConfig = ref<NightlyReportConfig | null>(null);
   const runs = ref<NightlyRun[]>([]);
+
+  // Live view of the in-flight run: observations stream in over the WS, and the
+  // start/soak timestamps drive the elapsed + soak-progress meters. All empty
+  // when nothing is running.
+  const activity = ref<NightlyObservation[]>([]);
+  const activeStart = ref<number | null>(null);
+  const soakStart = ref<number | null>(null);
 
   async function load() {
     status.value = await api.get<NightlyStatus>("/api/nightly");
@@ -29,18 +37,50 @@ export const useNightlyStore = defineStore("nightly", () => {
     runs.value = await api.get<NightlyRun[]>("/api/nightly/runs");
   }
 
+  // Seed the live view from the active run's detail (observation backlog + the
+  // start/soak timestamps). Clears everything when nothing is running.
+  async function seedActive() {
+    const id = status.value?.state.nightly_id;
+    if (!status.value?.state.active || !id) {
+      activity.value = [];
+      activeStart.value = null;
+      soakStart.value = null;
+      return;
+    }
+    const d = await detail(id);
+    activeStart.value = d.started_at ?? null;
+    soakStart.value = d.soak_started_at ?? null;
+    // Merge (dedupe by id) so a live frame that arrived mid-fetch isn't dropped.
+    const seen = new Set(activity.value.map((o) => o.id));
+    const merged = activity.value.concat((d.observations || []).filter((o) => !seen.has(o.id)));
+    activity.value = merged.sort((a, b) => a.ts - b.ts);
+  }
+
   function init() {
     const ws = useWsStore();
-    ws.subscribe("nightly.update", (frame: { type?: string }) => {
-      // Frames are lightweight signals; the REST payloads are the truth.
-      if (frame.type === "finished" || frame.type === "report") {
-        load();
+    ws.subscribe("nightly.update", (frame: Record<string, any>) => {
+      // Observations stream in live; append (dedupe by id) for the activity feed.
+      if (frame.type === "observation") {
+        if (!activity.value.some((o) => o.id === frame.id)) {
+          activity.value.push({
+            id: frame.id,
+            step: frame.step,
+            severity: frame.severity,
+            kind: frame.kind,
+            message: frame.message,
+            data: frame.data ?? null,
+            ts: frame.ts,
+          });
+        }
+      } else if (frame.type === "finished" || frame.type === "report") {
+        // The REST payloads are the truth; refresh + let seedActive clear the view.
+        load().then(seedActive);
         loadRuns();
       } else if (frame.type === "state" || frame.type === "step") {
-        load();
+        load().then(seedActive);
       }
     });
-    load();
+    load().then(seedActive);
     loadReportConfig();
     loadRuns();
   }
@@ -83,6 +123,9 @@ export const useNightlyStore = defineStore("nightly", () => {
     status,
     reportConfig,
     runs,
+    activity,
+    activeStart,
+    soakStart,
     init,
     load,
     loadRuns,


### PR DESCRIPTION
## Problem

While a nightly runs, the UI showed only `running — <step>` — no other feedback. During the multi-hour **soak** (which emits almost no observations) the panel looked frozen for hours.

## Change (frontend-only)

A **live run card** on the Nightly tab, shown while a run is active:

- **Phase timeline** across the pipeline steps (`self-update → firmware → prebuild → bench check → suite → soak → report`) — done steps ✓, current highlighted, pending dimmed.
- **Run elapsed** + a **soak progress bar** (`40m / 2h · 33% · ~1h 19m left`) that advances locally off `soak_started_at`, so the long quiet soak visibly progresses.
- **Activity feed** of the observation stream — the orchestrator already broadcasts every observation over `nightly.update` (the store previously dropped those frames); now they're kept, deduped, and rendered with severity colours.

The store seeds from the active run's detail (`started_at`, `soak_started_at`, observation backlog) and appends live `observation` frames. No backend changes.

## Verification

`npm run build` ✓ (typechecks). Rendered in a browser against the live backend with a representative active-soak state injected — screenshot confirms the timeline, progress bar (ETA), elapsed ticker, and severity-coloured feed all render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a live nightly run view with a visual phase timeline and current progress.
  * Displays elapsed time, nightly run ID, soak progress, and estimated time remaining.
  * Added a real-time activity feed with timestamps and severity indicators.
  * Activity updates now appear automatically as nightly run events are received.
  * Improved active-run status tracking and refresh behavior during state changes and completion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->