### PR TITLE
fix(deploy): bench runner needs [test] — install it and probe per-extra

### DIFF
--- a/docs/nightly.md
+++ b/docs/nightly.md
@@ -58,7 +58,7 @@ Environment (set in the plist):
 |---|---|---|
 | `MESHTASTIC_MCP_NIGHTLY_FW_DIR` | `~/.meshtastic_mcp/nightly-firmware` | the checkout the nightly may hard-reset |
 | `MESHTASTIC_FIRMWARE_ROOT` | same path | builds/bakes compile exactly what the nightly pulled |
-| `FLEETSUITE_EXTRAS` | `web,ui` | a clean redeploy installs the camera + OCR deps (soak snapshots), not just `web` |
+| `FLEETSUITE_EXTRAS` | `web,ui,test` | a clean redeploy installs the camera/OCR deps (soak snapshots) **and** `[test]` — the bench runner needs pytest, or every suite fails at spawn (`0 passed, 0 failed`) |
 | `FLEETSUITE_HOST` | `127.0.0.1` | web-server bind address. `0.0.0.0` exposes the UI on the LAN — **no auth, trusted networks only** (`FLEETSUITE_HOST=0.0.0.0 ./scripts/install-launchd.sh`) |
 | `PATH` | homebrew + platformio | launchd jobs get a bare PATH |
 

--- a/scripts/com.meshtastic.fleetsuite.plist
+++ b/scripts/com.meshtastic.fleetsuite.plist
@@ -38,10 +38,12 @@
 		<string>@HOME@/.meshtastic_mcp/nightly-firmware</string>
 		<key>MESHTASTIC_MCP_NIGHTLY_FW_DIR</key>
 		<string>@HOME@/.meshtastic_mcp/nightly-firmware</string>
-		<!-- Install the camera + OCR deps (opencv/pytesseract) on a clean deploy
-		     so soak snapshots work out of the box. fleetsuite.sh reads this. -->
+		<!-- Extras a clean deploy installs (fleetsuite.sh reads this): [ui] for
+		     camera + OCR (soak snapshots), [test] for the bench test runner —
+		     without pytest every nightly suite dies at spawn with
+		     "suite exit 1: 0 passed, 0 failed". -->
 		<key>FLEETSUITE_EXTRAS</key>
-		<string>web,ui</string>
+		<string>web,ui,test</string>
 		<!-- Web server bind address. install-launchd.sh substitutes
 		     @FLEETSUITE_HOST@ from $FLEETSUITE_HOST (default 127.0.0.1). Set it to
 		     0.0.0.0 to expose the UI on the LAN — no auth, trusted networks only. -->

--- a/scripts/fleetsuite.sh
+++ b/scripts/fleetsuite.sh
@@ -56,7 +56,13 @@ if [[ ! -x $PY ]]; then
 	note "creating venv (.venv)…"
 	python3 -m venv "$ROOT/.venv"
 fi
-if ! "$PY" -c 'import fastapi, aiosqlite, uvicorn, webview' >/dev/null 2>&1; then
+# Probe a sentinel import per requested extra, so a venv created before an
+# extra was added to FLEETSUITE_EXTRAS gets retrofitted instead of silently
+# limping (a [web]-only venv has no pytest → every nightly suite dies at spawn).
+PROBE="import fastapi, aiosqlite, uvicorn, webview"
+[[ ",$EXTRAS," == *",ui,"* ]] && PROBE="$PROBE, cv2"
+[[ ",$EXTRAS," == *",test,"* ]] && PROBE="$PROBE, pytest"
+if ! "$PY" -c "$PROBE" >/dev/null 2>&1; then
 	note "installing the [$EXTRAS] extra(s)…"
 	"$PY" -m pip install --quiet --upgrade pip
 	"$PY" -m pip install --quiet -e "$ROOT[$EXTRAS]"


### PR DESCRIPTION
## Problem

Every nightly suite failed at spawn — `suite exit 1: 0 passed, 0 failed` in ~7s (nights #1 and #3 on the bench Mac). Root cause: **the deployment venv had no pytest.** `fleetsuite.sh` installed only `FLEETSUITE_EXTRAS=web,ui`, and its dependency probe imported only web modules — so an existing venv was never retrofitted either. The bench test runner spawns `sys.executable -m pytest`, which died instantly.

(This also masked as "port contention" during triage: with the suite exiting instantly, the soak preflight followed the bench-check's serial churn within seconds and hit `multiple access on port` / corrupt-protobuf handshake timeouts.)

## Change

- plist template: `FLEETSUITE_EXTRAS=web,ui,test`
- `fleetsuite.sh`: probe a sentinel import per requested extra (`cv2` for `ui`, `pytest` for `test`) so a pre-existing venv gets missing extras installed instead of silently limping
- `docs/nightly.md`: env-table row updated

## Verification

`bash -n` ✓ · `plutil -lint` ✓ · probe matrix: `web,ui,test → import fastapi, cv2, pytest`; `web → import fastapi` ✓. Applied live on the bench deployment (pytest 9.1.1 installed; validation nightly re-run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
