### PR TITLE
fix(web): refuse a guarded port still held by a wedged serial reader

### DIFF
--- a/src/meshtastic_mcp/web/services/portlock.py
+++ b/src/meshtastic_mcp/web/services/portlock.py
@@ -22,6 +22,19 @@ import asyncio
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 
+# How long guard() waits for an abandoned (wedged) reader thread to die after
+# suspend, before refusing the port. Module constant so tests can shrink it.
+WEDGE_WAIT_S = 8.0
+_WEDGE_POLL_S = 0.25
+
+
+class PortWedgedError(RuntimeError):
+    """The device's port is still held by an abandoned serial-reader thread
+    (a close timed out mid-kernel-read — see SerialMonitor.is_wedged). Opening
+    a second reader now would interleave two consumers on one tty and corrupt
+    the protobuf stream, so the caller must fail cleanly instead; a
+    power-cycle/unwedge (device re-enumeration) frees the port."""
+
 
 class PortLocks:
     def __init__(self, serialmon=None) -> None:
@@ -38,11 +51,30 @@ class PortLocks:
     async def guard(self, serial: str) -> AsyncIterator[None]:
         """Hold exclusive access to a device's port: serialise against other
         port operations on the same serial and suspend its serial monitor for
-        the duration (resumed on exit, even on error)."""
+        the duration (resumed on exit, even on error).
+
+        If the monitor's reader thread survived suspend (abandoned by a timed
+        out close, still blocked in a kernel read), the port is NOT actually
+        free: a second reader would steal bytes from the first and the
+        meshtastic handshake fails with corrupt-protobuf / "multiple access on
+        port" symptoms (observed as soak-preflight config-read timeouts). Wait
+        briefly for the reader to die, then refuse with PortWedgedError rather
+        than proceed and corrupt."""
         async with self._lock(serial):
             if self.serialmon is not None:
                 await self.serialmon.suspend(serial)
             try:
+                is_wedged = getattr(self.serialmon, "is_wedged", None)
+                if is_wedged is not None and is_wedged(serial):
+                    deadline = asyncio.get_running_loop().time() + WEDGE_WAIT_S
+                    while is_wedged(serial):
+                        if asyncio.get_running_loop().time() >= deadline:
+                            raise PortWedgedError(
+                                f"{serial}: port still held by a wedged serial reader "
+                                "— refusing to open a second reader (it would corrupt "
+                                "the stream); power-cycle/unwedge the device to free it"
+                            )
+                        await asyncio.sleep(_WEDGE_POLL_S)
                 yield
             finally:
                 if self.serialmon is not None:

--- a/src/meshtastic_mcp/web/services/serial_monitor.py
+++ b/src/meshtastic_mcp/web/services/serial_monitor.py
@@ -163,6 +163,13 @@ class SerialMonitor:
         if thread is not None:
             await asyncio.to_thread(thread.join, 2.0)
             if thread.is_alive():
+                # Second chance: a reader blocked in a kernel read on a flapping
+                # CDC device often needs a few more seconds to error out. One
+                # longer join here avoids abandoning a thread that was about to
+                # die — the abandoned-alive state poisons every guard() on this
+                # port until the device re-enumerates.
+                await asyncio.to_thread(thread.join, 4.0)
+            if thread.is_alive():
                 # Abandon it but keep mon.thread set: the fd is still held, so a
                 # second reader must not open the port. _open()/is_wedged() treat
                 # a dead abandoned thread as closed, so recovery (power-cycle →

--- a/tests/unit/test_web_portlock.py
+++ b/tests/unit/test_web_portlock.py
@@ -101,3 +101,60 @@ def test_no_monitor_is_a_noop_guard():
             pass  # must not raise when there's no monitor to suspend
 
     asyncio.run(go())
+
+
+class _WedgedMonitor(_FakeMonitor):
+    """Reports a wedged (abandoned-alive) reader for the first N polls."""
+
+    def __init__(self, wedged_polls: int) -> None:
+        super().__init__()
+        self._left = wedged_polls
+
+    def is_wedged(self, serial: str) -> bool:
+        if self._left > 0:
+            self._left -= 1
+            return True
+        return False
+
+
+def test_guard_refuses_a_wedged_port(monkeypatch):
+    """A reader that survives suspend means the port is NOT free — guard must
+    fail fast with PortWedgedError instead of letting the caller open a second
+    reader and corrupt the stream. The monitor is still resumed."""
+    from meshtastic_mcp.web.services import portlock as pl_mod
+    from meshtastic_mcp.web.services.portlock import PortWedgedError
+
+    monkeypatch.setattr(pl_mod, "WEDGE_WAIT_S", 0.05)
+    monkeypatch.setattr(pl_mod, "_WEDGE_POLL_S", 0.01)
+
+    async def go():
+        mon = _WedgedMonitor(wedged_polls=10_000)  # never clears
+        pl = PortLocks(serialmon=mon)
+        entered = False
+        with pytest.raises(PortWedgedError):
+            async with pl.guard("DEV"):
+                entered = True
+        assert not entered  # the body must never run against a held port
+        assert mon.events == [("suspend", "DEV"), ("resume", "DEV")]
+
+    asyncio.run(go())
+
+
+def test_guard_proceeds_once_the_wedged_reader_dies(monkeypatch):
+    """A transiently-wedged reader (dies during the wait window) must not fail
+    the guard — it proceeds as soon as the port is genuinely free."""
+    from meshtastic_mcp.web.services import portlock as pl_mod
+
+    monkeypatch.setattr(pl_mod, "WEDGE_WAIT_S", 1.0)
+    monkeypatch.setattr(pl_mod, "_WEDGE_POLL_S", 0.01)
+
+    async def go():
+        mon = _WedgedMonitor(wedged_polls=3)  # clears on the 4th poll
+        pl = PortLocks(serialmon=mon)
+        entered = False
+        async with pl.guard("DEV"):
+            entered = True
+        assert entered
+        assert mon.events == [("suspend", "DEV"), ("resume", "DEV")]
+
+    asyncio.run(go())


### PR DESCRIPTION
## Problem

Nightly #3's soak preflight failed on 3 of 4 boards with `could not read live config (Timed out waiting for connection completion)`, and the log shows the underlying signature all night: `device reports readiness to read but returned no data (device disconnected or multiple access on port?)` + `FromRadio: Wire format was corrupt` — **two readers on one tty**.

The race: `SerialMonitor._close()` joins the reader thread for 2 s; a reader blocked in a kernel read on a flapping CDC device survives that and is **abandoned alive, still holding the port** (the documented `is_wedged` state). But `PortLocks.guard()` proceeded after `suspend()` regardless — so preflight/keep-alive/enrichment opened a **second reader** against the held port, split the byte stream, and corrupted the meshtastic handshake. Keep-alive pokes re-triggered it every 30 s through the soak.

## Change

- **`PortLocks.guard()`**: after suspend, if the monitor reports a wedged (abandoned-alive) reader, wait up to `WEDGE_WAIT_S` (8 s) for it to die; if it survives, raise **`PortWedgedError`** — a clean, observable failure telling the operator a power-cycle/unwedge is needed — instead of proceeding and corrupting.
- **`SerialMonitor._close()`**: one longer second-chance join (4 s) before abandoning — transient kernel-read stalls usually clear in seconds, and every abandonment poisons all guards on that port until re-enumeration.

## Tests

- wedged port → guard raises, the body never runs, the monitor is still resumed
- transiently-wedged port (reader dies during the wait) → guard proceeds

`ruff` ✓ · `mypy` ✓ · portlock suite ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)
