### PR TITLE
fix(deploy): sweep orphaned FleetSuite server processes; TERM the whole child tree

### DIFF
--- a/scripts/fleetsuite-supervisor.sh
+++ b/scripts/fleetsuite-supervisor.sh
@@ -58,12 +58,29 @@ if [[ $failures -ge $MAX_CRASHES && -n $last_good && -n $sha && $last_good != "$
 	fi
 fi
 
+# Sweep orphans from a previous incarnation BEFORE spawning ours. The console
+# script is a wrapper (Python.app shim on macOS): a SIGTERM delivered to the
+# wrapper does not always reach the real server process, which then survives a
+# launchctl kickstart/bootout as a PPID-1 orphan STILL HOLDING the serial
+# ports. Two readers on one tty split the byte stream and corrupt every
+# meshtastic handshake ("multiple access on port", protobuf 'Wire format was
+# corrupt', soak-preflight connect timeouts). Kill by full path so only THIS
+# deployment's server matches — never a dev copy running elsewhere.
+if pkill -f "$ROOT/.venv/bin/meshtastic-mcp-web" 2>/dev/null; then
+	note "swept lingering server process(es) from a previous incarnation"
+	sleep 2
+	pkill -9 -f "$ROOT/.venv/bin/meshtastic-mcp-web" 2>/dev/null || true
+fi
+
 start=$(date +%s)
-# Child (not exec): we must outlive it to measure its lifetime. Signals sent to
-# our process group (launchd) reach the child; forward SIGTERM explicitly too.
+# Child (not exec): we must outlive it to measure its lifetime. Job control
+# (set -m) gives the child its OWN process group, so the TERM forward below
+# reaches the whole tree (wrapper AND real server), not just the wrapper.
+set -m
 "$ROOT/scripts/fleetsuite.sh" --browser &
 child=$!
-trap 'kill -TERM "$child" 2>/dev/null' TERM INT
+set +m
+trap 'kill -TERM -- "-$child" 2>/dev/null' TERM INT
 wait "$child"
 code=$?
 duration=$(($(date +%s) - start))


### PR DESCRIPTION
## Problem — the real "port competition"

`launchctl kickstart -k` (or bootout) SIGTERMs the console-script wrapper, but the wrapper does not always forward the signal to the real server process. That process survives as a **PPID-1 orphan still holding the serial ports** — its reader threads keep consuming bytes. The next FleetSuite instance then fights the orphan on the same ttys: `device reports readiness to read but returned no data (multiple access on port?)`, `FromRadio: Wire format was corrupt`, and soak-preflight / config-read timeouts.

Observed live on the bench: an orphan from a 07:09 instance held 3 of 4 ports for two hours across several restarts; `lsof` showed one port held by **two processes at once**. Killing the orphan made all four guarded config reads pass on the first try.

## Change (supervisor)

- **Pre-spawn sweep**: `pkill -f "$ROOT/.venv/bin/meshtastic-mcp-web"` (TERM, 2 s grace, then `-9`) — matched by full deployment path so a dev copy running elsewhere is never touched.
- **Group TERM**: spawn the child in its own process group (`set -m`) and forward TERM to the group (`kill -TERM -- -$child`), so the wrapper *and* the real server both receive shutdown.

Complements #29 (in-process wedged-reader guard): #29 protects `guard()` from our own abandoned reader threads; this removes the cross-process double-reader.

## Verification

`bash -n` ✓. Live on the bench: orphans killed manually → all 4 device config reads pass cleanly; validation nightly re-running.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
