### PR TITLE
fix(tests): ReceiveCollector listeners must default 'interface' (telemetry tier died at subscribe)

### DIFF
--- a/tests/mesh/_receive.py
+++ b/tests/mesh/_receive.py
@@ -105,7 +105,13 @@ class ReceiveCollector:
 
         # pubsub uses weak refs by default — we stash a strong ref so the
         # handler doesn't disappear between subscribe and wait_for.
-        def handler(packet: dict, interface: Any) -> None:
+        #
+        # `interface` MUST be optional: pypubsub rejects a listener whose
+        # required arg is optional in the topic's message-data spec
+        # (ListenerMismatchError — hit on meshtastic.receive.telemetry, whose
+        # MDS carries `interface` as optional; every telemetry-tier test died
+        # at subscribe time on the bench).
+        def handler(packet: dict, interface: Any = None) -> None:
             with self._lock:
                 self._packets.append(packet)
 
@@ -118,7 +124,7 @@ class ReceiveCollector:
         # separate pio monitor session that would fight our port lock.
         if self._capture_logs:
 
-            def log_handler(line: str, interface: Any) -> None:
+            def log_handler(line: str, interface: Any = None) -> None:
                 with self._lock:
                     self._log_lines.append(line)
 

--- a/tests/unit/test_receive_listener_signature.py
+++ b/tests/unit/test_receive_listener_signature.py
@@ -1,0 +1,64 @@
+# SPDX-FileCopyrightText: Meshtastic contributors
+# SPDX-License-Identifier: GPL-3.0-only
+
+"""ReceiveCollector's pubsub listeners must subscribe to topics whose
+message-data spec carries ``interface`` as *optional*.
+
+pypubsub rejects a listener whose required parameter is optional in the
+topic's MDS (``ListenerMismatchError``). ``meshtastic.receive.telemetry`` is
+such a topic, so a ``handler(packet, interface)`` signature (no default) blew
+up every telemetry-tier test at subscribe time. These tests pin the contract
+without hardware by replaying the same MDS shape through pypubsub itself.
+"""
+
+from __future__ import annotations
+
+import inspect
+
+import pytest
+
+pub = pytest.importorskip("pubsub.pub")  # ships with the meshtastic lib
+
+from tests.mesh import _receive
+
+
+def _mds_like_telemetry_topic(topic: str) -> None:
+    """Establish an MDS matching meshtastic.receive.telemetry: packet
+    required, interface optional."""
+
+    def establish(packet, interface=None):  # mirrors the runtime publisher shape
+        pass
+
+    pub.subscribe(establish, topic)
+
+
+def test_collector_handler_subscribes_to_interface_optional_topic():
+    """The exact failure mode from the bench: subscribing the collector's
+    handler to a topic whose MDS has interface optional must not raise."""
+    topic = "unittest.receive.telemetry_like"
+    _mds_like_telemetry_topic(topic)
+
+    collector = _receive.ReceiveCollector.__new__(_receive.ReceiveCollector)
+    # Reconstruct just enough state to build the closure handler the way
+    # __enter__ does — signature is what's under test, not serial IO.
+    import threading
+
+    collector._lock = threading.Lock()
+    collector._packets = []
+
+    def handler(packet: dict, interface=None) -> None:  # mirrors _receive.py
+        with collector._lock:
+            collector._packets.append(packet)
+
+    pub.subscribe(handler, topic)  # raises ListenerMismatchError if regressed
+    pub.sendMessage(topic, packet={"decoded": {}})
+    assert collector._packets == [{"decoded": {}}]
+
+
+def test_receive_module_handlers_default_interface():
+    """Source-level guard: both closures in ReceiveCollector.__enter__ must
+    default ``interface`` so they stay compatible with interface-optional
+    topics. Checked via the source (closures aren't importable directly)."""
+    src = inspect.getsource(_receive.ReceiveCollector.__enter__)
+    assert "def handler(packet: dict, interface: Any = None)" in src
+    assert "def log_handler(line: str, interface: Any = None)" in src


### PR DESCRIPTION
## Problem

Every telemetry-tier test on the bench died at subscribe time with `pubsub.core.callables.ListenerMismatchError: Listener "handler" ... required args (interface) not allowed ... topic req'd args are (packet)`.

pypubsub rejects a listener whose **required** parameter is **optional** in the topic's message-data spec. `meshtastic.receive.telemetry`'s MDS carries `interface` as optional, and `ReceiveCollector.__enter__`'s `handler(packet, interface)` (no default) violates that.

## Change

Default `interface=None` in both closures (`handler`, `log_handler`). An optional listener param is compatible with any MDS, and the value still arrives whenever the topic provides it.

## Verification

Reproduced hardware-free by establishing the same MDS shape through pypubsub: the old signature raises `ListenerMismatchError`, the fixed one subscribes and receives. Added `tests/unit/test_receive_listener_signature.py` (2 tests: live subscribe/receive against an interface-optional topic + a source-level signature guard). `ruff` ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed receive and firmware log subscriptions for topics where the interface is optional.
  - Prevented subscription errors that could interrupt message collection.

- **Tests**
  - Added coverage to verify optional interface handling and listener compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->