### PR TITLE
feat(bake): retry nRF52 DFU entry across rounds with a power-cycle between

### DIFF
--- a/tests/test_00_bake.py
+++ b/tests/test_00_bake.py
@@ -28,7 +28,7 @@ from typing import Any
 
 import pytest
 
-from meshtastic_mcp import admin, boards, flash, hw_tools, info, port_recovery
+from meshtastic_mcp import admin, boards, flash, hw_tools, info, port_recovery, uhubctl
 
 from . import _bench
 
@@ -90,6 +90,15 @@ def _wait_port_free(
         ) from exc
 
 
+# DFU-entry rounds: each round is a touch_1200bps call (which itself retries
+# the touch twice); between rounds the board's own hub slot is power-cycled.
+# A fresh boot makes the Adafruit bootloader reliably receptive to the touch —
+# observed on the bench: the T114 (HT-n5262) refused DFU entry two nights
+# running until it was power-cycled right before the touch.
+_DFU_TOUCH_ROUNDS = 3
+_DFU_REENUM_TIMEOUT_S = 30.0
+
+
 def _prepare_nrf52_for_upload(port: str) -> str:
     """Kick the RAK4631 (or similar nRF52 USB-DFU board) into bootloader mode
     via 1200bps touch, then return the port where pio should upload.
@@ -99,22 +108,48 @@ def _prepare_nrf52_for_upload(port: str) -> str:
     (0x239A/0x0029) at a different `/dev/cu.usbmodem*` path.
 
     `touch_1200bps` does the heavy lifting: bounded open/close, polls for the
-    Adafruit-bootloader PID specifically, retries the touch up to twice.
-    Fails loudly if the device doesn't enter DFU — no point trying pio
-    upload against an app-mode device, it'll just hang.
+    Adafruit-bootloader PID specifically, retries the touch up to twice. A
+    board whose app-mode USB stack has gone stale can ignore those touches
+    entirely, so on failure the board's own hub slot is power-cycled (fresh
+    boot → receptive bootloader) and the touch round repeats, up to
+    ``_DFU_TOUCH_ROUNDS``. Fails loudly if the device never enters DFU — no
+    point trying pio upload against an app-mode device, it'll just hang.
     """
     # Remember this board's physical hub slot before the touch. With several
     # nRF52 boards present (one may already be sitting in DFU), the global
     # bootloader scan in `touch_1200bps` can return a DIFFERENT board's
     # bootloader — so after the touch we re-pin to whatever is on THIS slot.
     hub, slot = port_recovery.hub_slot_for_port(port)
-    result = flash.touch_1200bps(port=port, settle_ms=500, retries=2)
+    result: dict[str, Any] = {}
+    for round_no in range(1, _DFU_TOUCH_ROUNDS + 1):
+        result = flash.touch_1200bps(port=port, settle_ms=500, retries=2)
+        if result.get("ok") or round_no == _DFU_TOUCH_ROUNDS:
+            break
+        # Off/on the board's own slot between rounds, then re-resolve the
+        # app-mode port (re-enumeration may move the /dev path) and let the
+        # app boot before touching again. Best-effort: without a resolvable
+        # slot or uhubctl, the next round is a plain re-touch.
+        if hub is None or slot is None:
+            continue
+        try:
+            uhubctl.cycle(hub, slot, delay_s=2)
+        except Exception as exc:
+            print(f"[bake] {port}: inter-round power-cycle unavailable ({exc}); re-touching")
+            continue
+        deadline = time.monotonic() + _DFU_REENUM_TIMEOUT_S
+        while time.monotonic() < deadline:
+            candidate = port_recovery.port_on_slot(hub, slot)
+            if candidate:
+                port = candidate
+                break
+            time.sleep(0.5)
+        time.sleep(2.0)  # app boot settle — a touch mid-boot is ignored
     if not result.get("ok"):
         raise AssertionError(
             f"nRF52 at {port} did not enter DFU bootloader after "
-            f"{result.get('attempts')} 1200bps touches. Manual recovery: "
-            f"double-tap the reset button on the board, then re-run. "
-            f"Detected port set before/after touch was unchanged."
+            f"{_DFU_TOUCH_ROUNDS} touch rounds (2 touches each) with "
+            f"power-cycles between rounds. Manual recovery: double-tap the "
+            f"reset button on the board, then re-run."
         )
     new_port = result["new_port"]
     if hub is not None and slot is not None:

--- a/tests/unit/test_bake_dfu_retry.py
+++ b/tests/unit/test_bake_dfu_retry.py
@@ -1,0 +1,122 @@
+# SPDX-FileCopyrightText: Meshtastic contributors
+# SPDX-License-Identifier: GPL-3.0-only
+
+"""The bake's nRF52 DFU-entry must retry the 1200bps touch across multiple
+rounds with a power-cycle of the board's own hub slot between rounds.
+
+Regression for the bench T114 (HT-n5262): its app-mode USB stack ignored the
+touch two nights running, but entered DFU immediately after a power-cycle.
+All hardware calls are monkeypatched — no boards or hub needed.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("meshtastic")
+
+from tests import test_00_bake as bake
+
+
+def _patch_common(monkeypatch, hub="20-3", slot=2):
+    monkeypatch.setattr(bake.port_recovery, "hub_slot_for_port", lambda p: (hub, slot))
+    monkeypatch.setattr(bake.port_recovery, "port_on_slot", lambda h, s: "/dev/cu.usbmodemAPP")
+    monkeypatch.setattr(bake.time, "sleep", lambda s: None)
+    monkeypatch.setattr(bake, "_DFU_REENUM_TIMEOUT_S", 0.1)
+
+
+def test_touch_failure_power_cycles_then_succeeds(monkeypatch):
+    """Round 1 fails → slot power-cycled → round 2 succeeds. The cycle hits
+    the board's OWN slot, and the touch resumes on the re-resolved port."""
+    _patch_common(monkeypatch)
+    calls = {"touch": 0, "cycles": []}
+
+    def fake_touch(port, settle_ms, retries):
+        calls["touch"] += 1
+        if calls["touch"] == 1:
+            return {"ok": False, "attempts": retries}
+        return {"ok": True, "new_port": "/dev/cu.usbmodemDFU"}
+
+    monkeypatch.setattr(bake.flash, "touch_1200bps", fake_touch)
+    monkeypatch.setattr(
+        bake.uhubctl, "cycle", lambda loc, p, delay_s: calls["cycles"].append((loc, p))
+    )
+
+    result = bake._prepare_nrf52_for_upload("/dev/cu.usbmodem143201")
+    assert calls["touch"] == 2
+    assert calls["cycles"] == [("20-3", 2)]  # exactly one cycle, on this board's slot
+    # After success the helper re-pins to whatever sits on THIS slot.
+    assert result == "/dev/cu.usbmodemAPP"
+
+
+def test_all_rounds_exhausted_raises_with_round_count(monkeypatch):
+    """Every round fails → AssertionError mentioning the round count; a cycle
+    ran between every pair of rounds (rounds-1 cycles), never after the last."""
+    _patch_common(monkeypatch)
+    calls = {"touch": 0, "cycles": 0}
+
+    monkeypatch.setattr(
+        bake.flash,
+        "touch_1200bps",
+        lambda port, settle_ms, retries: (
+            calls.__setitem__("touch", calls["touch"] + 1) or {"ok": False, "attempts": retries}
+        ),
+    )
+    monkeypatch.setattr(
+        bake.uhubctl,
+        "cycle",
+        lambda loc, p, delay_s: calls.__setitem__("cycles", calls["cycles"] + 1),
+    )
+
+    with pytest.raises(AssertionError, match="touch rounds"):
+        bake._prepare_nrf52_for_upload("/dev/cu.usbmodem143201")
+    assert calls["touch"] == bake._DFU_TOUCH_ROUNDS
+    assert calls["cycles"] == bake._DFU_TOUCH_ROUNDS - 1
+
+
+def test_no_hub_slot_still_retries_without_cycling(monkeypatch):
+    """A board with no resolvable hub slot degrades to plain re-touches."""
+    _patch_common(monkeypatch, hub=None, slot=None)
+    calls = {"touch": 0, "cycles": 0}
+
+    def fake_touch(port, settle_ms, retries):
+        calls["touch"] += 1
+        if calls["touch"] < 3:
+            return {"ok": False, "attempts": retries}
+        return {"ok": True, "new_port": "/dev/cu.usbmodemDFU"}
+
+    monkeypatch.setattr(bake.flash, "touch_1200bps", fake_touch)
+    monkeypatch.setattr(
+        bake.uhubctl,
+        "cycle",
+        lambda loc, p, delay_s: calls.__setitem__("cycles", calls["cycles"] + 1),
+    )
+
+    result = bake._prepare_nrf52_for_upload("/dev/cu.usbmodem143201")
+    assert calls["touch"] == 3
+    assert calls["cycles"] == 0  # no slot → no cycling, but retries continue
+    assert result == "/dev/cu.usbmodemDFU"  # no slot re-pin either
+
+
+def test_cycle_failure_degrades_to_plain_retouch(monkeypatch):
+    """uhubctl erroring between rounds must not sink the bake — the next
+    round proceeds as a plain re-touch on the original port."""
+    _patch_common(monkeypatch)
+    calls = {"touch": 0}
+
+    def fake_touch(port, settle_ms, retries):
+        calls["touch"] += 1
+        if calls["touch"] == 1:
+            return {"ok": False, "attempts": retries}
+        return {"ok": True, "new_port": "/dev/cu.usbmodemDFU"}
+
+    monkeypatch.setattr(bake.flash, "touch_1200bps", fake_touch)
+
+    def boom(loc, p, delay_s):
+        raise RuntimeError("uhubctl not present")
+
+    monkeypatch.setattr(bake.uhubctl, "cycle", boom)
+
+    result = bake._prepare_nrf52_for_upload("/dev/cu.usbmodem143201")
+    assert calls["touch"] == 2
+    assert result == "/dev/cu.usbmodemAPP"


### PR DESCRIPTION
## Problem

The bench T114 (HT-n5262) failed `test_bake[heltec_t114]` two nights running with `did not enter DFU bootloader after 2 1200bps touches` — its app-mode USB stack goes stale and ignores the touch entirely. The board itself is fine: it enters DFU and flashes immediately after a power-cycle (and after a manual double-tap). Meanwhile every T114 bake failure cascades into ~13 mesh/telemetry/traceroute pairing timeouts.

## Change

`_prepare_nrf52_for_upload` now runs up to **3 touch rounds** (`touch_1200bps` still retries twice within each round). Between rounds it:
1. power-cycles the board's **own hub slot** (`uhubctl.cycle`) — fresh boot → receptive bootloader,
2. re-resolves the app port on that slot (re-enumeration can move the `/dev` path),
3. lets the app finish booting before the next touch.

Degrades gracefully: no resolvable hub slot or no uhubctl → the remaining rounds are plain re-touches.

## Verification

4 unit tests, hardware fully mocked: fail → one cycle on the board's own slot → success (re-pinned to the slot's port); all-rounds-exhausted raises with the round count after exactly rounds−1 cycles; no-slot and cycle-error paths still retry without cycling. `ruff` ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved nRF52 firmware uploads by retrying DFU mode entry when the first attempt fails.
  - Automatically power-cycles the connected board when needed and reconnects to the correct USB port.
  - Continues safely without power cycling when the board’s hub location cannot be identified.
  - Reports a clear failure after all recovery attempts are exhausted.

- **Tests**
  - Added coverage for successful retries, exhausted attempts, unavailable hub details, and power-cycle errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->