### PR TITLE
fix(tests): detect device-offline via the hub connect flag (hub DOES cut power)

### DIFF
--- a/tests/_power.py
+++ b/tests/_power.py
@@ -67,6 +67,34 @@ def power_off(role: str, *, resolved: tuple[str, int] | None = None) -> dict[str
     return uhubctl_mod.power_off(loc, port)
 
 
+def hub_cuts_power(
+    role: str,
+    *,
+    expected_port: str | None = None,
+    absence_timeout_s: float = 8.0,
+) -> bool:
+    """Probe whether the hub ACTUALLY cuts VBUS on `role`'s port.
+
+    Some hubs (e.g. Terminus FE 2.1 clones, 1a40:0201) accept uhubctl's off
+    command and flip their status bits while VBUS stays hot — the device never
+    de-enumerates, so any test that expects a power cut to kill the board can
+    never pass. Cut the port, watch for de-enumeration, restore power (always,
+    even when the probe says no). Returns True iff the device truly vanished.
+
+    The target resolves once up-front, while the device is still visible —
+    `resolve_target` can't find a powered-off device.
+    """
+    resolved = uhubctl_mod.resolve_target(role)
+    power_off(role, resolved=resolved)
+    try:
+        wait_for_absence(role, timeout_s=absence_timeout_s, expected_port=expected_port)
+        return True
+    except TimeoutError:
+        return False
+    finally:
+        power_on(role, resolved=resolved)
+
+
 def power_cycle(
     role: str,
     *,

--- a/tests/mesh/test_peer_offline_recovery.py
+++ b/tests/mesh/test_peer_offline_recovery.py
@@ -39,11 +39,40 @@ from tests._port_discovery import resolve_port_by_role
 from ._receive import ReceiveCollector, nudge_nodeinfo
 
 
+@pytest.fixture(scope="module")
+def hub_actually_cuts_power(hub_devices: dict[str, str]) -> None:
+    """Skip the whole tier when the hub only PRETENDS to switch power.
+
+    Some hubs (e.g. Terminus FE 2.1 clones, 1a40:0201) accept uhubctl's off
+    command and report the port as off while VBUS stays hot — the device never
+    de-enumerates, so every test here would fail with "didn't disappear after
+    power_off" regardless of firmware behaviour (observed on the reference
+    bench: ports 1/2/7 all reported `0000 off` with the /dev node still
+    present). Probe once per module with the first hub device: cut, watch for
+    de-enumeration, restore. No real cut ⇒ skip with an actionable reason
+    instead of reporting impossible failures every night.
+    """
+    role, port = next(iter(hub_devices.items()))
+    try:
+        cuts = _power.hub_cuts_power(role, expected_port=port)
+    except Exception as exc:
+        pytest.skip(f"can't probe hub power control via {role!r}: {exc}")
+    # Power is restored by the probe; re-pin the port in case it moved.
+    hub_devices[role] = resolve_port_by_role(role, timeout_s=30.0)
+    if not cuts:
+        pytest.skip(
+            "hub does not actually cut VBUS (uhubctl reported off but the "
+            "device never de-enumerated) — the peer-offline tier needs a hub "
+            "with true per-port power switching (see uhubctl's supported list)"
+        )
+
+
 @pytest.mark.timeout(360)
 def test_peer_offline_then_recovers(
     mesh_pair: dict[str, Any],
     power_cycle,
     hub_devices: dict[str, str],
+    hub_actually_cuts_power: None,
 ) -> None:
     tx_port = mesh_pair["tx"]["port"]
     rx_node_num = mesh_pair["rx"]["my_node_num"]

--- a/tests/unit/test_hub_power_probe.py
+++ b/tests/unit/test_hub_power_probe.py
@@ -1,0 +1,70 @@
+# SPDX-FileCopyrightText: Meshtastic contributors
+# SPDX-License-Identifier: GPL-3.0-only
+
+"""`_power.hub_cuts_power` — the once-per-tier probe that detects hubs which
+only pretend to switch power (status bits flip, VBUS stays hot).
+
+Regression for the reference bench's Terminus FE 2.1 clone (1a40:0201):
+uhubctl reported every port `off` while the device node never left /dev, so
+the whole peer-offline tier failed with "didn't disappear after power_off".
+All hub/USB calls are monkeypatched — no hardware needed.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("meshtastic")
+
+from tests import _power
+
+
+@pytest.fixture()
+def rig(monkeypatch):
+    calls: dict = {"off": [], "on": [], "resolve": 0}
+    monkeypatch.setattr(
+        _power.uhubctl_mod,
+        "resolve_target",
+        lambda role: calls.__setitem__("resolve", calls["resolve"] + 1) or ("20-3", 7),
+    )
+    monkeypatch.setattr(
+        _power.uhubctl_mod, "power_off", lambda loc, p: calls["off"].append((loc, p)) or {}
+    )
+    monkeypatch.setattr(
+        _power.uhubctl_mod, "power_on", lambda loc, p: calls["on"].append((loc, p)) or {}
+    )
+    return calls
+
+
+def test_true_when_device_deenumerates(rig, monkeypatch):
+    monkeypatch.setattr(_power, "wait_for_absence", lambda role, timeout_s, expected_port: None)
+    assert _power.hub_cuts_power("rak4631", expected_port="/dev/x") is True
+    assert rig["off"] == [("20-3", 7)]
+    assert rig["on"] == [("20-3", 7)]  # power restored
+
+
+def test_false_when_device_survives_the_cut(rig, monkeypatch):
+    def never_absent(role, timeout_s, expected_port):
+        raise TimeoutError("still enumerated")
+
+    monkeypatch.setattr(_power, "wait_for_absence", never_absent)
+    assert _power.hub_cuts_power("rak4631", expected_port="/dev/x") is False
+    assert rig["on"] == [("20-3", 7)]  # power restored even on a no-op hub
+
+
+def test_resolves_target_once_before_the_cut(rig, monkeypatch):
+    """resolve_target must run exactly once, up-front — a powered-off device
+    is invisible to it, so resolving during restore would raise."""
+    monkeypatch.setattr(_power, "wait_for_absence", lambda role, timeout_s, expected_port: None)
+    _power.hub_cuts_power("rak4631")
+    assert rig["resolve"] == 1
+
+
+def test_power_restored_when_wait_raises_unexpectedly(rig, monkeypatch):
+    def boom(role, timeout_s, expected_port):
+        raise RuntimeError("list_devices exploded")
+
+    monkeypatch.setattr(_power, "wait_for_absence", boom)
+    with pytest.raises(RuntimeError):
+        _power.hub_cuts_power("rak4631")
+    assert rig["on"] == [("20-3", 7)]  # finally-block restore


### PR DESCRIPTION
## The finding

Controlled experiment on the reference bench's hub (Terminus FE 2.1 clone, `1a40:0201`, advertises `ppps`): `uhubctl -p N -a off` is accepted and the hub reports `0000 off` — **but the device never de-enumerates**. Verified on ports 1, 2, and 7: `/dev/cu.usbmodem*` stays present throughout. VBUS is never actually cut (and the bench boards have no batteries). Every `peer_offline_recovery` test therefore failed with `didn't disappear after power_off` — ~12 impossible failures polluting every nightly report.

## Change

- **`tests/_power.hub_cuts_power(role)`** — probe: resolve the target once up-front (a powered-off device is invisible to `resolve_target`), cut, watch for de-enumeration, **always restore power**. Returns whether the device truly vanished.
- **`test_peer_offline_recovery`** — a module-scoped fixture runs the probe once with the first hub device and **skips the tier with an actionable reason** ("hub does not actually cut VBUS … needs true per-port power switching") when the hub is a fake switcher. On a genuine PPPS hub the tier runs exactly as before.

## Bench note

Until the hub is replaced with a verified-PPPS model (see uhubctl's supported list — e.g. YKUSH), the recovery ladder's power-cycle rung and #32's inter-round cycles are also no-ops on this bench; #32's extra touch rounds are what actually help the T114.

## Verification

4 unit tests (hub calls mocked): device-vanishes → True; device-survives → False; exactly one up-front resolve; power restored even when the absence-wait raises. Live probe on the bench matches: all three tested ports report off with the device still enumerated. `ruff` ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved peer-offline recovery testing to verify that hub power is genuinely disconnected before running.
  * Tests now skip with an actionable reason when the connected hub cannot fully cut device power.
  * Ensured hub power is restored after power-probe checks, including when checks fail or encounter errors.

* **Tests**
  * Added coverage for successful power disconnection, failed disconnection, target resolution, error handling, and power restoration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->