### PR TITLE
add Immersion RF meter driver

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,7 +31,11 @@ decoupled so the device/admin/recorder core works with **no firmware checkout**.
   PA-calibration bench (`pa_meter_status` / `pa_measure` / `pa_sweep`). Absolute TX-power
   measurement off a node's PA — steps `lora.tx_power` and tables configured-vs-measured dBm with a
   compression/saturation analysis. Complements the SDR oracle (which checks frequency/presence, not
-  absolute power). See `IMMERSIONRC_METER_HANDOFF.md`.
+  absolute power). Unlike the other capabilities this one does **not** gate tool registration: the
+  three tools are always registered (the meter auto-powers-off, so a startup probe would hide the
+  very tool you use to check for it) and return a clear "no meter" result/error when absent; the
+  capability is informational (reported by `doctor`/startup). Region→frequency mapping lives in
+  `pa_sweep.resolve_band_mhz` via `lora_compliance.REGIONS`. See `docs/power-meter.md`.
 - **sdk-cli capability** (experimental; needs the Kotlin SDK headless CLI): `sdk_cli.py`
   device-IO backend via the JVM CLI — see `docs/sdk-cli-bridge.md`.
 - **FleetSuite web control plane** (the `[web]` extra, separate `meshtastic-mcp-web` entrypoint,
@@ -43,9 +47,9 @@ decoupled so the device/admin/recorder core works with **no firmware checkout**.
 `capabilities.detect()` drives this; the active set is logged at startup. `config.firmware_root()`
 raises when absent; use `config.firmware_root_or_none()` for capability checks. The `firmware_tool`
 decorator (`_FIRMWARE_TOOLS` in `server.py`) registers the firmware-coupled tools only when
-`CAPS.firmware` is active — 57 always-on tools; +4 android, +17 firmware, +2 sdr, +3 power_meter,
-and the apple/sdk-cli/local-model gates on top (≈87 with everything active). Counts drift —
-`doctor` and the startup log are the source of truth.
+`CAPS.firmware` is active — 60 always-on tools (includes the 3 power-meter tools, always
+registered); +4 android, +17 firmware, +2 sdr, and the apple/sdk-cli/local-model gates on top
+(≈87 with everything active). Counts drift — `doctor` and the startup log are the source of truth.
 
 **Provisioning:** `doctor.py` (the `doctor` MCP tool / `meshtastic-mcp doctor` CLI) probes every
 external dependency and emits the exact, platform-aware acquisition command for anything missing

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,6 +26,12 @@ decoupled so the device/admin/recorder core works with **no firmware checkout**.
   (`local_model_status` / `local_model_serve` / `local_model_serve_stop`).
 - **sdr capability** (needs the `[sdr]` extra + `librtlsdr` + an attached RTL-SDR): `sdr.py` +
   `rf_oracle.py` RF-compliance oracle (`rf_scan` / `rf_confirm_tx`).
+- **power-meter capability** (no extra — pure `pyserial`; needs an attached, powered-on ImmersionRC
+  RF Power Meter v2, USB CDC VID `0x04D8`/PID `0x000A`): `power_meter.py` driver + `pa_sweep.py`
+  PA-calibration bench (`pa_meter_status` / `pa_measure` / `pa_sweep`). Absolute TX-power
+  measurement off a node's PA — steps `lora.tx_power` and tables configured-vs-measured dBm with a
+  compression/saturation analysis. Complements the SDR oracle (which checks frequency/presence, not
+  absolute power). See `IMMERSIONRC_METER_HANDOFF.md`.
 - **sdk-cli capability** (experimental; needs the Kotlin SDK headless CLI): `sdk_cli.py`
   device-IO backend via the JVM CLI — see `docs/sdk-cli-bridge.md`.
 - **FleetSuite web control plane** (the `[web]` extra, separate `meshtastic-mcp-web` entrypoint,
@@ -37,9 +43,9 @@ decoupled so the device/admin/recorder core works with **no firmware checkout**.
 `capabilities.detect()` drives this; the active set is logged at startup. `config.firmware_root()`
 raises when absent; use `config.firmware_root_or_none()` for capability checks. The `firmware_tool`
 decorator (`_FIRMWARE_TOOLS` in `server.py`) registers the firmware-coupled tools only when
-`CAPS.firmware` is active — 57 always-on tools; +4 android, +17 firmware, +2 sdr, and the
-apple/sdk-cli/local-model gates on top (≈84 with everything active). Counts drift — `doctor`
-and the startup log are the source of truth.
+`CAPS.firmware` is active — 57 always-on tools; +4 android, +17 firmware, +2 sdr, +3 power_meter,
+and the apple/sdk-cli/local-model gates on top (≈87 with everything active). Counts drift —
+`doctor` and the startup log are the source of truth.
 
 **Provisioning:** `doctor.py` (the `doctor` MCP tool / `meshtastic-mcp doctor` CLI) probes every
 external dependency and emits the exact, platform-aware acquisition command for anything missing

--- a/docs/power-meter.md
+++ b/docs/power-meter.md
@@ -108,6 +108,14 @@ about regions; it speaks MHz only.
   afterwards. A `lora.tx_power` change applies live on firmware 2.8.0+; use
   `reboot_between_steps=True` for older firmware that only applies LoRa config on
   reboot.
+- **TX linger tuning:** each broadcast holds the node's port open `tx_linger_s`
+  after the send so the firmware's ~4 s broadcast politeness delay and the
+  packet's airtime complete before the close-triggered DTR reset drops the queued
+  TX. `pa_sweep` sets this explicitly (default 6 s) rather than inheriting
+  `send_text`'s conservative 8 s interactive default — it is paid per burst per
+  step, so it dominates sweep wall-clock. Raise it for slow presets (LONG_SLOW
+  and friends have multi-second airtime a 6 s linger would clip); lower it only
+  when you know the airtime is short.
 
 Every reading is an uncalibrated bench regression check (±0.5 dB instrument plus a
 hand-entered attenuator value), not a substitute for certified EMC-lab compliance

--- a/docs/power-meter.md
+++ b/docs/power-meter.md
@@ -1,0 +1,135 @@
+# RF power meter — ImmersionRC RF Power Meter v2
+
+The `power_meter` capability drives an **ImmersionRC RF Power Meter v2** over USB
+to measure the absolute transmit power coming off a Meshtastic node's PA. It is
+the measurement instrument behind the PA-calibration bench: `power_meter.py` is
+the driver, `pa_sweep.py` is the closed-loop orchestration, and three MCP tools
+expose them — `pa_meter_status`, `pa_measure`, and `pa_sweep`.
+
+This complements the RTL-SDR RF-compliance oracle (`sdr.py` / `rf_oracle.py`).
+The SDR answers *"did RF leave the antenna, at the right frequency, in-band?"*;
+the meter answers *"how much power, in absolute dBm, and where does the PA stop
+tracking the configured `lora.tx_power`?"* — a calibrated scalar the uncalibrated
+SDR cannot provide.
+
+The driver needs no extra dependency: it is pure `pyserial` (already a core dep).
+Everything below was verified live against meter firmware **1.0.11**.
+
+## Device identity
+
+- USB CDC serial device, **VID `0x04D8` (Microchip) / PID `0x000A`**. Windows
+  shows it as "Serielles USB-Gerät (COMx)". This firmware reports no manufacturer
+  string, so detection matches on VID/PID only (`power_meter.list_meters()`).
+- Baud rate is irrelevant on CDC; the driver opens at 9600.
+- **Auto-off:** the meter runs on a battery and powers itself off on an idle
+  timeout. When it does, the USB device disappears entirely and re-enumerates on
+  power-up (usually — but not guaranteed — on the same COM port). Treat a
+  vanished port as "asleep" and re-scan for the VID/PID. Hold **one** connection
+  for a whole measurement rather than reopening per reading, which races the
+  re-enumeration.
+
+## Wire protocol
+
+Line-based ASCII, commands terminated with `\n`, case-insensitive. Every reply is
+either a value line followed by an `OK` line, a bare `OK` line, or `ERROR`:
+
+```
+<value>\r\n
+OK\r\n
+```
+
+| Command | Meaning | Example reply |
+|---------|---------|---------------|
+| `V`       | firmware version string             | `RFPowerMeterv2 1.0.11` |
+| `D`       | current **average** power (dBm)      | `-26.450439` |
+| `E`       | current **peak** power (dBm)         | `-25.9596` |
+| `F`       | query the **stored** frequency (MHz) | `35` |
+| `F<idx>`  | set the active calibration curve by index; echoes the new MHz | `900` |
+| `S`       | persist current settings (updates the LCD + stored config) | `OK` only |
+
+The driver validates the trailing `OK` after every value reply; anything else is
+treated as a desynced stream and raised, rather than returning an unconfirmed
+value that would let the next command read garbage.
+
+## Calibration frequency table
+
+`F<idx>` selects one of 16 stored per-frequency calibration curves (0-based):
+
+```
+index:  0    1    2     3     4     5      6      7 ...                              15
+MHz:   35    72   433   868   900   1200   2400   5600 5650 5700 5750 5800 5850 5900 5950 6000
+```
+
+The meter has no continuous tuning — it applies whichever stored curve is active
+— so any target frequency is snapped to the nearest stored point
+(`power_meter.nearest_freq_index`). There is **no dedicated 915 MHz point** on fw
+1.0.11: US915-class work uses the 900 MHz curve (`F4`), matching the ExpressLRS
+tooling convention.
+
+Region-to-frequency resolution lives in `pa_sweep.resolve_band_mhz`, which maps a
+Meshtastic region enum name (`"US"`, `"EU_868"`, `"EU_433"`, `"JP"`, ...) to the
+centre of that region's allocation via `lora_compliance.REGIONS` — the same table
+firmware derives its channels from — and then snaps to the nearest calibration
+point. A bare MHz value (`"868"`) is accepted too. The driver itself knows nothing
+about regions; it speaks MHz only.
+
+## Quirks
+
+1. `F<idx>` changes the **active calibration curve immediately** but does **not**
+   update the LCD, and a subsequent bare `F` query still returns the old stored
+   value until an `S` (persist) is issued. Proof: the no-input noise-floor reading
+   shifts with the set curve (35 MHz: −26.5, 6 GHz: −23.5, 900 MHz: −25.3 dBm).
+2. `S` persists the serial-set frequency: after `F4` + `S` the LCD shows 900 MHz
+   and it survives a power cycle.
+3. Reference tools (ExpressLRS) send `F<idx>` **twice** with ~200 ms spacing "for
+   reliability"; the driver follows the same convention.
+4. Attenuator offsets are **never** sent to the meter — they are applied in
+   software (`pa_sweep`), added back on top of the reading.
+5. A sustained polling rate of ~10–12 Hz (50 ms between commands) works fine.
+
+## Measurement notes and safety
+
+- **Range:** −20 to +30 dBm (30 dB internal attenuator). **Absolute max +31 dBm
+  (1.3 W)**; more than 30 s above +27 dBm is out of spec and can damage the meter.
+  Accuracy ±0.5 dB. A bare Meshtastic PA at +22 dBm needs an external pad — pick
+  `attenuator_db` so the highest configured step minus the pad stays under the
+  absolute max. `pa_sweep` refuses to run a sweep that would exceed it.
+- **Noise floor** reads around −25 dBm at the 868/900 MHz calibration — that is
+  the log-detector floor, not zero. TX-vs-floor discrimination thresholds samples
+  at floor + margin (default 5 dB).
+- For LoRa bursts (constant envelope, seconds long) the **average** reading (`D`)
+  is the primary number; **peak** (`E`) is a cross-check.
+- The attenuator correction is applied to *every* reading, so it also inflates a
+  raw noise-floor read by the pad value — pass `attenuator_db=0` when you want the
+  meter's unreferenced floor.
+- **Meshtastic bench notes:** an idle node transmits rarely, so `pa_sweep` queues
+  large (~200 B) text broadcasts for multi-second airtime bursts. On EU_868 it
+  overrides `lora.override_duty_cycle` for the run and restores the original value
+  afterwards. A `lora.tx_power` change applies live on firmware 2.8.0+; use
+  `reboot_between_steps=True` for older firmware that only applies LoRa config on
+  reboot.
+
+Every reading is an uncalibrated bench regression check (±0.5 dB instrument plus a
+hand-entered attenuator value), not a substitute for certified EMC-lab compliance
+measurement.
+
+## Tools
+
+| Tool | Kind | Purpose |
+|------|------|---------|
+| `pa_meter_status` | read-only | Detect the meter; report version, stored frequency, and a live avg/peak reading. Returns `{"present": false, ...}` when none is attached. |
+| `pa_measure`      | read-only | Passive read at a band (region name or MHz): min/mean/max dBm over N samples. No Meshtastic device driven. |
+| `pa_sweep`        | destructive (`confirm=True`) | Closed-loop: step `lora.tx_power`, key TX, measure the PA output at each step; returns a configured-vs-measured table plus a compression/saturation analysis. |
+
+The tools are always registered (they cost nothing without a meter) and return a
+clear "no meter" result or error when one is not attached — deliberately, so
+`pa_meter_status` is available precisely when you suspect the meter has powered
+itself off. `doctor` reports meter presence under the `power_meter` group.
+
+## Reference implementations
+
+- [ExpressLRS/RfPowerMeter](https://github.com/ExpressLRS/RfPowerMeter) — the
+  official ELRS Python CLI (pyserial, VID/PID auto-detect, `F<idx>` twice, CSV
+  logging).
+- [SunjunKim/rf_power_meter_logger](https://github.com/SunjunKim/rf_power_meter_logger)
+  — a Processing GUI logger whose header documents the V/D/E/F command set.

--- a/docs/power-meter.md
+++ b/docs/power-meter.md
@@ -118,7 +118,7 @@ measurement.
 | Tool | Kind | Purpose |
 |------|------|---------|
 | `pa_meter_status` | read-only | Detect the meter; report version, stored frequency, and a live avg/peak reading. Returns `{"present": false, ...}` when none is attached. |
-| `pa_measure`      | read-only | Passive read at a band (region name or MHz): min/mean/max dBm over N samples. No Meshtastic device driven. |
+| `pa_measure`      | write (meter only) | Reads min/mean/max dBm over N samples; **selects the band's active calibration curve** on the meter (transient, not persisted), so it is not read-only. Harmless to any device under test — no Meshtastic device driven. |
 | `pa_sweep`        | destructive (`confirm=True`) | Closed-loop: step `lora.tx_power`, key TX, measure the PA output at each step; returns a configured-vs-measured table plus a compression/saturation analysis. |
 
 The tools are always registered (they cost nothing without a meter) and return a

--- a/docs/power-meter.md
+++ b/docs/power-meter.md
@@ -33,19 +33,23 @@ Everything below was verified live against meter firmware **1.0.11**.
 Line-based ASCII, commands terminated with `\n`, case-insensitive. Every reply is
 either a value line followed by an `OK` line, a bare `OK` line, or `ERROR`:
 
-```
+```text
 <value>\r\n
 OK\r\n
 ```
 
-| Command | Meaning | Example reply |
-|---------|---------|---------------|
+The **Example value line** column below shows only the `<value>` line; per the
+framing above it is always followed by a trailing `OK\r\n` (the driver validates
+that). `S` is the exception — it has no value line and replies with a bare `OK`.
+
+| Command | Meaning | Example value line |
+|---------|---------|--------------------|
 | `V`       | firmware version string             | `RFPowerMeterv2 1.0.11` |
 | `D`       | current **average** power (dBm)      | `-26.450439` |
 | `E`       | current **peak** power (dBm)         | `-25.9596` |
 | `F`       | query the **stored** frequency (MHz) | `35` |
 | `F<idx>`  | set the active calibration curve by index; echoes the new MHz | `900` |
-| `S`       | persist current settings (updates the LCD + stored config) | `OK` only |
+| `S`       | persist current settings (updates the LCD + stored config) | *(none; bare `OK`)* |
 
 The driver validates the trailing `OK` after every value reply; anything else is
 treated as a desynced stream and raised, rather than returning an unconfirmed
@@ -55,7 +59,7 @@ value that would let the next command read garbage.
 
 `F<idx>` selects one of 16 stored per-frequency calibration curves (0-based):
 
-```
+```text
 index:  0    1    2     3     4     5      6      7 ...                              15
 MHz:   35    72   433   868   900   1200   2400   5600 5650 5700 5750 5800 5850 5900 5950 6000
 ```

--- a/docs/power-meter.md
+++ b/docs/power-meter.md
@@ -111,11 +111,12 @@ about regions; it speaks MHz only.
 - **TX linger tuning:** each broadcast holds the node's port open `tx_linger_s`
   after the send so the firmware's ~4 s broadcast politeness delay and the
   packet's airtime complete before the close-triggered DTR reset drops the queued
-  TX. `pa_sweep` sets this explicitly (default 6 s) rather than inheriting
-  `send_text`'s conservative 8 s interactive default — it is paid per burst per
-  step, so it dominates sweep wall-clock. Raise it for slow presets (LONG_SLOW
-  and friends have multi-second airtime a 6 s linger would clip); lower it only
-  when you know the airtime is short.
+  TX. It is paid per burst per step, so it dominates sweep wall-clock. `pa_sweep`
+  leaves `tx_linger_s=None` by default and **auto-derives** it from the node's
+  live preset time-on-air (Semtech AN1200.13, `lora_time_on_air_s`): politeness +
+  airtime + margin. A fast preset (LONG_FAST ~200 B ≈ 2 s airtime) gets ~7 s;
+  LONG_SLOW (~12 s airtime) gets ~18 s — no clipping and no manual tuning. Pass a
+  number to override; the value used is echoed as `tx_linger_s` in the result.
 
 Every reading is an uncalibrated bench regression check (±0.5 dB instrument plus a
 hand-entered attenuator value), not a substitute for certified EMC-lab compliance

--- a/src/meshtastic_mcp/capabilities.py
+++ b/src/meshtastic_mcp/capabilities.py
@@ -93,6 +93,20 @@ def has_llama_server() -> bool:
     return llama_server.available()
 
 
+def has_power_meter() -> bool:
+    """True when an ImmersionRC RF Power Meter v2 is attached (VID 0x04D8/PID 0x000A).
+
+    Gates the PA-calibration bench tools (`pa_meter_status`, `pa_measure`,
+    `pa_sweep`): absolute TX-power measurement off a node's PA. Needs no extra
+    (the driver is pure `pyserial`, already a core dep) — only the meter plugged
+    in and powered on. It auto-powers-off on a battery timeout and vanishes from
+    USB, so a meter that was off at server startup won't light up the capability.
+    """
+    from . import power_meter
+
+    return len(power_meter.list_meters()) > 0
+
+
 def has_tak() -> bool:
     """True when the meshtastic-tak SDK is importable (the ``[tak]`` extra).
 
@@ -126,6 +140,7 @@ class Capabilities:
     local_model: bool
     llama_server: bool
     sdr: bool
+    power_meter: bool
     tak: bool
     sdk_cli: bool
 
@@ -140,6 +155,7 @@ class Capabilities:
                 ("local_model", self.local_model),
                 ("llama_server", self.llama_server),
                 ("sdr", self.sdr),
+                ("power_meter", self.power_meter),
                 ("tak", self.tak),
                 ("sdk_cli", self.sdk_cli),
             )
@@ -157,6 +173,7 @@ def detect() -> Capabilities:
         local_model=has_local_model(),
         llama_server=has_llama_server(),
         sdr=has_sdr(),
+        power_meter=has_power_meter(),
         tak=has_tak(),
         sdk_cli=has_sdk_cli(),
     )

--- a/src/meshtastic_mcp/capabilities.py
+++ b/src/meshtastic_mcp/capabilities.py
@@ -96,11 +96,14 @@ def has_llama_server() -> bool:
 def has_power_meter() -> bool:
     """True when an ImmersionRC RF Power Meter v2 is attached (VID 0x04D8/PID 0x000A).
 
-    Gates the PA-calibration bench tools (`pa_meter_status`, `pa_measure`,
-    `pa_sweep`): absolute TX-power measurement off a node's PA. Needs no extra
-    (the driver is pure `pyserial`, already a core dep) — only the meter plugged
-    in and powered on. It auto-powers-off on a battery timeout and vanishes from
-    USB, so a meter that was off at server startup won't light up the capability.
+    Informational only — reported by `doctor` and the startup summary. Unlike the
+    other capabilities this does NOT gate tool registration: the PA-calibration
+    bench tools (`pa_meter_status`, `pa_measure`, `pa_sweep`) are always
+    registered, because the meter auto-powers-off on a battery timeout and drops
+    off USB, so a startup-time probe would hide exactly the tool
+    (`pa_meter_status`) you reach for to check whether it's asleep. The tools
+    return a clear "no meter" result/error instead. Needs no extra — the driver
+    is pure `pyserial`, already a core dep.
     """
     from . import power_meter
 

--- a/src/meshtastic_mcp/doctor.py
+++ b/src/meshtastic_mcp/doctor.py
@@ -241,6 +241,38 @@ def _sdr_check() -> Check:
     )
 
 
+def _power_meter_check() -> Check:
+    """PA-calibration bench (`pa_meter_status`/`pa_measure`/`pa_sweep`): needs an
+    ImmersionRC RF Power Meter v2 (USB CDC, VID 0x04D8/PID 0x000A) attached and
+    powered on. No pip extra — the driver is pure `pyserial` (a core dep).
+    """
+    from . import power_meter
+
+    needed = "PA-calibration bench (pa_meter_status / pa_measure / pa_sweep)"
+    meters = power_meter.list_meters()
+    if meters:
+        return Check(
+            "rf-power-meter",
+            "power_meter",
+            STATUS_OK,
+            needed,
+            detail=f"{len(meters)} meter(s): {', '.join(meters)}",
+        )
+    return Check(
+        "rf-power-meter",
+        "power_meter",
+        STATUS_MISSING,
+        needed,
+        detail="no ImmersionRC meter (VID 0x04D8/PID 0x000A) found",
+        fix=_pkg(
+            "plug in an ImmersionRC RF Power Meter v2 and power it on "
+            "(it auto-powers-off on a battery timeout and drops off USB)",
+            "plug in an ImmersionRC RF Power Meter v2 and power it on; on Linux you may "
+            "need dialout-group / udev access to the CDC port",
+        ),
+    )
+
+
 def _tak_check() -> Check:
     """TAKPacketV2 wire compression (replay sim `profile tak.wire="v2"`): needs the
     meshtastic-tak SDK (the `tak` extra). Optional — the sim emits legacy
@@ -704,6 +736,8 @@ def run() -> DoctorReport:
         _gh_auth_check(),
         # sdr capability (RF compliance oracle)
         _sdr_check(),
+        # power_meter capability (ImmersionRC PA-calibration bench)
+        _power_meter_check(),
         # tak capability (TAKPacketV2 wire compression for the replay sim)
         _tak_check(),
         # sdk capability (experimental Kotlin-SDK device-IO bridge)

--- a/src/meshtastic_mcp/pa_sweep.py
+++ b/src/meshtastic_mcp/pa_sweep.py
@@ -37,7 +37,7 @@ import time
 from dataclasses import dataclass, field
 from typing import Any
 
-from . import admin, power_meter
+from . import admin, lora_compliance, power_meter
 from .rf_oracle import read_lora_context
 
 
@@ -48,6 +48,30 @@ class PaSweepError(RuntimeError):
 # A ~200 B text broadcast is near the Meshtastic payload ceiling and gives the
 # longest single-packet airtime; repeating it sustains the meter's view of the PA.
 _BURST_TEXT = "PA-SWEEP " + "x" * 190
+
+
+def resolve_band_mhz(band: str) -> float:
+    """Resolve a band to a frequency in MHz for the meter.
+
+    Accepts either a Meshtastic **region enum name** (``"US"``, ``"EU_868"``,
+    ``"EU_433"``, ``"JP"`` ...) — resolved to the centre of that region's
+    allocation via `lora_compliance.REGIONS`, the same table firmware derives its
+    channels from — or a bare MHz value (``"868"``, ``"915"``). Region names are
+    what `rf_oracle.read_lora_context` reports, so `sweep(band=None)` feeds one
+    straight through here. The meter has no continuous tuning, so whatever this
+    returns is snapped to the nearest stored calibration point by the driver.
+    """
+    key = band.strip().upper()
+    info = lora_compliance.REGIONS.get(key)
+    if info is not None:
+        return (info.freq_start_mhz + info.freq_end_mhz) / 2.0
+    try:
+        return float(band)
+    except ValueError as exc:
+        raise PaSweepError(
+            f"Unknown band {band!r}: pass a MHz value or a Meshtastic region name "
+            f"(e.g. US, EU_868, EU_433, JP, ANZ)."
+        ) from exc
 
 
 # ---------------------------------------------------------------------------
@@ -116,6 +140,13 @@ def _step_row(s: StepResult) -> dict[str, Any]:
     }
 
 
+def _avg(s: StepResult) -> float:
+    """The measured average, asserted non-None (callers filter to measured steps)."""
+    v = s.measured_avg_dbm
+    assert v is not None
+    return v
+
+
 def analyze_curve(steps: list[StepResult], *, compression_ratio: float = 0.5) -> dict[str, Any]:
     """Characterize the PA gain curve from the per-step measurements.
 
@@ -144,22 +175,20 @@ def analyze_curve(steps: list[StepResult], *, compression_ratio: float = 0.5) ->
     monotonic = True
     for prev, cur in itertools.pairwise(usable):
         d_cfg = cur.configured_dbm - prev.configured_dbm
-        assert cur.measured_avg_dbm is not None and prev.measured_avg_dbm is not None
-        d_meas = cur.measured_avg_dbm - prev.measured_avg_dbm
+        d_meas = _avg(cur) - _avg(prev)
         if d_meas < -0.5:
             monotonic = False
         if saturation_dbm is None and d_cfg > 0 and (d_meas / d_cfg) < compression_ratio:
             saturation_dbm = prev.configured_dbm
 
     lowest = usable[0]
-    highest = max(usable, key=lambda s: s.measured_avg_dbm)  # type: ignore[arg-type,return-value]
-    assert lowest.measured_avg_dbm is not None and highest.measured_avg_dbm is not None
+    highest = max(usable, key=_avg)
     return {
         "points": len(usable),
         "saturation_dbm": saturation_dbm,
-        "max_measured_dbm": round(highest.measured_avg_dbm, 2),
+        "max_measured_dbm": round(_avg(highest), 2),
         "max_measured_at_configured_dbm": highest.configured_dbm,
-        "offset_at_min_db": round(lowest.measured_avg_dbm - lowest.configured_dbm, 2),
+        "offset_at_min_db": round(_avg(lowest) - lowest.configured_dbm, 2),
         "monotonic": monotonic,
     }
 
@@ -218,19 +247,26 @@ def measure(
     """One-shot passive read of whatever the meter currently sees at `band`.
 
     No Meshtastic device involved — activates the band's calibration curve, takes
-    `samples` readings, and returns min/mean/max (attenuator-corrected). Use it to
-    read the noise floor, sanity-check a signal generator, or spot-check a TX that
-    something else is keying.
+    `samples` readings, and returns min/mean/max in dBm. `band` is a Meshtastic
+    region name (``"US"``, ``"EU_868"`` ...) or a bare MHz value (see
+    `resolve_band_mhz`). Use it to read the noise floor, sanity-check a signal
+    generator, or spot-check a TX that something else is keying.
+
+    `attenuator_db` is added to every reading (the pad sits between the source and
+    the meter). That's what you want for a signal, but note it also inflates a
+    noise-floor read by the pad value — pass ``attenuator_db=0`` if you want the
+    meter's raw floor rather than the floor referred to the pad's input.
     """
-    freq_mhz = power_meter.band_to_freq_mhz(band)
+    center_mhz = resolve_band_mhz(band)
     with power_meter.PowerMeter(meter_port) as m:
         m.version()  # fail fast if it's not actually an ImmersionRC meter
-        m.set_freq_mhz(freq_mhz, persist=persist_freq)
+        cal_mhz = m.set_freq_mhz(center_mhz, persist=persist_freq)
         readings = m.sample(samples, interval_s=interval_s, peak=peak)
     corrected = [r + attenuator_db for r in readings]
     return {
         "band": band,
-        "freq_mhz": freq_mhz,
+        "requested_center_mhz": round(center_mhz, 3),
+        "meter_cal_mhz": cal_mhz,
         "kind": "peak" if peak else "average",
         "attenuator_db": attenuator_db,
         "samples": len(corrected),
@@ -267,7 +303,14 @@ def status(meter_port: str | None = None) -> dict[str, Any]:
 
 
 def _key_burst(text: str, channel_index: int, port: str | None, repeat: int, gap_s: float) -> int:
-    """Queue `repeat` broadcast bursts to sustain TX airtime; return packets queued."""
+    """Queue `repeat` broadcast bursts to sustain TX airtime; return packets queued.
+
+    Note: once `send_text` gains a `tx_linger_s` (holds the port open past a
+    broadcast so firmware's channel-politeness delay doesn't drop the queued TX),
+    pass an explicit value here tuned to the burst timing rather than inheriting
+    the send-a-message default, which would add several seconds of linger per
+    burst and stretch a multi-step sweep considerably.
+    """
     queued = 0
     for i in range(repeat):
         admin.send_text(text=text, channel_index=channel_index, port=port)
@@ -275,6 +318,37 @@ def _key_burst(text: str, channel_index: int, port: str | None, repeat: int, gap
         if i + 1 < repeat:
             time.sleep(gap_s)
     return queued
+
+
+def _restore_config(
+    path: str,
+    value: object,
+    port: str | None,
+    errors: list[str],
+    *,
+    attempts: int = 3,
+    backoff_s: float = 0.5,
+) -> None:
+    """Best-effort restore of one config field, retrying the busy case.
+
+    Each restore opens the node's serial port, and per the "one MCP call per
+    serial port" rule that acquisition is non-blocking and fails fast with a
+    *busy* error. Restoring `override_duty_cycle` in particular has regulatory
+    consequences if it's left on, so we retry the busy case a few times and, on
+    final failure, record it in `errors` instead of raising — so one field's
+    failure never skips the next field's restore, and the caller can surface what
+    didn't come back rather than leaving it silently wrong.
+    """
+    for i in range(attempts):
+        try:
+            admin.set_config(path, value, port=port)
+            return
+        except Exception as exc:
+            if "busy" in str(exc).lower() and i + 1 < attempts:
+                time.sleep(backoff_s)
+                continue
+            errors.append(f"{path}: {exc}")
+            return
 
 
 def sweep(
@@ -303,15 +377,17 @@ def sweep(
     the mesh, and (optionally) reboots the node between steps. Requires
     ``confirm=True``.
 
-    `band` defaults to the node's configured region (read live). `attenuator_db`
-    is the pad between the PA and the meter (added back in software). The result
-    is a table of configured vs measured dBm plus `analyze_curve`'s
-    saturation/gain summary.
+    `band` defaults to the node's configured region (read live) — a Meshtastic
+    region name like ``"US"`` or ``"EU_868"``, resolved to a frequency via
+    `resolve_band_mhz`. `attenuator_db` is the pad between the PA and the meter
+    (added back in software). The result is a table of configured vs measured dBm
+    plus `analyze_curve`'s saturation/gain summary.
 
     Safety: refuses any step whose *expected* meter input (configured power minus
     attenuator) would exceed the meter's absolute max — protect the instrument
     with an adequate pad. Restores the original `tx_power` and duty-cycle override
-    on exit unless ``restore_config=False``.
+    on exit unless ``restore_config=False``; each restore is independent and its
+    failure is surfaced in ``restore_errors`` rather than silently swallowed.
     """
     if not confirm:
         raise PaSweepError(
@@ -325,7 +401,7 @@ def sweep(
     region = ctx.get("region", "UNSET")
     if band is None:
         band = region
-    freq_mhz = power_meter.band_to_freq_mhz(band)
+    center_mhz = resolve_band_mhz(band)
 
     # Protect the meter: the pad must knock the highest configured step below the
     # meter's absolute max. (Approximate — ignores PA gain error, which is what
@@ -338,14 +414,17 @@ def sweep(
             "absolute max. Add more attenuation before sweeping."
         )
 
+    # 0 is firmware's "use the region's default power" sentinel, not literally
+    # 0 dBm — restoring it hands the node back to its default, which is correct.
     original_tx_power = ctx.get("tx_power", 0)
     original_duty_override = bool(ctx.get("override_duty_cycle", False))
     duty_override_touched = False
+    restore_errors: list[str] = []
     steps: list[StepResult] = []
 
     with power_meter.PowerMeter(meter_port) as m:
         m.version()
-        m.set_freq_mhz(freq_mhz)
+        cal_mhz = m.set_freq_mhz(center_mhz)
 
         # Floor: no TX in flight, so read the meter directly (no sampler thread).
         floor_readings = m.sample(floor_samples, interval_s=sample_interval_s)
@@ -384,10 +463,15 @@ def sweep(
                     )
                 )
         finally:
+            # Restore each field independently: a busy/transient failure on one
+            # must not skip the next (leaving override_duty_cycle stuck on is the
+            # regulatory hazard). Failures land in restore_errors, reported below.
             if restore_config:
-                admin.set_config("lora.tx_power", int(original_tx_power), port=port)
+                _restore_config("lora.tx_power", int(original_tx_power), port, restore_errors)
                 if duty_override_touched:
-                    admin.set_config("lora.override_duty_cycle", original_duty_override, port=port)
+                    _restore_config(
+                        "lora.override_duty_cycle", original_duty_override, port, restore_errors
+                    )
 
     table = [_step_row(s) for s in steps]
     silent_steps = [s.configured_dbm for s in steps if not s.rf_observed]
@@ -395,7 +479,8 @@ def sweep(
     return {
         "band": band,
         "region": region,
-        "freq_mhz": freq_mhz,
+        "requested_center_mhz": round(center_mhz, 3),
+        "meter_cal_mhz": cal_mhz,
         "attenuator_db": attenuator_db,
         "floor_dbm": round(floor_dbm, 2),
         "floor_margin_db": floor_margin_db,
@@ -403,6 +488,7 @@ def sweep(
         "curve": analyze_curve(steps),
         "silent_steps_dbm": silent_steps,
         "config_restored": restore_config,
+        "restore_errors": restore_errors,
         "caveat": (
             "Bench regression check: ImmersionRC meter (~±0.5 dB) with a hand-entered "
             "attenuator value; not a calibrated/certified measurement. Steps with no TX-active "

--- a/src/meshtastic_mcp/pa_sweep.py
+++ b/src/meshtastic_mcp/pa_sweep.py
@@ -1,0 +1,409 @@
+# SPDX-FileCopyrightText: Meshtastic contributors
+# SPDX-License-Identifier: GPL-3.0-only
+
+"""Closed-loop PA calibration: step a Meshtastic node's configured `lora.tx_power`
+and measure the actual power off its PA with an ImmersionRC meter (`power_meter.py`),
+producing a configured-vs-measured table and a compression/saturation analysis.
+
+This answers the question neither the SDR oracle nor the firmware can: *does the
+radio actually emit the power it's told to, and where does the PA stop tracking?*
+`rf_oracle.confirm_tx` tells you whether RF left the antenna at the right
+frequency; this tells you **how much** power, in absolute dBm, at each configured
+step — the PA gain curve and its saturation point.
+
+Flow per step (`sweep`):
+  1. set `lora.tx_power` on the node (optionally reboot for pre-2.8.0 firmware
+     that doesn't apply LoRa config live),
+  2. key a multi-second TX burst (queued ~200 B broadcasts — an idle node rarely
+     transmits, and EU868 duty-cycle limits are overridden for the bench run),
+  3. sample the meter's average power throughout the burst and keep only samples
+     that clear the pre-captured noise floor (TX-active discrimination),
+  4. correct for the external attenuator (in software — the meter never sees it)
+     and record configured vs measured.
+
+The pure functions (`classify_active`, `summarize_step`, `analyze_curve`) contain
+all the measurement logic and are unit-tested without hardware
+(`tests/unit/test_power_meter.py`). Everything is a bench regression check with a
+~±0.5 dB instrument and a hand-entered attenuator value — not a certified
+measurement (see `power_meter.py`).
+"""
+
+from __future__ import annotations
+
+import itertools
+import statistics
+import threading
+import time
+from dataclasses import dataclass, field
+from typing import Any
+
+from . import admin, power_meter
+from .rf_oracle import read_lora_context
+
+
+class PaSweepError(RuntimeError):
+    pass
+
+
+# A ~200 B text broadcast is near the Meshtastic payload ceiling and gives the
+# longest single-packet airtime; repeating it sustains the meter's view of the PA.
+_BURST_TEXT = "PA-SWEEP " + "x" * 190
+
+
+# ---------------------------------------------------------------------------
+# Pure measurement logic — no hardware, fully unit-testable.
+# ---------------------------------------------------------------------------
+def classify_active(
+    samples: list[float], floor_dbm: float, *, margin_db: float = 5.0
+) -> list[float]:
+    """Keep only samples that clear the noise floor by `margin_db` — i.e. the
+    ones taken while the PA was actually transmitting.
+
+    The meter's log-detector floor sits around -25 dBm even with no input, so a
+    plain max/mean over a capture window blurs TX bursts together with idle
+    time. Thresholding at ``floor + margin`` isolates the TX-active samples the
+    same way `sdr.active_windows` isolates active time segments.
+    """
+    threshold = floor_dbm + margin_db
+    return [s for s in samples if s >= threshold]
+
+
+@dataclass(frozen=True)
+class StepResult:
+    configured_dbm: int
+    measured_avg_dbm: float | None  # None when no TX-active sample was captured
+    measured_peak_dbm: float | None
+    active_samples: int
+    total_samples: int
+
+    @property
+    def rf_observed(self) -> bool:
+        return self.measured_avg_dbm is not None
+
+
+def summarize_step(
+    samples: list[float],
+    configured_dbm: int,
+    floor_dbm: float,
+    *,
+    attenuator_db: float = 0.0,
+    margin_db: float = 5.0,
+) -> StepResult:
+    """Reduce one step's raw meter samples to a `StepResult`, applying the
+    attenuator correction (added back in software — the pad sits between the PA
+    and the meter, so true power = meter reading + attenuator_db).
+    """
+    active = classify_active(samples, floor_dbm, margin_db=margin_db)
+    if not active:
+        return StepResult(configured_dbm, None, None, 0, len(samples))
+    avg = statistics.fmean(active) + attenuator_db
+    peak = max(active) + attenuator_db
+    return StepResult(configured_dbm, avg, peak, len(active), len(samples))
+
+
+def _step_row(s: StepResult) -> dict[str, Any]:
+    """One `sweep` table row — measured fields are None when the step was silent."""
+    avg, peak = s.measured_avg_dbm, s.measured_peak_dbm
+    observed = avg is not None and peak is not None
+    return {
+        "configured_dbm": s.configured_dbm,
+        "measured_avg_dbm": round(avg, 2) if avg is not None else None,
+        "measured_peak_dbm": round(peak, 2) if peak is not None else None,
+        "delta_db": round(avg - s.configured_dbm, 2) if avg is not None else None,
+        "active_samples": s.active_samples,
+        "total_samples": s.total_samples,
+        "rf_observed": observed,
+    }
+
+
+def analyze_curve(steps: list[StepResult], *, compression_ratio: float = 0.5) -> dict[str, Any]:
+    """Characterize the PA gain curve from the per-step measurements.
+
+    Reports where the PA stops tracking the configured setting: the
+    **saturation point** is the first configured step whose incremental measured
+    gain per +1 dB configured falls below `compression_ratio` (a linear PA tracks
+    ~1.0; a saturated one flattens toward 0). Also reports the offset at the
+    lowest step (measured − configured — the PA/system gain error after
+    attenuator correction), peak measured power, and whether the curve is
+    monotonic.
+    """
+    usable = [s for s in steps if s.measured_avg_dbm is not None]
+    if len(usable) < 2:
+        first = usable[0].measured_avg_dbm if usable else None
+        return {
+            "points": len(usable),
+            "saturation_dbm": None,
+            "max_measured_dbm": first,
+            "offset_at_min_db": (first - usable[0].configured_dbm if first is not None else None),
+            "monotonic": True,
+            "note": "need >=2 measured steps for a curve",
+        }
+
+    usable.sort(key=lambda s: s.configured_dbm)
+    saturation_dbm: int | None = None
+    monotonic = True
+    for prev, cur in itertools.pairwise(usable):
+        d_cfg = cur.configured_dbm - prev.configured_dbm
+        assert cur.measured_avg_dbm is not None and prev.measured_avg_dbm is not None
+        d_meas = cur.measured_avg_dbm - prev.measured_avg_dbm
+        if d_meas < -0.5:
+            monotonic = False
+        if saturation_dbm is None and d_cfg > 0 and (d_meas / d_cfg) < compression_ratio:
+            saturation_dbm = prev.configured_dbm
+
+    lowest = usable[0]
+    highest = max(usable, key=lambda s: s.measured_avg_dbm)  # type: ignore[arg-type,return-value]
+    assert lowest.measured_avg_dbm is not None and highest.measured_avg_dbm is not None
+    return {
+        "points": len(usable),
+        "saturation_dbm": saturation_dbm,
+        "max_measured_dbm": round(highest.measured_avg_dbm, 2),
+        "max_measured_at_configured_dbm": highest.configured_dbm,
+        "offset_at_min_db": round(lowest.measured_avg_dbm - lowest.configured_dbm, 2),
+        "monotonic": monotonic,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Hardware orchestration.
+# ---------------------------------------------------------------------------
+@dataclass
+class _BackgroundSampler:
+    """Continuously reads the meter's average power in a thread until stopped.
+
+    Only this thread touches the meter's serial port during a burst; the main
+    thread drives the Meshtastic node (a *different* port), so there's no
+    contention — but never sample the same meter from two threads at once.
+    """
+
+    meter: power_meter.PowerMeter
+    interval_s: float = 0.05
+    _samples: list[float] = field(default_factory=list)
+    _stop: threading.Event = field(default_factory=threading.Event)
+    _thread: threading.Thread | None = None
+    _error: str | None = None
+
+    def _run(self) -> None:
+        while not self._stop.is_set():
+            try:
+                self._samples.append(self.meter.read_avg_dbm())
+            except power_meter.PowerMeterError as exc:
+                self._error = str(exc)
+                return
+            self._stop.wait(self.interval_s)
+
+    def start(self) -> None:
+        self._thread = threading.Thread(target=self._run, daemon=True)
+        self._thread.start()
+
+    def stop(self) -> list[float]:
+        self._stop.set()
+        if self._thread is not None:
+            self._thread.join(timeout=5.0)
+        if self._error is not None:
+            raise PaSweepError(f"meter sampling failed mid-burst: {self._error}")
+        return list(self._samples)
+
+
+def measure(
+    band: str,
+    *,
+    samples: int = 20,
+    interval_s: float = 0.05,
+    attenuator_db: float = 0.0,
+    meter_port: str | None = None,
+    peak: bool = False,
+    persist_freq: bool = False,
+) -> dict[str, Any]:
+    """One-shot passive read of whatever the meter currently sees at `band`.
+
+    No Meshtastic device involved — activates the band's calibration curve, takes
+    `samples` readings, and returns min/mean/max (attenuator-corrected). Use it to
+    read the noise floor, sanity-check a signal generator, or spot-check a TX that
+    something else is keying.
+    """
+    freq_mhz = power_meter.band_to_freq_mhz(band)
+    with power_meter.PowerMeter(meter_port) as m:
+        m.version()  # fail fast if it's not actually an ImmersionRC meter
+        m.set_freq_mhz(freq_mhz, persist=persist_freq)
+        readings = m.sample(samples, interval_s=interval_s, peak=peak)
+    corrected = [r + attenuator_db for r in readings]
+    return {
+        "band": band,
+        "freq_mhz": freq_mhz,
+        "kind": "peak" if peak else "average",
+        "attenuator_db": attenuator_db,
+        "samples": len(corrected),
+        "min_dbm": round(min(corrected), 2),
+        "mean_dbm": round(statistics.fmean(corrected), 2),
+        "max_dbm": round(max(corrected), 2),
+    }
+
+
+def status(meter_port: str | None = None) -> dict[str, Any]:
+    """Detect the meter and report version, stored frequency, and a live reading.
+
+    Read-only probe — the bench equivalent of `recorder_status`. Returns
+    ``{"present": False}`` (never raises) when no meter is attached.
+    """
+    port = meter_port or power_meter.find_meter_port()
+    if port is None:
+        return {"present": False, "detail": "no ImmersionRC meter (VID 0x04D8/PID 0x000A) attached"}
+    try:
+        with power_meter.PowerMeter(port) as m:
+            info = m.info()
+            avg = m.read_avg_dbm()
+            peak = m.read_peak_dbm()
+    except power_meter.PowerMeterError as exc:
+        return {"present": True, "port": port, "error": str(exc)}
+    return {
+        "present": True,
+        "port": info.port,
+        "version": info.version,
+        "stored_freq_mhz": info.stored_freq_mhz,
+        "current_avg_dbm": round(avg, 2),
+        "current_peak_dbm": round(peak, 2),
+    }
+
+
+def _key_burst(text: str, channel_index: int, port: str | None, repeat: int, gap_s: float) -> int:
+    """Queue `repeat` broadcast bursts to sustain TX airtime; return packets queued."""
+    queued = 0
+    for i in range(repeat):
+        admin.send_text(text=text, channel_index=channel_index, port=port)
+        queued += 1
+        if i + 1 < repeat:
+            time.sleep(gap_s)
+    return queued
+
+
+def sweep(
+    powers: list[int],
+    band: str | None = None,
+    *,
+    port: str | None = None,
+    meter_port: str | None = None,
+    channel_index: int = 0,
+    attenuator_db: float = 0.0,
+    burst_repeat: int = 3,
+    burst_gap_s: float = 0.3,
+    settle_s: float = 1.5,
+    floor_samples: int = 20,
+    floor_margin_db: float = 5.0,
+    sample_interval_s: float = 0.05,
+    reboot_between_steps: bool = False,
+    reboot_wait_s: float = 20.0,
+    override_duty_cycle: bool = True,
+    restore_config: bool = True,
+    confirm: bool = False,
+) -> dict[str, Any]:
+    """Step `lora.tx_power` through `powers` and measure the PA output at each.
+
+    Destructive/closed-loop: mutates the node's LoRa config, keys real TX onto
+    the mesh, and (optionally) reboots the node between steps. Requires
+    ``confirm=True``.
+
+    `band` defaults to the node's configured region (read live). `attenuator_db`
+    is the pad between the PA and the meter (added back in software). The result
+    is a table of configured vs measured dBm plus `analyze_curve`'s
+    saturation/gain summary.
+
+    Safety: refuses any step whose *expected* meter input (configured power minus
+    attenuator) would exceed the meter's absolute max — protect the instrument
+    with an adequate pad. Restores the original `tx_power` and duty-cycle override
+    on exit unless ``restore_config=False``.
+    """
+    if not confirm:
+        raise PaSweepError(
+            "pa_sweep mutates lora.tx_power, keys TX onto the mesh, and may reboot the "
+            "node — pass confirm=True to proceed."
+        )
+    if not powers:
+        raise PaSweepError("powers list is empty")
+
+    ctx = read_lora_context(port=port)
+    region = ctx.get("region", "UNSET")
+    if band is None:
+        band = region
+    freq_mhz = power_meter.band_to_freq_mhz(band)
+
+    # Protect the meter: the pad must knock the highest configured step below the
+    # meter's absolute max. (Approximate — ignores PA gain error, which is what
+    # we're measuring — so this is a floor, not a guarantee. Use a generous pad.)
+    max_expected_input = max(powers) - attenuator_db
+    if max_expected_input > power_meter.METER_ABS_MAX_DBM:
+        raise PaSweepError(
+            f"max configured {max(powers)} dBm minus {attenuator_db} dB pad = "
+            f"{max_expected_input:.1f} dBm exceeds the meter's {power_meter.METER_ABS_MAX_DBM} dBm "
+            "absolute max. Add more attenuation before sweeping."
+        )
+
+    original_tx_power = ctx.get("tx_power", 0)
+    duty_override_touched = False
+    steps: list[StepResult] = []
+
+    with power_meter.PowerMeter(meter_port) as m:
+        m.version()
+        m.set_freq_mhz(freq_mhz)
+
+        # Floor: no TX in flight, so read the meter directly (no sampler thread).
+        floor_readings = m.sample(floor_samples, interval_s=sample_interval_s)
+        floor_dbm = statistics.median(floor_readings)
+
+        if override_duty_cycle:
+            admin.set_config("lora.override_duty_cycle", True, port=port)
+            duty_override_touched = True
+
+        try:
+            for p in powers:
+                admin.set_config("lora.tx_power", int(p), port=port)
+                if reboot_between_steps:
+                    admin.reboot(port=port, confirm=True)
+                    time.sleep(reboot_wait_s)
+                else:
+                    time.sleep(settle_s)
+
+                sampler = _BackgroundSampler(m, interval_s=sample_interval_s)
+                sampler.start()
+                _key_burst(_BURST_TEXT, channel_index, port, burst_repeat, burst_gap_s)
+                # Let the queued bursts drain onto the air before we stop watching.
+                time.sleep(settle_s)
+                raw = sampler.stop()
+
+                steps.append(
+                    summarize_step(
+                        raw,
+                        int(p),
+                        floor_dbm,
+                        attenuator_db=attenuator_db,
+                        margin_db=floor_margin_db,
+                    )
+                )
+        finally:
+            if restore_config:
+                admin.set_config("lora.tx_power", int(original_tx_power), port=port)
+                if duty_override_touched:
+                    admin.set_config("lora.override_duty_cycle", False, port=port)
+
+    table = [_step_row(s) for s in steps]
+    silent_steps = [s.configured_dbm for s in steps if not s.rf_observed]
+
+    return {
+        "band": band,
+        "region": region,
+        "freq_mhz": freq_mhz,
+        "attenuator_db": attenuator_db,
+        "floor_dbm": round(floor_dbm, 2),
+        "floor_margin_db": floor_margin_db,
+        "table": table,
+        "curve": analyze_curve(steps),
+        "silent_steps_dbm": silent_steps,
+        "config_restored": restore_config,
+        "caveat": (
+            "Bench regression check: ImmersionRC meter (~±0.5 dB) with a hand-entered "
+            "attenuator value; not a calibrated/certified measurement. Steps with no TX-active "
+            "sample (silent_steps_dbm) may be a dead PA, but under airtime pressure a queued "
+            "packet can also transmit after the sampling window closes — re-run spaced out "
+            "before concluding a step is truly silent."
+        ),
+    }

--- a/src/meshtastic_mcp/pa_sweep.py
+++ b/src/meshtastic_mcp/pa_sweep.py
@@ -31,6 +31,7 @@ measurement (see `power_meter.py`).
 from __future__ import annotations
 
 import itertools
+import math
 import statistics
 import threading
 import time
@@ -48,6 +49,84 @@ class PaSweepError(RuntimeError):
 # A ~200 B text broadcast is near the Meshtastic payload ceiling and gives the
 # longest single-packet airtime; repeating it sustains the meter's view of the PA.
 _BURST_TEXT = "PA-SWEEP " + "x" * 190
+
+# Bytes the firmware adds around the text before it goes on air: the MeshPacket
+# header (~16 B) plus the Data submessage / encryption framing. Slightly generous
+# on purpose — over-estimating airtime lengthens the linger, which is the safe
+# direction (a short linger clips the TX; a long one only costs time).
+_MESH_PACKET_OVERHEAD_BYTES = 32
+
+# Firmware's channel-politeness delay before it keys a broadcast (send_text.py
+# documents ~4 s), plus a margin. The linger must cover this delay *plus* the
+# packet's airtime, since send_text returns as soon as the packet is queued.
+_TX_POLITENESS_S = 4.0
+_TX_LINGER_MARGIN_S = 1.0
+# Used only if the live preset can't be predicted (unknown region / malformed
+# ctx) — sizing the linger must never crash a sweep.
+_FALLBACK_TX_LINGER_S = 8.0
+
+
+def lora_time_on_air_s(
+    payload_bytes: int,
+    sf: int,
+    bw_khz: float,
+    cr: int,
+    *,
+    preamble_symbols: int = 16,
+    explicit_header: bool = True,
+    crc: bool = True,
+) -> float:
+    """LoRa time-on-air (seconds) via the Semtech AN1200.13 formula.
+
+    `cr` is the Meshtastic coding-rate denominator (5..8 for 4/5..4/8).
+    `preamble_symbols` defaults to 16 (Meshtastic's setting). Low-data-rate
+    optimization is applied automatically when the symbol time exceeds 16 ms
+    (SF11/125 kHz and SF12), matching firmware. Used to size the sweep's TX
+    linger so a burst isn't cut off before it finishes transmitting.
+    """
+    bw_hz = bw_khz * 1000.0
+    t_sym = (2**sf) / bw_hz
+    low_data_rate_opt = 1 if t_sym > 16e-3 else 0
+    header = 0 if explicit_header else 1
+    crc_on = 1 if crc else 0
+    cr_val = cr - 4  # 5..8 (4/5..4/8) -> 1..4
+    numerator = 8 * payload_bytes - 4 * sf + 28 + 16 * crc_on - 20 * header
+    denominator = 4 * (sf - 2 * low_data_rate_opt)
+    payload_symbols = 8 + max(math.ceil(numerator / denominator) * (cr_val + 4), 0)
+    t_preamble = (preamble_symbols + 4.25) * t_sym
+    t_payload = payload_symbols * t_sym
+    return t_preamble + t_payload
+
+
+def _derive_tx_linger_s(ctx: dict[str, Any]) -> float:
+    """Size the per-burst TX linger from the node's live LoRa preset.
+
+    Predicts SF/BW/CR from `ctx` (same path as `rf_oracle`), computes the burst's
+    time-on-air, and returns politeness delay + airtime + margin — so a fast
+    preset gets a short linger and a slow one (LONG_SLOW: multi-second airtime)
+    gets a long enough linger not to clip. Falls back to a safe constant if the
+    preset can't be predicted; linger sizing must never crash a sweep.
+    """
+    try:
+        pred = lora_compliance.predict_lora_params(
+            ctx["region"],
+            ctx.get("modem_preset", "LONG_FAST"),
+            channel_name=ctx.get("channel_name", ""),
+            channel_num=ctx.get("channel_num", 0),
+            use_preset=ctx.get("use_preset", True),
+            bandwidth_khz=ctx.get("bandwidth"),
+            spread_factor=ctx.get("spread_factor"),
+            coding_rate=ctx.get("coding_rate"),
+            override_frequency_mhz=ctx.get("override_frequency", 0.0),
+            frequency_offset_mhz=ctx.get("frequency_offset", 0.0),
+            device_role=ctx.get("device_role", "CLIENT"),
+        )
+        toa = lora_time_on_air_s(
+            len(_BURST_TEXT) + _MESH_PACKET_OVERHEAD_BYTES, pred.sf, pred.bw_khz, pred.cr
+        )
+        return _TX_POLITENESS_S + toa + _TX_LINGER_MARGIN_S
+    except Exception:
+        return _FALLBACK_TX_LINGER_S
 
 
 def resolve_band_mhz(band: str) -> float:
@@ -372,7 +451,7 @@ def sweep(
     attenuator_db: float = 0.0,
     burst_repeat: int = 3,
     burst_gap_s: float = 0.3,
-    tx_linger_s: float = 6.0,
+    tx_linger_s: float | None = None,
     settle_s: float = 1.5,
     floor_samples: int = 20,
     floor_margin_db: float = 5.0,
@@ -397,12 +476,13 @@ def sweep(
 
     Each step keys `burst_repeat` broadcasts, holding the node's port open
     `tx_linger_s` per send so the firmware's ~4 s broadcast politeness delay plus
-    the packet's airtime finish before close (without it, queued TX is lost). The
-    default (6 s) covers a fast-preset ~200 B packet; raise it for slow presets
-    (LONG_SLOW and friends have multi-second airtime that a 6 s linger would clip)
-    and lower it only if you know the airtime is short. This is paid once per
-    burst per step, so it dominates sweep wall-clock — the meter sampler runs
-    throughout, so it does not need the conservative interactive send default.
+    the packet's airtime finish before close (without it, queued TX is lost).
+    `tx_linger_s=None` (default) **auto-derives** it from the live preset's
+    time-on-air (`_derive_tx_linger_s`): politeness + airtime + margin, so a fast
+    preset gets a short linger and LONG_SLOW (multi-second airtime) gets a long
+    enough one — no clipping, no manual tuning. Pass a number to override. This is
+    paid once per burst per step and dominates sweep wall-clock; the value used is
+    reported as `tx_linger_s` in the result.
 
     Safety: refuses any step whose *expected* meter input (configured power minus
     attenuator) would exceed the meter's absolute max — protect the instrument
@@ -423,6 +503,7 @@ def sweep(
     if band is None:
         band = region
     center_mhz = resolve_band_mhz(band)
+    linger_s = tx_linger_s if tx_linger_s is not None else _derive_tx_linger_s(ctx)
 
     # Protect the meter: the pad must knock the highest configured step below the
     # meter's absolute max. (Approximate — ignores PA gain error, which is what
@@ -469,7 +550,7 @@ def sweep(
 
                 sampler = _BackgroundSampler(m, interval_s=sample_interval_s)
                 sampler.start()
-                _key_burst(_BURST_TEXT, channel_index, port, burst_repeat, burst_gap_s, tx_linger_s)
+                _key_burst(_BURST_TEXT, channel_index, port, burst_repeat, burst_gap_s, linger_s)
                 # Let the queued bursts drain onto the air before we stop watching.
                 time.sleep(settle_s)
                 raw = sampler.stop()
@@ -503,6 +584,7 @@ def sweep(
         "requested_center_mhz": round(center_mhz, 3),
         "meter_cal_mhz": cal_mhz,
         "attenuator_db": attenuator_db,
+        "tx_linger_s": round(linger_s, 2),
         "floor_dbm": round(floor_dbm, 2),
         "floor_margin_db": floor_margin_db,
         "table": table,

--- a/src/meshtastic_mcp/pa_sweep.py
+++ b/src/meshtastic_mcp/pa_sweep.py
@@ -302,18 +302,29 @@ def status(meter_port: str | None = None) -> dict[str, Any]:
     }
 
 
-def _key_burst(text: str, channel_index: int, port: str | None, repeat: int, gap_s: float) -> int:
+def _key_burst(
+    text: str,
+    channel_index: int,
+    port: str | None,
+    repeat: int,
+    gap_s: float,
+    tx_linger_s: float,
+) -> int:
     """Queue `repeat` broadcast bursts to sustain TX airtime; return packets queued.
 
-    Note: once `send_text` gains a `tx_linger_s` (holds the port open past a
-    broadcast so firmware's channel-politeness delay doesn't drop the queued TX),
-    pass an explicit value here tuned to the burst timing rather than inheriting
-    the send-a-message default, which would add several seconds of linger per
-    burst and stretch a multi-step sweep considerably.
+    Each `send_text` holds the node's port open for `tx_linger_s` after the send
+    so the firmware's channel-politeness delay (~4 s for broadcasts) and the
+    packet's airtime finish before the close-triggered DTR reset drops the queued
+    TX. We pass this explicitly rather than inheriting `send_text`'s
+    send-a-message default (8 s): here it's paid `repeat` times per step and the
+    meter sampler is watching throughout, so the sweep tunes it to just cover the
+    politeness delay plus one packet's airtime instead of the conservative
+    interactive default. Slow presets (long airtime) need a higher value — see
+    `sweep`'s `tx_linger_s`.
     """
     queued = 0
     for i in range(repeat):
-        admin.send_text(text=text, channel_index=channel_index, port=port)
+        admin.send_text(text=text, channel_index=channel_index, port=port, tx_linger_s=tx_linger_s)
         queued += 1
         if i + 1 < repeat:
             time.sleep(gap_s)
@@ -361,6 +372,7 @@ def sweep(
     attenuator_db: float = 0.0,
     burst_repeat: int = 3,
     burst_gap_s: float = 0.3,
+    tx_linger_s: float = 6.0,
     settle_s: float = 1.5,
     floor_samples: int = 20,
     floor_margin_db: float = 5.0,
@@ -382,6 +394,15 @@ def sweep(
     `resolve_band_mhz`. `attenuator_db` is the pad between the PA and the meter
     (added back in software). The result is a table of configured vs measured dBm
     plus `analyze_curve`'s saturation/gain summary.
+
+    Each step keys `burst_repeat` broadcasts, holding the node's port open
+    `tx_linger_s` per send so the firmware's ~4 s broadcast politeness delay plus
+    the packet's airtime finish before close (without it, queued TX is lost). The
+    default (6 s) covers a fast-preset ~200 B packet; raise it for slow presets
+    (LONG_SLOW and friends have multi-second airtime that a 6 s linger would clip)
+    and lower it only if you know the airtime is short. This is paid once per
+    burst per step, so it dominates sweep wall-clock — the meter sampler runs
+    throughout, so it does not need the conservative interactive send default.
 
     Safety: refuses any step whose *expected* meter input (configured power minus
     attenuator) would exceed the meter's absolute max — protect the instrument
@@ -448,7 +469,7 @@ def sweep(
 
                 sampler = _BackgroundSampler(m, interval_s=sample_interval_s)
                 sampler.start()
-                _key_burst(_BURST_TEXT, channel_index, port, burst_repeat, burst_gap_s)
+                _key_burst(_BURST_TEXT, channel_index, port, burst_repeat, burst_gap_s, tx_linger_s)
                 # Let the queued bursts drain onto the air before we stop watching.
                 time.sleep(settle_s)
                 raw = sampler.stop()

--- a/src/meshtastic_mcp/pa_sweep.py
+++ b/src/meshtastic_mcp/pa_sweep.py
@@ -339,6 +339,7 @@ def sweep(
         )
 
     original_tx_power = ctx.get("tx_power", 0)
+    original_duty_override = bool(ctx.get("override_duty_cycle", False))
     duty_override_touched = False
     steps: list[StepResult] = []
 
@@ -350,7 +351,10 @@ def sweep(
         floor_readings = m.sample(floor_samples, interval_s=sample_interval_s)
         floor_dbm = statistics.median(floor_readings)
 
-        if override_duty_cycle:
+        # Only flip the duty-cycle override if it isn't already where we need it —
+        # then we know the original value to put back, and we never write a device
+        # that was already configured the way we want.
+        if override_duty_cycle and not original_duty_override:
             admin.set_config("lora.override_duty_cycle", True, port=port)
             duty_override_touched = True
 
@@ -383,7 +387,7 @@ def sweep(
             if restore_config:
                 admin.set_config("lora.tx_power", int(original_tx_power), port=port)
                 if duty_override_touched:
-                    admin.set_config("lora.override_duty_cycle", False, port=port)
+                    admin.set_config("lora.override_duty_cycle", original_duty_override, port=port)
 
     table = [_step_row(s) for s in steps]
     silent_steps = [s.configured_dbm for s in steps if not s.rf_observed]

--- a/src/meshtastic_mcp/power_meter.py
+++ b/src/meshtastic_mcp/power_meter.py
@@ -208,9 +208,16 @@ class PowerMeter:
                 raise PowerMeterError(f"meter rejected command {command!r} (ERROR)")
             if first == "OK":
                 return "OK"
-            # Value replies are followed by a trailing OK line; consume it so it
-            # doesn't desync the next command's read.
-            self._ser.readline()
+            # Value replies are followed by a trailing OK line; consume AND validate
+            # it. If it isn't OK (a dropped byte, an out-of-band ERROR, a truncated
+            # frame) the stream is desynced — fail loud rather than hand back a value
+            # paired with an unconfirmed reply and let the next command read garbage.
+            trailer = self._ser.readline().decode("ascii", "replace").strip()
+            if trailer != "OK":
+                raise PowerMeterError(
+                    f"desynced reply to {command!r}: expected trailing 'OK' after value "
+                    f"{first!r}, got {trailer!r}"
+                )
             return first
         except serial.SerialException as exc:
             raise PowerMeterError(
@@ -287,6 +294,8 @@ class PowerMeter:
         Uses ``D`` (average) by default, ``E`` (peak) when ``peak=True``. ~10-12 Hz
         (interval 0.05 s) is the sustained rate the meter handles comfortably.
         """
+        if count <= 0:
+            raise PowerMeterError(f"sample count must be >= 1, got {count}")
         read = self.read_peak_dbm if peak else self.read_avg_dbm
         out: list[float] = []
         for i in range(count):

--- a/src/meshtastic_mcp/power_meter.py
+++ b/src/meshtastic_mcp/power_meter.py
@@ -1,0 +1,296 @@
+# SPDX-FileCopyrightText: Meshtastic contributors
+# SPDX-License-Identifier: GPL-3.0-only
+
+"""ImmersionRC RF Power Meter v2 driver — the measurement instrument half of the
+PA-calibration bench (`pa_sweep.py` is the closed-loop orchestration half).
+
+This is a lab power meter, not an SDR: it reports a single scalar power reading
+(average or peak dBm) through its internal log detector, already calibrated per
+frequency band. That makes it the right tool for the one thing the RTL-SDR
+oracle (`sdr.py`) deliberately can't do — read *absolute* transmit power off a
+Meshtastic node's PA and watch how it tracks the configured `lora.tx_power`
+across a sweep. See `IMMERSIONRC_METER_HANDOFF.md` for the hardware notes this
+driver is built from (verified live against firmware 1.0.11).
+
+The wire protocol is line-based ASCII over USB CDC; every reply is either
+``<value>\\r\\n`` followed by ``OK\\r\\n``, or a bare ``OK\\r\\n`` (for the persist
+command), or ``ERROR\\r\\n`` for an unknown command. All the parsing lives in
+``PowerMeter._cmd`` and is exercised by `tests/unit/test_power_meter.py` against
+a fake serial port — no meter required to test the protocol logic.
+
+Calibration caveat (same spirit as `sdr.py`): the meter is accurate to ~±0.5 dB
+and the reading depends on the external attenuator you must add in front of it
+(the meter tops out at +30 dBm / 1.3 W absolute max — a bare Meshtastic PA at
++22 dBm needs a pad). Attenuator correction is applied in software (`pa_sweep`),
+never sent to the meter. Treat results as a bench regression check, not a
+certified measurement.
+"""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+
+import serial
+from serial.tools import list_ports
+
+# USB CDC identifiers for the ImmersionRC RF Power Meter v2 (Microchip CDC stack).
+# This firmware (1.0.11) reports no manufacturer string, so match on VID/PID only;
+# newer firmware may add manufacturer == "ImmersionRC" (the ELRS tooling also matches
+# on that) but we don't rely on it.
+METER_VID = 0x04D8
+METER_PID = 0x000A
+
+# The meter's stored per-frequency calibration curves, selected by 0-based index
+# via the ``F<idx>`` command. Values are MHz. Verified against fw 1.0.11 — note
+# there is no dedicated 915 MHz point, so US915 work uses the 900 MHz curve (F4),
+# matching the ExpressLRS tooling convention.
+FREQ_INDEX_MHZ: tuple[int, ...] = (
+    35, 72, 433, 868, 900, 1200, 2400,
+    5600, 5650, 5700, 5750, 5800, 5850, 5900, 5950, 6000,
+)  # fmt: skip
+
+# Meshtastic band -> the nearest usable calibration point on this meter.
+# EU868 lands exactly on F3; US915 uses F4 (900 MHz), the closest stored curve.
+_MESHTASTIC_BAND_MHZ: dict[str, int] = {
+    "EU868": 868,
+    "US915": 900,
+    "ANZ": 900,
+    "LORA_24": 2400,
+}
+
+# Reference tools send ``F<idx>`` twice with ~200 ms spacing "for reliability";
+# the second write reliably takes even when the first is dropped mid-enumeration.
+_FREQ_SET_REPEAT_GAP_S = 0.2
+
+# Absolute-max input the meter tolerates (1.3 W); readings above +30 dBm are out
+# of spec and >30 s above +27 dBm can damage it. `pa_sweep` refuses to key TX
+# that would exceed this after attenuator correction.
+METER_ABS_MAX_DBM = 31.0
+
+
+class PowerMeterError(RuntimeError):
+    """Raised for a missing meter, a serial failure, or an unexpected reply."""
+
+
+def list_meters() -> list[str]:
+    """Return the device paths of all attached ImmersionRC meters (matched by VID/PID).
+
+    Never opens a port — pure enumeration, safe to call from capability
+    detection. Returns ``[]`` (never raises) when pyserial can't enumerate.
+    """
+    try:
+        return [
+            p.device for p in list_ports.comports() if p.vid == METER_VID and p.pid == METER_PID
+        ]
+    except Exception:
+        # Capability detection must never crash startup — a wedged USB stack or
+        # a platform quirk in comports() just means "no meter".
+        return []
+
+
+def find_meter_port() -> str | None:
+    """First attached meter's device path, or None. See `list_meters`."""
+    meters = list_meters()
+    return meters[0] if meters else None
+
+
+def nearest_freq_index(mhz: float) -> int:
+    """Index into `FREQ_INDEX_MHZ` of the calibration point closest to `mhz`.
+
+    The meter has no continuous tuning — it applies whichever stored curve is
+    active — so any target frequency snaps to the nearest available point.
+    """
+    return min(range(len(FREQ_INDEX_MHZ)), key=lambda i: abs(FREQ_INDEX_MHZ[i] - mhz))
+
+
+def band_to_freq_mhz(band: str) -> int:
+    """Resolve a band name (``"EU868"``/``"US915"``/...) or a numeric string to MHz.
+
+    Accepts a Meshtastic region label or a bare MHz value (``"868"``) so callers
+    can pass either a region or an explicit frequency.
+    """
+    key = band.strip().upper()
+    if key in _MESHTASTIC_BAND_MHZ:
+        return _MESHTASTIC_BAND_MHZ[key]
+    try:
+        return int(float(band))
+    except ValueError as exc:
+        raise PowerMeterError(
+            f"Unknown band {band!r}. Use a MHz value or one of: {', '.join(_MESHTASTIC_BAND_MHZ)}."
+        ) from exc
+
+
+@dataclass(frozen=True)
+class MeterInfo:
+    port: str
+    version: str
+    stored_freq_mhz: int
+
+
+class PowerMeter:
+    """Synchronous line-protocol client for the ImmersionRC RF Power Meter v2.
+
+    Usage::
+
+        with PowerMeter(port) as m:
+            m.set_freq_mhz(868)          # activate the 868 MHz calibration curve
+            avg = m.read_avg_dbm()       # D — average power
+            peak = m.read_peak_dbm()     # E — peak power
+
+    One meter, one open connection: the auto-off timeout re-enumerates the USB
+    device, so hold a single connection for the whole measurement rather than
+    reopening per reading (reopening races the enumeration). `pa_sweep` follows
+    this — it opens the meter once and keeps it for the full sweep.
+    """
+
+    def __init__(self, port: str | None = None, baud: int = 9600, timeout: float = 0.5) -> None:
+        self._port = port or find_meter_port()
+        if self._port is None:
+            raise PowerMeterError(
+                "No ImmersionRC power meter found (VID 0x04D8 / PID 0x000A). "
+                "Plug it in and confirm it is powered on — it auto-powers-off on "
+                "a battery timeout and disappears from USB when it does."
+            )
+        self._baud = baud
+        self._timeout = timeout
+        self._ser: serial.Serial | None = None
+
+    # -- lifecycle ----------------------------------------------------------
+    def open(self) -> PowerMeter:
+        if self._ser is not None:
+            return self
+        try:
+            self._ser = serial.Serial(self._port, self._baud, timeout=self._timeout)
+        except serial.SerialException as exc:
+            raise PowerMeterError(f"Could not open power meter at {self._port}: {exc}") from exc
+        return self
+
+    def close(self) -> None:
+        if self._ser is not None:
+            try:
+                self._ser.close()
+            finally:
+                self._ser = None
+
+    def __enter__(self) -> PowerMeter:
+        return self.open()
+
+    def __exit__(self, *_exc: object) -> None:
+        self.close()
+
+    @property
+    def port(self) -> str:
+        assert self._port is not None  # guaranteed non-None by __init__
+        return self._port
+
+    # -- protocol -----------------------------------------------------------
+    def _cmd(self, command: str) -> str:
+        """Send one command, return its value token (or ``"OK"`` for `S`).
+
+        Reply grammar (baud is irrelevant on CDC; commands are case-insensitive):
+            value command -> ``<value>\\r\\n`` then ``OK\\r\\n``  -> returns ``<value>``
+            persist (`S`) -> ``OK\\r\\n``                          -> returns ``"OK"``
+            unknown       -> ``ERROR\\r\\n``                       -> raises
+        """
+        if self._ser is None:
+            raise PowerMeterError("power meter is not open; call open() or use a with-block")
+        try:
+            self._ser.reset_input_buffer()
+            self._ser.write((command + "\n").encode("ascii"))
+            first = self._ser.readline().decode("ascii", "replace").strip()
+            if first == "":
+                raise PowerMeterError(
+                    f"no reply to {command!r} — meter may have powered off (auto-off timeout) "
+                    "or the connection dropped"
+                )
+            if first == "ERROR":
+                raise PowerMeterError(f"meter rejected command {command!r} (ERROR)")
+            if first == "OK":
+                return "OK"
+            # Value replies are followed by a trailing OK line; consume it so it
+            # doesn't desync the next command's read.
+            self._ser.readline()
+            return first
+        except serial.SerialException as exc:
+            raise PowerMeterError(
+                f"serial error talking to meter at {self._port}: {exc} "
+                "(the meter re-enumerates on auto-off — re-scan for VID/PID)"
+            ) from exc
+
+    def _cmd_float(self, command: str) -> float:
+        raw = self._cmd(command)
+        try:
+            return float(raw)
+        except ValueError as exc:
+            raise PowerMeterError(f"expected a number from {command!r}, got {raw!r}") from exc
+
+    # -- high-level operations ---------------------------------------------
+    def version(self) -> str:
+        """Firmware version string, e.g. ``RFPowerMeterv2 1.0.11`` (the ``V`` command)."""
+        v = self._cmd("V")
+        if "RFPowerMeter" not in v:
+            raise PowerMeterError(f"unexpected version reply {v!r} — is this an ImmersionRC meter?")
+        return v
+
+    def read_avg_dbm(self) -> float:
+        """Current **average** power in dBm (the ``D`` command). Primary reading for
+        constant-envelope LoRa bursts."""
+        return self._cmd_float("D")
+
+    def read_peak_dbm(self) -> float:
+        """Current **peak** power in dBm (the ``E`` command). Cross-check for `read_avg_dbm`."""
+        return self._cmd_float("E")
+
+    def stored_freq_mhz(self) -> int:
+        """The persisted calibration frequency shown on the LCD (the bare ``F`` query).
+
+        Note the quirk: a serial ``F<idx>`` changes the *active* curve immediately
+        but does NOT update this stored value until an ``S`` (persist) — so right
+        after `set_freq_mhz(persist=False)` this still reports the old value even
+        though readings already reflect the new curve.
+        """
+        return int(self._cmd_float("F"))
+
+    def set_freq_index(self, index: int, *, persist: bool = False) -> int:
+        """Activate calibration curve `index` (0-based into `FREQ_INDEX_MHZ`).
+
+        Sent twice with a short gap, matching the reference tooling. Returns the
+        MHz the meter echoes back. With ``persist=True`` also issues ``S`` so the
+        LCD updates and the setting survives a power cycle.
+        """
+        if not 0 <= index < len(FREQ_INDEX_MHZ):
+            raise PowerMeterError(
+                f"frequency index {index} out of range 0..{len(FREQ_INDEX_MHZ) - 1}"
+            )
+        self._cmd(f"F{index}")
+        time.sleep(_FREQ_SET_REPEAT_GAP_S)
+        echoed = self._cmd(f"F{index}")
+        if persist:
+            self._cmd("S")
+        try:
+            return int(float(echoed))
+        except ValueError:
+            return FREQ_INDEX_MHZ[index]
+
+    def set_freq_mhz(self, mhz: float, *, persist: bool = False) -> int:
+        """Activate the calibration curve nearest to `mhz`. See `set_freq_index`."""
+        return self.set_freq_index(nearest_freq_index(mhz), persist=persist)
+
+    def info(self) -> MeterInfo:
+        """One round-trip snapshot: version + stored frequency."""
+        return MeterInfo(self.port, self.version(), self.stored_freq_mhz())
+
+    def sample(self, count: int, *, interval_s: float = 0.05, peak: bool = False) -> list[float]:
+        """Take `count` readings, `interval_s` apart, returning the dBm values.
+
+        Uses ``D`` (average) by default, ``E`` (peak) when ``peak=True``. ~10-12 Hz
+        (interval 0.05 s) is the sustained rate the meter handles comfortably.
+        """
+        read = self.read_peak_dbm if peak else self.read_avg_dbm
+        out: list[float] = []
+        for i in range(count):
+            out.append(read())
+            if i + 1 < count:
+                time.sleep(interval_s)
+        return out

--- a/src/meshtastic_mcp/power_meter.py
+++ b/src/meshtastic_mcp/power_meter.py
@@ -9,8 +9,13 @@ This is a lab power meter, not an SDR: it reports a single scalar power reading
 frequency band. That makes it the right tool for the one thing the RTL-SDR
 oracle (`sdr.py`) deliberately can't do — read *absolute* transmit power off a
 Meshtastic node's PA and watch how it tracks the configured `lora.tx_power`
-across a sweep. See `IMMERSIONRC_METER_HANDOFF.md` for the hardware notes this
-driver is built from (verified live against firmware 1.0.11).
+across a sweep. See `docs/power-meter.md` for the full hardware reference
+(device identity, wire protocol, calibration table, quirks) this driver
+implements; it was verified live against firmware 1.0.11.
+
+This module deliberately knows nothing about Meshtastic regions — it speaks
+frequencies in MHz only. Region-to-frequency resolution lives in `pa_sweep.py`,
+where `lora_compliance.REGIONS` is the single source of truth for band edges.
 
 The wire protocol is line-based ASCII over USB CDC; every reply is either
 ``<value>\\r\\n`` followed by ``OK\\r\\n``, or a bare ``OK\\r\\n`` (for the persist
@@ -49,15 +54,6 @@ FREQ_INDEX_MHZ: tuple[int, ...] = (
     35, 72, 433, 868, 900, 1200, 2400,
     5600, 5650, 5700, 5750, 5800, 5850, 5900, 5950, 6000,
 )  # fmt: skip
-
-# Meshtastic band -> the nearest usable calibration point on this meter.
-# EU868 lands exactly on F3; US915 uses F4 (900 MHz), the closest stored curve.
-_MESHTASTIC_BAND_MHZ: dict[str, int] = {
-    "EU868": 868,
-    "US915": 900,
-    "ANZ": 900,
-    "LORA_24": 2400,
-}
 
 # Reference tools send ``F<idx>`` twice with ~200 ms spacing "for reliability";
 # the second write reliably takes even when the first is dropped mid-enumeration.
@@ -102,23 +98,6 @@ def nearest_freq_index(mhz: float) -> int:
     active — so any target frequency snaps to the nearest available point.
     """
     return min(range(len(FREQ_INDEX_MHZ)), key=lambda i: abs(FREQ_INDEX_MHZ[i] - mhz))
-
-
-def band_to_freq_mhz(band: str) -> int:
-    """Resolve a band name (``"EU868"``/``"US915"``/...) or a numeric string to MHz.
-
-    Accepts a Meshtastic region label or a bare MHz value (``"868"``) so callers
-    can pass either a region or an explicit frequency.
-    """
-    key = band.strip().upper()
-    if key in _MESHTASTIC_BAND_MHZ:
-        return _MESHTASTIC_BAND_MHZ[key]
-    try:
-        return int(float(band))
-    except ValueError as exc:
-        raise PowerMeterError(
-            f"Unknown band {band!r}. Use a MHz value or one of: {', '.join(_MESHTASTIC_BAND_MHZ)}."
-        ) from exc
 
 
 @dataclass(frozen=True)

--- a/src/meshtastic_mcp/power_meter.py
+++ b/src/meshtastic_mcp/power_meter.py
@@ -33,11 +33,14 @@ certified measurement.
 
 from __future__ import annotations
 
+import threading
 import time
 from dataclasses import dataclass
 
 import serial
 from serial.tools import list_ports
+
+from . import registry
 
 # USB CDC identifiers for the ImmersionRC RF Power Meter v2 (Microchip CDC stack).
 # This firmware (1.0.11) reports no manufacturer string, so match on VID/PID only;
@@ -134,14 +137,32 @@ class PowerMeter:
         self._baud = baud
         self._timeout = timeout
         self._ser: serial.Serial | None = None
+        self._lock: threading.Lock | None = None
 
     # -- lifecycle ----------------------------------------------------------
     def open(self) -> PowerMeter:
+        """Acquire the meter's exclusive port lock and open the serial connection.
+
+        Uses the same non-blocking `registry.port_lock` as the Meshtastic serial
+        path (the "one call per serial port" rule), so a concurrent bench call on
+        the same meter fails fast with a busy error instead of two callers
+        stepping on one instrument. The lock is held for the whole open/act/close
+        lifecycle (i.e. the enclosing `with` block) and released in `close`, and
+        the underlying port is opened `exclusive=True`.
+        """
         if self._ser is not None:
             return self
+        lock = registry.port_lock(self.port)
+        if not lock.acquire(blocking=False):
+            raise PowerMeterError(
+                f"Power meter port {self._port} is busy — another operation is in flight. "
+                "Retry shortly."
+            )
+        self._lock = lock
         try:
-            self._ser = serial.Serial(self._port, self._baud, timeout=self._timeout)
-        except serial.SerialException as exc:
+            self._ser = serial.Serial(self._port, self._baud, timeout=self._timeout, exclusive=True)
+        except (serial.SerialException, ValueError) as exc:
+            self._release_lock()
             raise PowerMeterError(f"Could not open power meter at {self._port}: {exc}") from exc
         return self
 
@@ -151,6 +172,15 @@ class PowerMeter:
                 self._ser.close()
             finally:
                 self._ser = None
+        self._release_lock()
+
+    def _release_lock(self) -> None:
+        if self._lock is not None:
+            try:
+                self._lock.release()
+            except RuntimeError:
+                pass
+            self._lock = None
 
     def __enter__(self) -> PowerMeter:
         return self.open()

--- a/src/meshtastic_mcp/rf_oracle.py
+++ b/src/meshtastic_mcp/rf_oracle.py
@@ -92,6 +92,7 @@ def read_lora_context(port: str | None = None) -> dict[str, Any]:
         "override_frequency": lora.get("override_frequency", 0.0),
         "frequency_offset": lora.get("frequency_offset", 0.0),
         "tx_power": lora.get("tx_power", 0),
+        "override_duty_cycle": lora.get("override_duty_cycle", False),
         "device_role": device.get("role", "CLIENT"),
         "channel_name": channel_name,
     }

--- a/src/meshtastic_mcp/server.py
+++ b/src/meshtastic_mcp/server.py
@@ -1604,7 +1604,7 @@ def pa_sweep(
     channel_index: int = 0,
     attenuator_db: float = 0.0,
     burst_repeat: int = 3,
-    tx_linger_s: float = 6.0,
+    tx_linger_s: float | None = None,
     settle_s: float = 1.5,
     reboot_between_steps: bool = False,
     override_duty_cycle: bool = True,
@@ -1622,12 +1622,13 @@ def pa_sweep(
     firmware that doesn't apply LoRa config live). It captures the meter's noise
     floor first, then keeps only TX-active samples (floor + margin) per step.
 
-    `tx_linger_s` (default 6 s) is how long each broadcast holds the port open so
-    the firmware's ~4 s politeness delay + airtime finish before close drops the
-    TX; it is paid per burst per step and dominates wall-clock, so it is tuned
-    below `send_text`'s conservative 8 s default. Raise it for slow presets
-    (multi-second airtime would be clipped at 6 s); lower it only for short
-    airtime.
+    `tx_linger_s` is how long each broadcast holds the port open so the firmware's
+    ~4 s politeness delay + airtime finish before close drops the TX; it is paid
+    per burst per step and dominates wall-clock. Leave it `None` (default) to
+    **auto-derive** it from the node's live preset time-on-air — a fast preset
+    gets a short linger, LONG_SLOW gets a long enough one, no clipping and no
+    tuning. Pass a number to override. The value used is echoed as `tx_linger_s`
+    in the result.
 
     Instrument safety: pick `attenuator_db` so the highest configured power minus
     the pad stays under the meter's +31 dBm absolute max — the sweep refuses to
@@ -1647,7 +1648,7 @@ def pa_sweep(
 
     Returns:
         {band, region, requested_center_mhz, meter_cal_mhz, attenuator_db,
-         floor_dbm, floor_margin_db, table: [{configured_dbm, measured_avg_dbm,
+         tx_linger_s, floor_dbm, floor_margin_db, table: [{configured_dbm, measured_avg_dbm,
          measured_peak_dbm, delta_db, active_samples, total_samples, rf_observed}],
          curve: {points, saturation_dbm, max_measured_dbm,
          max_measured_at_configured_dbm, offset_at_min_db, monotonic},

--- a/src/meshtastic_mcp/server.py
+++ b/src/meshtastic_mcp/server.py
@@ -42,6 +42,9 @@ from . import (
 from . import (
     inject as inject_mod,
 )
+from . import (
+    pa_sweep as pa_sweep_mod,
+)
 from . import sdk_cli as sdk_cli_mod
 from . import userprefs as userprefs_mod
 from .recorder import get_recorder
@@ -158,6 +161,22 @@ def sdr_tool(*args: Any, **kwargs: Any):
     return deco
 
 
+def power_meter_tool(*args: Any, **kwargs: Any):
+    """Like `@app.tool()` but only registers when the power_meter capability is active.
+
+    Without an attached ImmersionRC RF Power Meter v2 the PA-calibration bench
+    tools (`pa_meter_status`, `pa_measure`, `pa_sweep`) are not advertised. See
+    `doctor` for what's missing.
+    """
+
+    def deco(fn):
+        if CAPS.power_meter:
+            return app.tool(*args, **kwargs)(fn)
+        return fn
+
+    return deco
+
+
 def sdk_tool(*args: Any, **kwargs: Any):
     """Like `@app.tool()` but only registers when the Kotlin SDK CLI is present.
 
@@ -204,6 +223,13 @@ _SDR_TOOLS = (
     "rf_confirm_tx",
 )
 
+# Power-meter-coupled tools, gated by `power_meter_tool` on the power_meter capability.
+_POWER_METER_TOOLS = (
+    "pa_meter_status",
+    "pa_measure",
+    "pa_sweep",
+)
+
 # Firmware-coupled tools, gated by `firmware_tool` on the firmware capability.
 _FIRMWARE_TOOLS = (
     "list_boards",
@@ -248,6 +274,13 @@ def _log_capabilities() -> None:
                 "(install the 'sdr' extra + librtlsdr + an RTL-SDR to enable): %s",
                 len(_SDR_TOOLS),
                 ", ".join(_SDR_TOOLS),
+            )
+        if not CAPS.power_meter:
+            log.info(
+                "power_meter capability inactive: %d PA-calibration tools not registered "
+                "(plug in a powered-on ImmersionRC RF Power Meter v2 to enable): %s",
+                len(_POWER_METER_TOOLS),
+                ", ".join(_POWER_METER_TOOLS),
             )
     except Exception as exc:  # never fail startup over a capability probe
         log.warning("capability detection failed: %s", exc)
@@ -1536,6 +1569,120 @@ def rf_confirm_tx(
     )
 
 
+# ---------- PA calibration bench (ImmersionRC RF Power Meter v2) ------------
+
+
+@power_meter_tool()
+def pa_meter_status(meter_port: str | None = None) -> dict[str, Any]:
+    """Detect the ImmersionRC RF Power Meter and report a live reading — the
+    bench-instrument equivalent of `recorder_status`. Read-only; no Meshtastic
+    device involved.
+
+    Use it to confirm the meter is connected and awake before a `pa_sweep`
+    (it auto-powers-off on a battery timeout and vanishes from USB), and to see
+    the current noise floor / any signal it's presently reading.
+
+    Returns:
+        {present: bool, port, version, stored_freq_mhz, current_avg_dbm,
+         current_peak_dbm}  — or {present: false, detail} when none is attached.
+    """
+    return pa_sweep_mod.status(meter_port=meter_port)
+
+
+@power_meter_tool()
+def pa_measure(
+    band: str,
+    samples: int = 20,
+    interval_s: float = 0.05,
+    attenuator_db: float = 0.0,
+    meter_port: str | None = None,
+    peak: bool = False,
+) -> dict[str, Any]:
+    """Passively read the power the meter currently sees at `band` — no Meshtastic
+    device driven. Activates the band's calibration curve, takes `samples`
+    readings, returns min/mean/max in dBm (corrected for `attenuator_db`, the pad
+    between the source and the meter).
+
+    `band` accepts a Meshtastic region (`"EU868"`, `"US915"`, ...) or a bare MHz
+    value (`"868"`); it snaps to the meter's nearest stored calibration point.
+    Use it to read the noise floor, verify a signal generator, or spot-check a TX
+    something else is keying. For a closed-loop node PA sweep use `pa_sweep`.
+
+    Returns:
+        {band, freq_mhz, kind, attenuator_db, samples, min_dbm, mean_dbm, max_dbm}
+    """
+    return pa_sweep_mod.measure(
+        band,
+        samples=samples,
+        interval_s=interval_s,
+        attenuator_db=attenuator_db,
+        meter_port=meter_port,
+        peak=peak,
+    )
+
+
+@power_meter_tool()
+def pa_sweep(
+    powers: list[int],
+    band: str | None = None,
+    port: str | None = None,
+    meter_port: str | None = None,
+    channel_index: int = 0,
+    attenuator_db: float = 0.0,
+    burst_repeat: int = 3,
+    settle_s: float = 1.5,
+    reboot_between_steps: bool = False,
+    override_duty_cycle: bool = True,
+    restore_config: bool = True,
+    confirm: bool = False,
+) -> dict[str, Any]:
+    """Closed-loop PA calibration: step `lora.tx_power` through `powers` and
+    measure the actual power off the node's PA with the ImmersionRC meter,
+    producing a configured-vs-measured table and a compression/saturation
+    analysis. Requires confirm=True.
+
+    Destructive: for each step it writes `lora.tx_power` on the node, keys real
+    ~200 B broadcast bursts onto the mesh (an idle node rarely transmits), and
+    optionally reboots between steps (`reboot_between_steps=True` for pre-2.8.0
+    firmware that doesn't apply LoRa config live). It captures the meter's noise
+    floor first, then keeps only TX-active samples (floor + margin) per step.
+
+    Instrument safety: pick `attenuator_db` so the highest configured power minus
+    the pad stays under the meter's +31 dBm absolute max — the sweep refuses to
+    run otherwise. `band` defaults to the node's configured region. On EU868 the
+    duty-cycle limit is overridden for the run and restored after (with
+    `override_duty_cycle=True`, the default). The original `tx_power` and
+    duty-cycle override are restored on exit unless `restore_config=False`.
+
+    A step with no TX-active sample (see `silent_steps_dbm`) can be a dead PA —
+    but under airtime pressure a queued packet can also transmit after the
+    sampling window closes, so re-run spaced out before concluding a step is
+    truly silent. Uncalibrated bench check (~±0.5 dB + hand-entered pad), not a
+    certified measurement.
+
+    Returns:
+        {band, region, freq_mhz, attenuator_db, floor_dbm, floor_margin_db,
+         table: [{configured_dbm, measured_avg_dbm, measured_peak_dbm, delta_db,
+         active_samples, total_samples, rf_observed}], curve: {points,
+         saturation_dbm, max_measured_dbm, max_measured_at_configured_dbm,
+         offset_at_min_db, monotonic}, silent_steps_dbm, config_restored, caveat}
+    """
+    return pa_sweep_mod.sweep(
+        powers,
+        band=band,
+        port=port,
+        meter_port=meter_port,
+        channel_index=channel_index,
+        attenuator_db=attenuator_db,
+        burst_repeat=burst_repeat,
+        settle_s=settle_s,
+        reboot_between_steps=reboot_between_steps,
+        override_duty_cycle=override_duty_cycle,
+        restore_config=restore_config,
+        confirm=confirm,
+    )
+
+
 @app.tool()
 def shutdown(port: str | None = None, confirm: bool = False, seconds: int = 10) -> dict[str, Any]:
     """Shut down the connected node in `seconds` seconds. Requires confirm=True.
@@ -2532,6 +2679,8 @@ _READ_ONLY = {
     "triage_window",  # reads device window (+optional screenshot); no mutation
     "local_model_status",  # reports backend/reachability; no mutation
     "rf_scan",  # passive SDR capture; no device/host mutation
+    "pa_meter_status",  # reads the power meter; no device/host mutation
+    "pa_measure",  # passive meter read; no Meshtastic-device mutation
     "sdk_status",  # reports SDK-CLI bridge availability; no mutation
     "sdk_device_info",  # reads device snapshot via the Kotlin SDK CLI; no mutation
     "sdk_list_nodes",  # reads the device node DB via the Kotlin SDK CLI; no mutation
@@ -2553,6 +2702,7 @@ _DESTRUCTIVE = {
     "send_text",  # injects a mesh packet; cannot be recalled
     "inject_frame",  # injects a forged frame into the RX pipeline; cannot be recalled
     "rf_confirm_tx",  # calls send_text internally; injects a mesh packet
+    "pa_sweep",  # writes lora.tx_power, keys TX, may reboot the node
     "send_input_event",  # drives device button/GPIO; side-effect on hardware
     "reboot",
     "shutdown",
@@ -2644,6 +2794,11 @@ _OPEN_WORLD = {
     "picotool_load",
     "picotool_raw",
     "push_fake_nodedb",
+    # Talk to the external ImmersionRC power meter over USB; pa_sweep also drives
+    # the node's TX onto the mesh.
+    "pa_meter_status",
+    "pa_measure",
+    "pa_sweep",
     # Return user-authored content from remote mesh nodes — untrusted input
     # that can carry prompt-injection payloads (lethal-trifecta leg 2).
     "logs_window",
@@ -2673,6 +2828,9 @@ _TITLE_OVERRIDES: dict[str, str] = {
     "uhubctl_cycle": "USB Hub Port Cycle",
     "get_environment_doctor_report": "Environment Doctor Report",
     "get_active_capabilities": "Active Capabilities",
+    "pa_meter_status": "PA Meter Status",
+    "pa_measure": "PA Meter Measure",
+    "pa_sweep": "PA Power Sweep (Closed-Loop)",
 }
 
 

--- a/src/meshtastic_mcp/server.py
+++ b/src/meshtastic_mcp/server.py
@@ -1604,6 +1604,7 @@ def pa_sweep(
     channel_index: int = 0,
     attenuator_db: float = 0.0,
     burst_repeat: int = 3,
+    tx_linger_s: float = 6.0,
     settle_s: float = 1.5,
     reboot_between_steps: bool = False,
     override_duty_cycle: bool = True,
@@ -1620,6 +1621,13 @@ def pa_sweep(
     optionally reboots between steps (`reboot_between_steps=True` for pre-2.8.0
     firmware that doesn't apply LoRa config live). It captures the meter's noise
     floor first, then keeps only TX-active samples (floor + margin) per step.
+
+    `tx_linger_s` (default 6 s) is how long each broadcast holds the port open so
+    the firmware's ~4 s politeness delay + airtime finish before close drops the
+    TX; it is paid per burst per step and dominates wall-clock, so it is tuned
+    below `send_text`'s conservative 8 s default. Raise it for slow presets
+    (multi-second airtime would be clipped at 6 s); lower it only for short
+    airtime.
 
     Instrument safety: pick `attenuator_db` so the highest configured power minus
     the pad stays under the meter's +31 dBm absolute max — the sweep refuses to
@@ -1653,6 +1661,7 @@ def pa_sweep(
         channel_index=channel_index,
         attenuator_db=attenuator_db,
         burst_repeat=burst_repeat,
+        tx_linger_s=tx_linger_s,
         settle_s=settle_s,
         reboot_between_steps=reboot_between_steps,
         override_duty_cycle=override_duty_cycle,

--- a/src/meshtastic_mcp/server.py
+++ b/src/meshtastic_mcp/server.py
@@ -2657,8 +2657,7 @@ _READ_ONLY = {
     "triage_window",  # reads device window (+optional screenshot); no mutation
     "local_model_status",  # reports backend/reachability; no mutation
     "rf_scan",  # passive SDR capture; no device/host mutation
-    "pa_meter_status",  # reads the power meter; no device/host mutation
-    "pa_measure",  # passive meter read; no Meshtastic-device mutation
+    "pa_meter_status",  # reads the power meter (version/stored freq/live dBm); no state change
     "sdk_status",  # reports SDK-CLI bridge availability; no mutation
     "sdk_device_info",  # reads device snapshot via the Kotlin SDK CLI; no mutation
     "sdk_list_nodes",  # reads the device node DB via the Kotlin SDK CLI; no mutation
@@ -2680,6 +2679,10 @@ _DESTRUCTIVE = {
     "send_text",  # injects a mesh packet; cannot be recalled
     "inject_frame",  # injects a forged frame into the RX pipeline; cannot be recalled
     "rf_confirm_tx",  # calls send_text internally; injects a mesh packet
+    # Selects the meter's active calibration curve (set_freq_mhz) — a transient,
+    # non-persisted instrument state change, so not read-only. Idempotent (same
+    # band -> same curve) and harmless to any DUT; the set_config-style pattern.
+    "pa_measure",
     "pa_sweep",  # writes lora.tx_power, keys TX, may reboot the node
     "send_input_event",  # drives device button/GPIO; side-effect on hardware
     "reboot",
@@ -2726,6 +2729,7 @@ _IDEMPOTENT_WRITES = {
     "set_owner",
     "set_channel_url",
     "userprefs_set",
+    "pa_measure",  # re-selecting the same band leaves the meter in the same state
 }
 # Open-world: interacts with an external device, radio mesh, or host hardware.
 # Also includes tools whose OUTPUT may contain untrusted content sourced from

--- a/src/meshtastic_mcp/server.py
+++ b/src/meshtastic_mcp/server.py
@@ -161,22 +161,6 @@ def sdr_tool(*args: Any, **kwargs: Any):
     return deco
 
 
-def power_meter_tool(*args: Any, **kwargs: Any):
-    """Like `@app.tool()` but only registers when the power_meter capability is active.
-
-    Without an attached ImmersionRC RF Power Meter v2 the PA-calibration bench
-    tools (`pa_meter_status`, `pa_measure`, `pa_sweep`) are not advertised. See
-    `doctor` for what's missing.
-    """
-
-    def deco(fn):
-        if CAPS.power_meter:
-            return app.tool(*args, **kwargs)(fn)
-        return fn
-
-    return deco
-
-
 def sdk_tool(*args: Any, **kwargs: Any):
     """Like `@app.tool()` but only registers when the Kotlin SDK CLI is present.
 
@@ -223,13 +207,6 @@ _SDR_TOOLS = (
     "rf_confirm_tx",
 )
 
-# Power-meter-coupled tools, gated by `power_meter_tool` on the power_meter capability.
-_POWER_METER_TOOLS = (
-    "pa_meter_status",
-    "pa_measure",
-    "pa_sweep",
-)
-
 # Firmware-coupled tools, gated by `firmware_tool` on the firmware capability.
 _FIRMWARE_TOOLS = (
     "list_boards",
@@ -274,13 +251,6 @@ def _log_capabilities() -> None:
                 "(install the 'sdr' extra + librtlsdr + an RTL-SDR to enable): %s",
                 len(_SDR_TOOLS),
                 ", ".join(_SDR_TOOLS),
-            )
-        if not CAPS.power_meter:
-            log.info(
-                "power_meter capability inactive: %d PA-calibration tools not registered "
-                "(plug in a powered-on ImmersionRC RF Power Meter v2 to enable): %s",
-                len(_POWER_METER_TOOLS),
-                ", ".join(_POWER_METER_TOOLS),
             )
     except Exception as exc:  # never fail startup over a capability probe
         log.warning("capability detection failed: %s", exc)
@@ -1572,7 +1542,7 @@ def rf_confirm_tx(
 # ---------- PA calibration bench (ImmersionRC RF Power Meter v2) ------------
 
 
-@power_meter_tool()
+@app.tool()
 def pa_meter_status(meter_port: str | None = None) -> dict[str, Any]:
     """Detect the ImmersionRC RF Power Meter and report a live reading — the
     bench-instrument equivalent of `recorder_status`. Read-only; no Meshtastic
@@ -1589,7 +1559,7 @@ def pa_meter_status(meter_port: str | None = None) -> dict[str, Any]:
     return pa_sweep_mod.status(meter_port=meter_port)
 
 
-@power_meter_tool()
+@app.tool()
 def pa_measure(
     band: str,
     samples: int = 20,
@@ -1603,13 +1573,17 @@ def pa_measure(
     readings, returns min/mean/max in dBm (corrected for `attenuator_db`, the pad
     between the source and the meter).
 
-    `band` accepts a Meshtastic region (`"EU868"`, `"US915"`, ...) or a bare MHz
-    value (`"868"`); it snaps to the meter's nearest stored calibration point.
-    Use it to read the noise floor, verify a signal generator, or spot-check a TX
-    something else is keying. For a closed-loop node PA sweep use `pa_sweep`.
+    `band` accepts a Meshtastic region name (`"US"`, `"EU_868"`, `"EU_433"`,
+    `"JP"`, ...) or a bare MHz value (`"868"`); it snaps to the meter's nearest
+    stored calibration point. Use it to read the noise floor, verify a signal
+    generator, or spot-check a TX something else is keying. Note `attenuator_db`
+    is added to every reading, so it inflates a noise-floor read by the pad value
+    — pass `attenuator_db=0` for the meter's raw floor. For a closed-loop node PA
+    sweep use `pa_sweep`.
 
     Returns:
-        {band, freq_mhz, kind, attenuator_db, samples, min_dbm, mean_dbm, max_dbm}
+        {band, requested_center_mhz, meter_cal_mhz, kind, attenuator_db, samples,
+         min_dbm, mean_dbm, max_dbm}
     """
     return pa_sweep_mod.measure(
         band,
@@ -1621,7 +1595,7 @@ def pa_measure(
     )
 
 
-@power_meter_tool()
+@app.tool()
 def pa_sweep(
     powers: list[int],
     band: str | None = None,
@@ -1649,10 +1623,13 @@ def pa_sweep(
 
     Instrument safety: pick `attenuator_db` so the highest configured power minus
     the pad stays under the meter's +31 dBm absolute max — the sweep refuses to
-    run otherwise. `band` defaults to the node's configured region. On EU868 the
+    run otherwise. `band` defaults to the node's configured region (a Meshtastic
+    region name like `"US"` / `"EU_868"`, or a bare MHz value). On EU_868 the
     duty-cycle limit is overridden for the run and restored after (with
     `override_duty_cycle=True`, the default). The original `tx_power` and
-    duty-cycle override are restored on exit unless `restore_config=False`.
+    duty-cycle override are restored on exit unless `restore_config=False`; each
+    restore is independent, and any that fails (e.g. the port was busy) is
+    reported in `restore_errors` instead of silently leaving state changed.
 
     A step with no TX-active sample (see `silent_steps_dbm`) can be a dead PA —
     but under airtime pressure a queued packet can also transmit after the
@@ -1661,11 +1638,12 @@ def pa_sweep(
     certified measurement.
 
     Returns:
-        {band, region, freq_mhz, attenuator_db, floor_dbm, floor_margin_db,
-         table: [{configured_dbm, measured_avg_dbm, measured_peak_dbm, delta_db,
-         active_samples, total_samples, rf_observed}], curve: {points,
-         saturation_dbm, max_measured_dbm, max_measured_at_configured_dbm,
-         offset_at_min_db, monotonic}, silent_steps_dbm, config_restored, caveat}
+        {band, region, requested_center_mhz, meter_cal_mhz, attenuator_db,
+         floor_dbm, floor_margin_db, table: [{configured_dbm, measured_avg_dbm,
+         measured_peak_dbm, delta_db, active_samples, total_samples, rf_observed}],
+         curve: {points, saturation_dbm, max_measured_dbm,
+         max_measured_at_configured_dbm, offset_at_min_db, monotonic},
+         silent_steps_dbm, config_restored, restore_errors, caveat}
     """
     return pa_sweep_mod.sweep(
         powers,

--- a/tests/unit/test_power_meter.py
+++ b/tests/unit/test_power_meter.py
@@ -329,6 +329,35 @@ def test_sweep_enables_then_restores_duty_override_when_originally_off(monkeypat
     assert duty_writes[-1] is False, "should restore to the original (off) value, not force True"
 
 
+def test_sweep_passes_tuned_tx_linger_to_send_text(monkeypatch) -> None:
+    # Bursts must key with the sweep's tuned tx_linger_s, not send_text's 8 s
+    # interactive default (which would be paid per burst per step).
+    sent: list[dict] = []
+    monkeypatch.setattr(pa_sweep.admin, "set_config", lambda path, value, port=None: None)
+    monkeypatch.setattr(
+        pa_sweep.admin, "send_text", lambda **k: (sent.append(k), {"ok": True, "packet_id": 1})[1]
+    )
+    monkeypatch.setattr(
+        pa_sweep,
+        "read_lora_context",
+        lambda port=None: {"region": "EU_868", "tx_power": 13, "override_duty_cycle": True},
+    )
+    monkeypatch.setattr(pa_sweep.power_meter, "PowerMeter", _FakeMeter)
+    monkeypatch.setattr(pa_sweep.time, "sleep", lambda *_a: None)
+
+    pa_sweep.sweep(
+        [20],
+        band="EU_868",
+        confirm=True,
+        settle_s=0,
+        floor_samples=3,
+        burst_repeat=2,
+        tx_linger_s=3.5,
+    )
+    assert len(sent) == 2, "one send per burst_repeat"
+    assert all(k.get("tx_linger_s") == 3.5 for k in sent), "each burst uses the tuned linger"
+
+
 def test_sweep_restores_independently_and_reports_errors(monkeypatch) -> None:
     # If the tx_power restore fails (port busy), the duty-cycle restore must STILL
     # run — leaving override_duty_cycle stuck on is the regulatory hazard — and the

--- a/tests/unit/test_power_meter.py
+++ b/tests/unit/test_power_meter.py
@@ -329,6 +329,43 @@ def test_sweep_enables_then_restores_duty_override_when_originally_off(monkeypat
     assert duty_writes[-1] is False, "should restore to the original (off) value, not force True"
 
 
+def test_lora_time_on_air_matches_known_values() -> None:
+    # Semtech AN1200.13, Meshtastic 16-symbol preamble.
+    # LONG_FAST (SF11/250 kHz, 4/5), 20 B payload ~= 0.395 s.
+    fast = pa_sweep.lora_time_on_air_s(20, sf=11, bw_khz=250, cr=5)
+    assert fast == pytest.approx(0.395, abs=0.01)
+    # LONG_SLOW (SF12/125 kHz, 4/8) is far longer for the same payload.
+    slow = pa_sweep.lora_time_on_air_s(20, sf=12, bw_khz=125, cr=8)
+    assert slow == pytest.approx(1.974, abs=0.02)
+    assert slow > 4 * fast
+
+
+def test_derive_tx_linger_scales_with_preset() -> None:
+    base = {
+        "use_preset": True,
+        "channel_name": "",
+        "channel_num": 0,
+        "bandwidth": None,
+        "spread_factor": None,
+        "coding_rate": None,
+        "override_frequency": 0.0,
+        "frequency_offset": 0.0,
+        "device_role": "CLIENT",
+    }
+    fast = pa_sweep._derive_tx_linger_s({**base, "region": "US", "modem_preset": "LONG_FAST"})
+    slow = pa_sweep._derive_tx_linger_s({**base, "region": "US", "modem_preset": "LONG_SLOW"})
+    # politeness (~4 s) + airtime + margin: a fast preset is single-digit seconds,
+    # LONG_SLOW is much longer (its ~200 B airtime alone is ~12 s).
+    assert 5.0 < fast < 10.0
+    assert slow > fast
+    assert slow > 12.0
+
+
+def test_derive_tx_linger_falls_back_on_bad_ctx() -> None:
+    # Sizing the linger must never crash a sweep, even on an unpredictable ctx.
+    assert pa_sweep._derive_tx_linger_s({}) == pa_sweep._FALLBACK_TX_LINGER_S
+
+
 def test_sweep_passes_tuned_tx_linger_to_send_text(monkeypatch) -> None:
     # Bursts must key with the sweep's tuned tx_linger_s, not send_text's 8 s
     # interactive default (which would be paid per burst per step).

--- a/tests/unit/test_power_meter.py
+++ b/tests/unit/test_power_meter.py
@@ -5,7 +5,7 @@
 
 The wire protocol (`PowerMeter._cmd`) is exercised against a fake serial port
 that mimics the meter's ``<value>\\r\\n`` + ``OK\\r\\n`` reply grammar (verified
-live against fw 1.0.11 — see `IMMERSIONRC_METER_HANDOFF.md`). The measurement
+live against fw 1.0.11 — see `docs/power-meter.md`). The measurement
 logic (`classify_active`, `summarize_step`, `analyze_curve`) is pure and tested
 on synthetic sample sets, the same way `test_sdr.py` tests the SDR analysis on
 synthetic IQ — this is the regression net for the bench-calibration path.
@@ -31,7 +31,10 @@ class FakeSerial:
         self.closed = False
 
     def reset_input_buffer(self) -> None:
-        pass
+        # Real hardware flushes any unread bytes here; model that so a test's
+        # "_outbox is empty" assertion checks the driver drained cleanly rather
+        # than being masked by a stale queue the flush would have cleared.
+        self._outbox.clear()
 
     def write(self, data: bytes) -> int:
         cmd = data.decode("ascii").strip()
@@ -134,12 +137,24 @@ def test_nearest_freq_index_snaps() -> None:
     assert power_meter.FREQ_INDEX_MHZ[power_meter.nearest_freq_index(5805)] == 5800
 
 
-def test_band_to_freq_mhz() -> None:
-    assert power_meter.band_to_freq_mhz("EU868") == 868
-    assert power_meter.band_to_freq_mhz("US915") == 900
-    assert power_meter.band_to_freq_mhz("868") == 868
-    with pytest.raises(power_meter.PowerMeterError):
-        power_meter.band_to_freq_mhz("NOTABAND")
+def test_resolve_band_mhz_real_region_names() -> None:
+    # The blocking bug the old suite missed: sweep(band=None) feeds through the
+    # protobuf region enum name ("US", "EU_868", ...), not "US915"/"EU868".
+    assert pa_sweep.resolve_band_mhz("US") == pytest.approx(915.0)  # 902-928 centre
+    assert power_meter.nearest_freq_index(pa_sweep.resolve_band_mhz("US")) == 4  # -> 900 MHz curve
+    assert pa_sweep.resolve_band_mhz("EU_868") == pytest.approx((869.4 + 869.65) / 2)
+    assert power_meter.nearest_freq_index(pa_sweep.resolve_band_mhz("EU_868")) == 3  # -> 868
+    assert pa_sweep.resolve_band_mhz("EU_433") == pytest.approx(433.5)
+    assert power_meter.nearest_freq_index(pa_sweep.resolve_band_mhz("EU_433")) == 2  # -> 433
+
+
+def test_resolve_band_mhz_accepts_bare_mhz() -> None:
+    assert pa_sweep.resolve_band_mhz("868") == pytest.approx(868.0)
+
+
+def test_resolve_band_mhz_rejects_garbage() -> None:
+    with pytest.raises(pa_sweep.PaSweepError, match="Unknown band"):
+        pa_sweep.resolve_band_mhz("NOTABAND")
 
 
 def test_list_meters_never_raises(monkeypatch) -> None:
@@ -218,7 +233,7 @@ def test_sample_rejects_nonpositive_count() -> None:
 
 def test_sweep_requires_confirm() -> None:
     with pytest.raises(pa_sweep.PaSweepError, match="confirm=True"):
-        pa_sweep.sweep([20], band="EU868", confirm=False)
+        pa_sweep.sweep([20], band="EU_868", confirm=False)
 
 
 # ---------------------------------------------------------------------------
@@ -259,7 +274,11 @@ def _patch_sweep(monkeypatch, *, original_duty: bool) -> list[tuple[str, object]
     monkeypatch.setattr(
         pa_sweep,
         "read_lora_context",
-        lambda port=None: {"region": "EU868", "tx_power": 20, "override_duty_cycle": original_duty},
+        lambda port=None: {
+            "region": "EU_868",
+            "tx_power": 20,
+            "override_duty_cycle": original_duty,
+        },
     )
     monkeypatch.setattr(pa_sweep.power_meter, "PowerMeter", _FakeMeter)
     monkeypatch.setattr(pa_sweep.time, "sleep", lambda *_a: None)
@@ -269,7 +288,7 @@ def _patch_sweep(monkeypatch, *, original_duty: bool) -> list[tuple[str, object]
 def test_sweep_leaves_duty_override_untouched_when_already_on(monkeypatch) -> None:
     calls = _patch_sweep(monkeypatch, original_duty=True)
     pa_sweep.sweep(
-        [17, 20], band="EU868", confirm=True, settle_s=0, floor_samples=3, burst_repeat=1
+        [17, 20], band="EU_868", confirm=True, settle_s=0, floor_samples=3, burst_repeat=1
     )
     duty_writes = [c for c in calls if c[0] == "lora.override_duty_cycle"]
     assert duty_writes == [], "must not write override_duty_cycle when it was already True"
@@ -281,8 +300,39 @@ def test_sweep_leaves_duty_override_untouched_when_already_on(monkeypatch) -> No
 def test_sweep_enables_then_restores_duty_override_when_originally_off(monkeypatch) -> None:
     calls = _patch_sweep(monkeypatch, original_duty=False)
     pa_sweep.sweep(
-        [17, 20], band="EU868", confirm=True, settle_s=0, floor_samples=3, burst_repeat=1
+        [17, 20], band="EU_868", confirm=True, settle_s=0, floor_samples=3, burst_repeat=1
     )
     duty_writes = [v for p, v in calls if p == "lora.override_duty_cycle"]
     assert duty_writes[0] is True, "should enable the override for the bench run"
     assert duty_writes[-1] is False, "should restore to the original (off) value, not force True"
+
+
+def test_sweep_restores_independently_and_reports_errors(monkeypatch) -> None:
+    # If the tx_power restore fails (port busy), the duty-cycle restore must STILL
+    # run — leaving override_duty_cycle stuck on is the regulatory hazard — and the
+    # failure must surface in restore_errors rather than being swallowed.
+    calls: list[tuple[str, object]] = []
+
+    def flaky_set_config(path, value, port=None):
+        calls.append((path, value))
+        if path == "lora.tx_power" and value == 99:  # the restore of the original
+            raise RuntimeError("port COM7 is busy - retry shortly")
+
+    monkeypatch.setattr(pa_sweep.admin, "set_config", flaky_set_config)
+    monkeypatch.setattr(pa_sweep.admin, "send_text", lambda **_k: {"ok": True, "packet_id": 1})
+    monkeypatch.setattr(
+        pa_sweep,
+        "read_lora_context",
+        lambda port=None: {"region": "EU_868", "tx_power": 99, "override_duty_cycle": False},
+    )
+    monkeypatch.setattr(pa_sweep.power_meter, "PowerMeter", _FakeMeter)
+    monkeypatch.setattr(pa_sweep.time, "sleep", lambda *_a: None)
+
+    res = pa_sweep.sweep(
+        [20], band="EU_868", confirm=True, settle_s=0, floor_samples=3, burst_repeat=1
+    )
+
+    assert res["restore_errors"], "a failed restore must be surfaced"
+    assert any("lora.tx_power" in e for e in res["restore_errors"])
+    # The duty-cycle restore ran despite the tx_power restore failing.
+    assert ("lora.override_duty_cycle", False) in calls

--- a/tests/unit/test_power_meter.py
+++ b/tests/unit/test_power_meter.py
@@ -1,0 +1,205 @@
+# SPDX-FileCopyrightText: Meshtastic contributors
+# SPDX-License-Identifier: GPL-3.0-only
+
+"""ImmersionRC power-meter driver protocol + PA-sweep analysis, no hardware.
+
+The wire protocol (`PowerMeter._cmd`) is exercised against a fake serial port
+that mimics the meter's ``<value>\\r\\n`` + ``OK\\r\\n`` reply grammar (verified
+live against fw 1.0.11 — see `IMMERSIONRC_METER_HANDOFF.md`). The measurement
+logic (`classify_active`, `summarize_step`, `analyze_curve`) is pure and tested
+on synthetic sample sets, the same way `test_sdr.py` tests the SDR analysis on
+synthetic IQ — this is the regression net for the bench-calibration path.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from meshtastic_mcp import pa_sweep, power_meter
+
+
+# ---------------------------------------------------------------------------
+# Fake serial port: canned replies keyed by the command written to it.
+# ---------------------------------------------------------------------------
+class FakeSerial:
+    """Minimal stand-in for `serial.Serial` speaking the meter's line protocol."""
+
+    def __init__(self, replies: dict[str, list[str]]) -> None:
+        # replies maps a command (without newline) -> the lines it answers with.
+        self._replies = replies
+        self._outbox: list[str] = []
+        self.closed = False
+
+    def reset_input_buffer(self) -> None:
+        pass
+
+    def write(self, data: bytes) -> int:
+        cmd = data.decode("ascii").strip()
+        lines = self._replies.get(cmd)
+        if lines is None:
+            lines = ["ERROR"]
+        self._outbox.extend(lines)
+        return len(data)
+
+    def readline(self) -> bytes:
+        if not self._outbox:
+            return b""  # timeout / no data
+        return (self._outbox.pop(0) + "\r\n").encode("ascii")
+
+    def close(self) -> None:
+        self.closed = True
+
+
+def _meter_with(replies: dict[str, list[str]]) -> power_meter.PowerMeter:
+    m = power_meter.PowerMeter.__new__(power_meter.PowerMeter)
+    m._port = "COM-TEST"  # type: ignore[attr-defined]
+    m._baud = 9600  # type: ignore[attr-defined]
+    m._timeout = 0.5  # type: ignore[attr-defined]
+    m._ser = FakeSerial(replies)  # type: ignore[attr-defined]
+    return m
+
+
+# ---------------------------------------------------------------------------
+# Protocol
+# ---------------------------------------------------------------------------
+def test_value_reply_consumes_trailing_ok() -> None:
+    m = _meter_with({"D": ["-26.450439", "OK"]})
+    assert m.read_avg_dbm() == pytest.approx(-26.450439)
+
+
+def test_peak_reply() -> None:
+    m = _meter_with({"E": ["-25.9596", "OK"]})
+    assert m.read_peak_dbm() == pytest.approx(-25.9596)
+
+
+def test_version_validated() -> None:
+    m = _meter_with({"V": ["RFPowerMeterv2 1.0.11", "OK"]})
+    assert "1.0.11" in m.version()
+
+
+def test_version_rejects_foreign_device() -> None:
+    m = _meter_with({"V": ["SomeOtherDevice", "OK"]})
+    with pytest.raises(power_meter.PowerMeterError):
+        m.version()
+
+
+def test_persist_returns_ok_only() -> None:
+    # `S` answers with a bare OK (no value line); _cmd must not block waiting for a value.
+    m = _meter_with({"S": ["OK"]})
+    assert m._cmd("S") == "OK"
+
+
+def test_unknown_command_raises() -> None:
+    m = _meter_with({})  # every command -> ERROR
+    with pytest.raises(power_meter.PowerMeterError, match="ERROR"):
+        m.read_avg_dbm()
+
+
+def test_empty_reply_flags_powered_off() -> None:
+    # An auto-off meter answers nothing (readline times out -> "").
+    m = _meter_with({"D": []})
+    with pytest.raises(power_meter.PowerMeterError, match=r"powered off|no reply"):
+        m.read_avg_dbm()
+
+
+def test_set_freq_index_echoes_and_consumes_cleanly(monkeypatch) -> None:
+    monkeypatch.setattr(power_meter.time, "sleep", lambda _s: None)  # skip the 200 ms gap
+    m = _meter_with({"F3": ["868", "OK"], "S": ["OK"]})
+    ser: FakeSerial = m._ser  # type: ignore[assignment]
+    echoed = m.set_freq_index(3, persist=True)
+    assert echoed == 868
+    assert ser._outbox == []  # every value+OK pair (F3 twice) and the S/OK fully consumed
+
+
+def test_set_freq_index_out_of_range() -> None:
+    m = _meter_with({})
+    with pytest.raises(power_meter.PowerMeterError, match="out of range"):
+        m.set_freq_index(99)
+
+
+# ---------------------------------------------------------------------------
+# Frequency mapping
+# ---------------------------------------------------------------------------
+def test_nearest_freq_index_snaps() -> None:
+    assert power_meter.FREQ_INDEX_MHZ[power_meter.nearest_freq_index(868)] == 868
+    assert power_meter.FREQ_INDEX_MHZ[power_meter.nearest_freq_index(915)] == 900  # closest point
+    assert power_meter.FREQ_INDEX_MHZ[power_meter.nearest_freq_index(5805)] == 5800
+
+
+def test_band_to_freq_mhz() -> None:
+    assert power_meter.band_to_freq_mhz("EU868") == 868
+    assert power_meter.band_to_freq_mhz("US915") == 900
+    assert power_meter.band_to_freq_mhz("868") == 868
+    with pytest.raises(power_meter.PowerMeterError):
+        power_meter.band_to_freq_mhz("NOTABAND")
+
+
+def test_list_meters_never_raises(monkeypatch) -> None:
+    def boom() -> list:
+        raise RuntimeError("usb wedged")
+
+    monkeypatch.setattr(power_meter.list_ports, "comports", boom)
+    assert power_meter.list_meters() == []
+
+
+# ---------------------------------------------------------------------------
+# Pure measurement logic
+# ---------------------------------------------------------------------------
+def test_classify_active_filters_floor() -> None:
+    floor = -25.0
+    samples = [-25.1, -24.8, -10.0, -9.5, -24.9]  # two real TX samples, rest floor
+    active = pa_sweep.classify_active(samples, floor, margin_db=5.0)
+    assert active == [-10.0, -9.5]
+
+
+def test_summarize_step_applies_attenuator() -> None:
+    # Meter reads ~ -10 dBm through a 30 dB pad => true power ~ +20 dBm.
+    samples = [-25.0, -10.0, -9.0, -24.0]
+    step = pa_sweep.summarize_step(samples, 20, -25.0, attenuator_db=30.0, margin_db=5.0)
+    assert step.rf_observed
+    assert step.measured_avg_dbm == pytest.approx(30.0 + (-9.5))  # mean of active + pad
+    assert step.measured_peak_dbm == pytest.approx(30.0 + (-9.0))
+    assert step.active_samples == 2
+    assert step.total_samples == 4
+
+
+def test_summarize_step_no_active_sample_is_silent() -> None:
+    step = pa_sweep.summarize_step([-25.0, -24.9], 5, -25.0)
+    assert not step.rf_observed
+    assert step.measured_avg_dbm is None
+
+
+def _step(cfg: int, meas: float | None) -> pa_sweep.StepResult:
+    return pa_sweep.StepResult(cfg, meas, meas, 5 if meas is not None else 0, 5)
+
+
+def test_analyze_curve_finds_saturation() -> None:
+    # Linear up to 17 dBm, then the PA compresses (measured barely moves).
+    steps = [
+        _step(5, 5.0),
+        _step(11, 11.0),
+        _step(17, 17.0),
+        _step(20, 17.4),  # +3 configured -> +0.4 measured => ratio 0.13 < 0.5
+        _step(22, 17.5),
+    ]
+    curve = pa_sweep.analyze_curve(steps)
+    assert curve["saturation_dbm"] == 17
+    assert curve["max_measured_dbm"] == pytest.approx(17.5)
+    assert curve["monotonic"] is True
+
+
+def test_analyze_curve_offset_at_min() -> None:
+    steps = [_step(5, 3.0), _step(20, 18.0)]  # 2 dB system loss at the bottom
+    curve = pa_sweep.analyze_curve(steps)
+    assert curve["offset_at_min_db"] == pytest.approx(-2.0)
+
+
+def test_analyze_curve_needs_two_points() -> None:
+    curve = pa_sweep.analyze_curve([_step(20, 20.0), _step(22, None)])
+    assert curve["saturation_dbm"] is None
+    assert "need >=2" in curve["note"]
+
+
+def test_sweep_requires_confirm() -> None:
+    with pytest.raises(pa_sweep.PaSweepError, match="confirm=True"):
+        pa_sweep.sweep([20], band="EU868", confirm=False)

--- a/tests/unit/test_power_meter.py
+++ b/tests/unit/test_power_meter.py
@@ -95,6 +95,14 @@ def test_unknown_command_raises() -> None:
         m.read_avg_dbm()
 
 
+def test_value_reply_without_trailing_ok_is_desync() -> None:
+    # A value line followed by something other than OK means the stream is
+    # desynced — must fail loud, not hand back the value with an unconfirmed frame.
+    m = _meter_with({"D": ["-26.45", "ERROR"]})
+    with pytest.raises(power_meter.PowerMeterError, match="desynced"):
+        m.read_avg_dbm()
+
+
 def test_empty_reply_flags_powered_off() -> None:
     # An auto-off meter answers nothing (readline times out -> "").
     m = _meter_with({"D": []})
@@ -200,6 +208,81 @@ def test_analyze_curve_needs_two_points() -> None:
     assert "need >=2" in curve["note"]
 
 
+def test_sample_rejects_nonpositive_count() -> None:
+    # measure()/floor capture do min/mean/max on the result — an empty list from
+    # count<=0 would crash opaquely downstream, so reject it at the source.
+    m = _meter_with({"D": ["-25.0", "OK"]})
+    with pytest.raises(power_meter.PowerMeterError, match="count must be >= 1"):
+        m.sample(0)
+
+
 def test_sweep_requires_confirm() -> None:
     with pytest.raises(pa_sweep.PaSweepError, match="confirm=True"):
         pa_sweep.sweep([20], band="EU868", confirm=False)
+
+
+# ---------------------------------------------------------------------------
+# sweep() duty-cycle-override restore (mocked collaborators, no hardware)
+# ---------------------------------------------------------------------------
+class _FakeMeter:
+    """Stand-in for `PowerMeter` in sweep tests: floor at -25, TX-active at -10."""
+
+    def __init__(self, *_a, **_k) -> None:
+        pass
+
+    def __enter__(self) -> _FakeMeter:
+        return self
+
+    def __exit__(self, *_exc: object) -> bool:
+        return False
+
+    def version(self) -> str:
+        return "RFPowerMeterv2 1.0.11"
+
+    def set_freq_mhz(self, mhz: float, *, persist: bool = False) -> int:
+        return int(mhz)
+
+    def sample(self, count: int, *, interval_s: float = 0.05, peak: bool = False) -> list[float]:
+        return [-25.0] * count  # noise floor
+
+    def read_avg_dbm(self) -> float:
+        return -10.0  # clears floor+margin => a TX-active sample
+
+
+def _patch_sweep(monkeypatch, *, original_duty: bool) -> list[tuple[str, object]]:
+    """Wire sweep()'s collaborators to fakes; return the recorded set_config calls."""
+    calls: list[tuple[str, object]] = []
+    monkeypatch.setattr(
+        pa_sweep.admin, "set_config", lambda path, value, port=None: calls.append((path, value))
+    )
+    monkeypatch.setattr(pa_sweep.admin, "send_text", lambda **_k: {"ok": True, "packet_id": 1})
+    monkeypatch.setattr(
+        pa_sweep,
+        "read_lora_context",
+        lambda port=None: {"region": "EU868", "tx_power": 20, "override_duty_cycle": original_duty},
+    )
+    monkeypatch.setattr(pa_sweep.power_meter, "PowerMeter", _FakeMeter)
+    monkeypatch.setattr(pa_sweep.time, "sleep", lambda *_a: None)
+    return calls
+
+
+def test_sweep_leaves_duty_override_untouched_when_already_on(monkeypatch) -> None:
+    calls = _patch_sweep(monkeypatch, original_duty=True)
+    pa_sweep.sweep(
+        [17, 20], band="EU868", confirm=True, settle_s=0, floor_samples=3, burst_repeat=1
+    )
+    duty_writes = [c for c in calls if c[0] == "lora.override_duty_cycle"]
+    assert duty_writes == [], "must not write override_duty_cycle when it was already True"
+    # tx_power still restored to the original.
+    tx_writes = [v for p, v in calls if p == "lora.tx_power"]
+    assert tx_writes[-1] == 20
+
+
+def test_sweep_enables_then_restores_duty_override_when_originally_off(monkeypatch) -> None:
+    calls = _patch_sweep(monkeypatch, original_duty=False)
+    pa_sweep.sweep(
+        [17, 20], band="EU868", confirm=True, settle_s=0, floor_samples=3, burst_repeat=1
+    )
+    duty_writes = [v for p, v in calls if p == "lora.override_duty_cycle"]
+    assert duty_writes[0] is True, "should enable the override for the bench run"
+    assert duty_writes[-1] is False, "should restore to the original (off) value, not force True"

--- a/tests/unit/test_power_meter.py
+++ b/tests/unit/test_power_meter.py
@@ -59,6 +59,7 @@ def _meter_with(replies: dict[str, list[str]]) -> power_meter.PowerMeter:
     m._baud = 9600  # type: ignore[attr-defined]
     m._timeout = 0.5  # type: ignore[attr-defined]
     m._ser = FakeSerial(replies)  # type: ignore[attr-defined]
+    m._lock = None  # type: ignore[attr-defined]  # built via __new__, never took the port lock
     return m
 
 
@@ -155,6 +156,25 @@ def test_resolve_band_mhz_accepts_bare_mhz() -> None:
 def test_resolve_band_mhz_rejects_garbage() -> None:
     with pytest.raises(pa_sweep.PaSweepError, match="Unknown band"):
         pa_sweep.resolve_band_mhz("NOTABAND")
+
+
+def test_open_is_exclusive_per_port(monkeypatch) -> None:
+    # A second open on the same meter port fails fast with a busy error (the
+    # "one call per serial port" rule), and the port frees again after close.
+    from meshtastic_mcp import registry
+
+    monkeypatch.setattr(power_meter.serial, "Serial", lambda *_a, **_k: FakeSerial({}))
+    registry.clear_port_lock("COM-LOCK-TEST")
+
+    m1 = power_meter.PowerMeter("COM-LOCK-TEST").open()
+    try:
+        with pytest.raises(power_meter.PowerMeterError, match="busy"):
+            power_meter.PowerMeter("COM-LOCK-TEST").open()
+    finally:
+        m1.close()
+
+    m2 = power_meter.PowerMeter("COM-LOCK-TEST").open()  # freed after close -> succeeds
+    m2.close()
 
 
 def test_list_meters_never_raises(monkeypatch) -> None:
@@ -274,9 +294,11 @@ def _patch_sweep(monkeypatch, *, original_duty: bool) -> list[tuple[str, object]
     monkeypatch.setattr(
         pa_sweep,
         "read_lora_context",
+        # tx_power distinct from every swept step (17, 20) so the restore
+        # assertion verifies cleanup ran, not just the last step's write.
         lambda port=None: {
             "region": "EU_868",
-            "tx_power": 20,
+            "tx_power": 13,
             "override_duty_cycle": original_duty,
         },
     )
@@ -292,9 +314,9 @@ def test_sweep_leaves_duty_override_untouched_when_already_on(monkeypatch) -> No
     )
     duty_writes = [c for c in calls if c[0] == "lora.override_duty_cycle"]
     assert duty_writes == [], "must not write override_duty_cycle when it was already True"
-    # tx_power still restored to the original.
+    # tx_power restored to the original (13), distinct from the last step (20).
     tx_writes = [v for p, v in calls if p == "lora.tx_power"]
-    assert tx_writes[-1] == 20
+    assert tx_writes[-1] == 13
 
 
 def test_sweep_enables_then_restores_duty_override_when_originally_off(monkeypatch) -> None:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added detection and documentation-backed support for the ImmersionRC RF Power Meter v2, surfaced in capability summaries.
  * Introduced MCP tools for meter status, band-calibrated measurements, and confirmed closed-loop TX power sweeps with safety bounds.
  * Doctor now reports power-meter presence and provides remediation when missing.
* **Documentation**
  * Added/expanded power-meter and PA-calibration guides, including the command protocol and calibration/sweep workflow.
  * Updated architecture notes and always-on tool registration accounting.
* **Bug Fixes**
  * Improved sweep duty-cycle override and restoration behavior.
* **Tests**
  * Added comprehensive unit tests for protocol handling, calibration logic, and sweep orchestration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->