### PR TITLE
fix(send_text): wait_for_tx confirmed against evidence that can exist (was: false on delivered messages)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -192,14 +192,30 @@ config_diff("before", "after")     # or diff two snapshots
 
 **Send a message and confirm delivery**
 ```
-list_devices()                      # pick port
-send_text(port=<port>, text="…")    # inject into mesh
-packets_window(port=<port>, start="-30s")  # confirm TEXT_MESSAGE_APP packet emitted
+list_devices()                          # pick port
+set_debug_log_api(port=<port>, enabled=True)        # required for confirmation (see below)
+send_text(port=<port>, text="…", wait_for_tx=True)  # tx_confirmed + tx_latency_s
 ```
-Or collapse send + confirm into one call:
-```
-send_text(port=<port>, text="…", wait_for_tx=True)  # returns tx_confirmed + tx_latency_s
-```
+**A node cannot see its own transmission on the receive path.** `packets_window`
+(and the recorder's packet stream generally) is fed by the `meshtastic.receive`
+pubsub topic, which only carries packets the node *received* — a message you
+just sent will never appear there. Do not "confirm" a local send with
+`packets_window`; it returns empty even when the message was delivered.
+
+`wait_for_tx=True` instead looks for the firmware's `Started Tx (id=…)` log line
+(and for a neighbour rebroadcasting the packet). That log only reaches the
+recorder when `set_debug_log_api(True)` is on for the port, or a `serial_session`
+is tapping it. `tx_confirmed` is three-valued:
+
+| value | meaning |
+| --- | --- |
+| `true` | transmission observed |
+| `false` | logs were flowing and showed no TX — a real failure signal |
+| `null` | not observable (usually debug-log capture is off) — **not** a failure |
+
+Check `tx_unconfirmed_reason` when you get `false` or `null`. Note it confirms the
+packet *reached the air*, not that any peer received it — for end-to-end delivery
+use `want_ack=True` on a direct message, or observe on a second node.
 
 **Read or write config**
 ```
@@ -301,7 +317,8 @@ UI-drive on physical phones requires USB debugging enabled and the device truste
 These will produce flaky, slow, or incorrect results:
 
 - **Polling `device_info()` or `list_nodes()` in a tight loop.** Both open/hold/close the serial port. The exclusive lock is non-blocking — a concurrent caller does not queue; it fails fast with a `... is busy — ... Retry shortly.` error you must catch and retry. Use `recorder_status()` + `events_window()` for ongoing observation instead.
-- **Asserting immediately after `send_text`.** Mesh delivery is best-effort and async. Always query the recorder window with a bounded deadline (e.g. `start="-30s"`, retry every 1 s up to 30 s), not a bare sleep.
+- **Asserting immediately after `send_text`.** Mesh delivery is best-effort and async. Use `wait_for_tx=True` (bounded by `tx_timeout_s`), not a bare sleep.
+- **Confirming a local send with `packets_window`.** That stream only carries packets the node *received*; your own transmission never appears there, so it reads as failure on a working mesh. Use `wait_for_tx=True` with `set_debug_log_api(True)`, and treat `tx_confirmed: null` as "not observable", not "failed". See *Send a message and confirm delivery*.
 - **Calling a firmware tool without checking `doctor()` first.** If `MESHTASTIC_FIRMWARE_ROOT` is unset, firmware tools are not registered at all. Call `doctor()` on first failure; parse `fix_commands` and surface them to the user.
 - **Omitting `confirm=True` on destructive tools then retrying.** The confirm gate is intentional — don't loop-retry without it. Surface the confirmation requirement to the user.
 - **Assuming the recorder has data immediately.** It starts capturing when a serial session opens. If you just opened the port, query with `start="-5s"` and check `line_count > 0` before asserting content.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -198,9 +198,13 @@ send_text(port=<port>, text="…", wait_for_tx=True)  # tx_confirmed + tx_latenc
 ```
 **A node cannot see its own transmission on the receive path.** `packets_window`
 (and the recorder's packet stream generally) is fed by the `meshtastic.receive`
-pubsub topic, which only carries packets the node *received* — a message you
-just sent will never appear there. Do not "confirm" a local send with
-`packets_window`; it returns empty even when the message was delivered.
+pubsub topic, which a self-originated packet never reaches: the firmware echoes
+it back but omits the now-redundant `from` field, and
+`MeshInterface._handlePacketFromRadio` treats that as *"Device returned a packet
+we sent, ignoring"* and returns before publishing. Do not "confirm" a local send
+with `packets_window`; it returns empty even when the message was delivered.
+`rf_oracle.confirm_tx` documents the same constraint for its
+`firmware_self_reported_tx` field.
 
 `wait_for_tx=True` instead looks for the firmware's `Started Tx (id=…)` log line
 (and for a neighbour rebroadcasting the packet). That log only reaches the
@@ -318,7 +322,7 @@ These will produce flaky, slow, or incorrect results:
 
 - **Polling `device_info()` or `list_nodes()` in a tight loop.** Both open/hold/close the serial port. The exclusive lock is non-blocking — a concurrent caller does not queue; it fails fast with a `... is busy — ... Retry shortly.` error you must catch and retry. Use `recorder_status()` + `events_window()` for ongoing observation instead.
 - **Asserting immediately after `send_text`.** Mesh delivery is best-effort and async. Use `wait_for_tx=True` (bounded by `tx_timeout_s`), not a bare sleep.
-- **Confirming a local send with `packets_window`.** That stream only carries packets the node *received*; your own transmission never appears there, so it reads as failure on a working mesh. Use `wait_for_tx=True` with `set_debug_log_api(True)`, and treat `tx_confirmed: null` as "not observable", not "failed". See *Send a message and confirm delivery*.
+- **Confirming a local send with `packets_window`.** A self-originated packet never reaches that stream — the library drops the firmware's echo as "a packet we sent" — so it reads as failure on a working mesh. Use `wait_for_tx=True` with `set_debug_log_api(True)`, and treat `tx_confirmed: null` as "not observable", not "failed". See *Send a message and confirm delivery*.
 - **Calling a firmware tool without checking `doctor()` first.** If `MESHTASTIC_FIRMWARE_ROOT` is unset, firmware tools are not registered at all. Call `doctor()` on first failure; parse `fix_commands` and surface them to the user.
 - **Omitting `confirm=True` on destructive tools then retrying.** The confirm gate is intentional — don't loop-retry without it. Surface the confirmation requirement to the user.
 - **Assuming the recorder has data immediately.** It starts capturing when a serial session opens. If you just opened the port, query with `start="-5s"` and check `line_count > 0` before asserting content.

--- a/src/meshtastic_mcp/server.py
+++ b/src/meshtastic_mcp/server.py
@@ -12,7 +12,6 @@ every tool post-registration (see ``_apply_tool_annotations``).
 from __future__ import annotations
 
 import logging
-import re
 import time
 from datetime import UTC
 from typing import Any
@@ -1324,37 +1323,55 @@ def _confirm_tx(
     if packet_id is None:
         return None, None, "no packet id was returned for this send, so nothing to match against"
 
-    # Firmware prints the id as lowercase, zero-padded 32-bit hex.
-    started_tx = re.compile(rf"Started Tx \(id=0x{packet_id:08x}\b")
+    # Firmware prints the id as lowercase, zero-padded 32-bit hex. Push this at
+    # `logs_window` as its `grep` rather than filtering the results ourselves:
+    # grep is applied *before* the max_lines cap, so the one line we need can
+    # never be truncated away by an unrelated burst of firmware chatter. That is
+    # not hypothetical — an unfiltered 2 min window on real hardware measured
+    # total_matched=455 / dropped=395.
+    tx_pattern = rf"Started Tx \(id=0x{packet_id:08x}\b"
     t0 = time.monotonic()
     deadline = t0 + tx_timeout_s
     saw_any_log = False
+    packets_truncated = False
 
     while True:
-        logs = log_query.logs_window(start="-2m", port=port, max_lines=200)
-        if logs.get("lines"):
-            saw_any_log = True
-            for entry in logs["lines"]:
-                if started_tx.search(entry.get("line", "")):
-                    return True, round(time.monotonic() - t0, 2), None
+        hits = log_query.logs_window(start="-2m", port=port, grep=tx_pattern, max_lines=20)
+        if hits.get("lines"):
+            return True, round(time.monotonic() - t0, 2), None
 
+        # Separate existence probe: "is any log flowing for this port at all?"
+        # Only ever asks for one line, so the cap is irrelevant here too.
+        if not saw_any_log:
+            probe = log_query.logs_window(start="-2m", port=port, max_lines=1)
+            if probe.get("lines") or probe.get("total_matched"):
+                saw_any_log = True
+
+        # A neighbour's rebroadcast comes back with our id. `packets_window` has
+        # no grep, so honour `dropped` instead of silently trusting a capped list.
         packets = log_query.packets_window(start="-2m", max=200)
         for pkt in packets.get("packets", []):
             if pkt.get("id") == packet_id:
                 return True, round(time.monotonic() - t0, 2), None
+        if packets.get("dropped", 0) > 0:
+            packets_truncated = True
 
         if time.monotonic() >= deadline:
             break
         time.sleep(1.0)
 
     if not saw_any_log:
-        return (
-            None,
-            None,
+        reason = (
             "no firmware log lines were captured for this port, so transmission "
             "could not be observed — enable set_debug_log_api(True) (or hold a "
-            "serial_session) to make tx_confirmed meaningful",
+            "serial_session) to make tx_confirmed meaningful"
         )
+        if packets_truncated:
+            reason += (
+                "; the packet window was also truncated (dropped>0), so a "
+                "rebroadcast may have been missed — narrow the window and retry"
+            )
+        return None, None, reason
     return False, None, "firmware logs were captured but showed no 'Started Tx' for this packet"
 
 

--- a/src/meshtastic_mcp/server.py
+++ b/src/meshtastic_mcp/server.py
@@ -12,6 +12,7 @@ every tool post-registration (see ``_apply_tool_annotations``).
 from __future__ import annotations
 
 import logging
+import re
 import time
 from datetime import UTC
 from typing import Any
@@ -1291,6 +1292,72 @@ def config_diff(name_a: str, name_b: str | None = None, port: str | None = None)
     return config_snapshot_mod.diff(name_a, name_b, port=port)
 
 
+def _confirm_tx(
+    packet_id: int | None,
+    port: str | None,
+    tx_timeout_s: float,
+) -> tuple[bool | None, float | None, str | None]:
+    """Poll for evidence that `packet_id` actually reached the air.
+
+    Returns `(confirmed, latency_s, reason)` where `confirmed` is:
+      * `True`  — positive evidence of transmission,
+      * `False` — an evidence channel was working and showed no transmission,
+      * `None`  — no evidence channel available, so we genuinely cannot tell.
+
+    The `None` case matters. A node cannot observe its own transmission through
+    the receive path: the recorder's packet stream is fed by the
+    `meshtastic.receive` pubsub topic, which only carries packets the node
+    *received*. Reporting that absence as `False` claimed failure for messages
+    that were verifiably delivered.
+
+    Two things do constitute evidence:
+
+    1. The firmware's own log line ``Started Tx (id=0x…)``, captured when
+       `set_debug_log_api(True)` is on (or a `serial_session` is tapping the
+       port). Deliberately NOT ``enqueue for send`` — a packet can be enqueued
+       and then killed before airtime, which is exactly the bug PR #18 fixed,
+       so matching the enqueue line would restore a false positive.
+    2. A neighbour rebroadcasting our packet, which arrives back on the receive
+       path carrying the same id. Real proof it reached the air, and it works
+       even with no log capture.
+    """
+    if packet_id is None:
+        return None, None, "no packet id was returned for this send, so nothing to match against"
+
+    # Firmware prints the id as lowercase, zero-padded 32-bit hex.
+    started_tx = re.compile(rf"Started Tx \(id=0x{packet_id:08x}\b")
+    t0 = time.monotonic()
+    deadline = t0 + tx_timeout_s
+    saw_any_log = False
+
+    while True:
+        logs = log_query.logs_window(start="-2m", port=port, max_lines=200)
+        if logs.get("lines"):
+            saw_any_log = True
+            for entry in logs["lines"]:
+                if started_tx.search(entry.get("line", "")):
+                    return True, round(time.monotonic() - t0, 2), None
+
+        packets = log_query.packets_window(start="-2m", max=200)
+        for pkt in packets.get("packets", []):
+            if pkt.get("id") == packet_id:
+                return True, round(time.monotonic() - t0, 2), None
+
+        if time.monotonic() >= deadline:
+            break
+        time.sleep(1.0)
+
+    if not saw_any_log:
+        return (
+            None,
+            None,
+            "no firmware log lines were captured for this port, so transmission "
+            "could not be observed — enable set_debug_log_api(True) (or hold a "
+            "serial_session) to make tx_confirmed meaningful",
+        )
+    return False, None, "firmware logs were captured but showed no 'Started Tx' for this packet"
+
+
 @app.tool()
 def send_text(
     text: str,
@@ -1313,15 +1380,23 @@ def send_text(
     before the serial port resets. Prevents loss of queued broadcasts.
 
     Delivery is async and best-effort. By default this returns as soon as the
-    packet is queued. Set `wait_for_tx=True` to additionally poll the recorder
-    (up to `tx_timeout_s`) for the matching TEXT_MESSAGE_APP packet on the wire
-    — collapsing the usual send + `packets_window` confirmation dance into one
-    call.
+    packet is queued. Set `wait_for_tx=True` to additionally poll (up to
+    `tx_timeout_s`) for evidence the radio actually transmitted: the firmware's
+    `Started Tx (id=…)` log line, or a neighbour rebroadcasting the packet.
+
+    `tx_confirmed` is three-valued. `true` means transmission was observed;
+    `false` means logs were flowing and showed no transmission; **`null` means
+    it could not be observed at all** — most often because firmware logs are not
+    being captured. Call `set_debug_log_api(True)` on the port (or hold a
+    `serial_session`) to make confirmation meaningful; without it, `null` is the
+    expected answer and does NOT mean the message failed. `tx_unconfirmed_reason`
+    explains which case you got.
 
     Returns:
         {ok: true, packet_id: int | null, destination: str}
         plus when wait_for_tx=True:
-        {tx_confirmed: bool, tx_latency_s: float | null}
+        {tx_confirmed: bool | null, tx_latency_s: float | null,
+         tx_unconfirmed_reason?: str}
     """
     result = admin.send_text(
         text=text,
@@ -1334,26 +1409,11 @@ def send_text(
     if not wait_for_tx:
         return result
 
-    packet_id = result.get("packet_id")
-    t0 = time.monotonic()
-    deadline = t0 + tx_timeout_s
-    confirmed = False
-    while time.monotonic() < deadline:
-        window = log_query.packets_window(start="-1m", portnum="TEXT_MESSAGE_APP", max=50)
-        for pkt in window.get("packets", []):
-            # Match by packet id when we have one; else fall back to any recent TX.
-            if packet_id is not None and pkt.get("id") == packet_id:
-                confirmed = True
-                break
-            if packet_id is None and pkt.get("portnum") == "TEXT_MESSAGE_APP":
-                confirmed = True
-                break
-        if confirmed:
-            break
-        time.sleep(1.0)
-
+    confirmed, latency_s, reason = _confirm_tx(result.get("packet_id"), port, tx_timeout_s)
     result["tx_confirmed"] = confirmed
-    result["tx_latency_s"] = round(time.monotonic() - t0, 2) if confirmed else None
+    result["tx_latency_s"] = latency_s
+    if reason is not None:
+        result["tx_unconfirmed_reason"] = reason
     return result
 
 

--- a/src/meshtastic_mcp/server.py
+++ b/src/meshtastic_mcp/server.py
@@ -1304,10 +1304,17 @@ def _confirm_tx(
       * `None`  — no evidence channel available, so we genuinely cannot tell.
 
     The `None` case matters. A node cannot observe its own transmission through
-    the receive path: the recorder's packet stream is fed by the
-    `meshtastic.receive` pubsub topic, which only carries packets the node
-    *received*. Reporting that absence as `False` claimed failure for messages
-    that were verifiably delivered.
+    the receive path. The firmware *does* echo the packet back, but it omits the
+    now-redundant `from` field on that echo, and
+    `MeshInterface._handlePacketFromRadio` treats a missing `from` as "Device
+    returned a packet we sent, ignoring" and returns before publishing any pubsub
+    event (`mesh_interface.py`). So it never reaches `meshtastic.receive`, and so
+    never reaches the recorder's packet stream. Reporting that absence as `False`
+    claimed failure for messages that were verifiably delivered.
+
+    `rf_oracle.confirm_tx` documents the same constraint from the RF side, and
+    its `firmware_self_reported_tx` field carries the identical caveat — it is a
+    known, documented limitation there, not a bug.
 
     Two things do constitute evidence:
 

--- a/tests/unit/test_wait_for_tx.py
+++ b/tests/unit/test_wait_for_tx.py
@@ -36,8 +36,8 @@ import pytest
 PID = 2268636889  # 0x8738a6d9 — a real id observed on hardware
 
 
-def _log_line(text: str) -> dict[str, Any]:
-    return {"ts": 1784837044.0, "port": "/dev/ttyACM1", "line": text}
+def _log_line(text: str, port: str = "/dev/ttyACM1") -> dict[str, Any]:
+    return {"ts": 1784837044.0, "port": port, "line": text}
 
 
 @pytest.fixture
@@ -52,16 +52,33 @@ def stub_query(monkeypatch):
     """
     from meshtastic_mcp import server
 
-    state: dict[str, Any] = {"log_lines": [], "packets": [], "server": server}
+    state: dict[str, Any] = {
+        "log_lines": [],
+        "packets": [],
+        "server": server,
+        "ports_queried": [],
+    }
 
     def fake_logs_window(*_a, **kwargs):
-        """Mirrors log_query.logs_window: grep is applied BEFORE the max_lines
-        cap, and the cap keeps the most recent N. Emulating the cap is what
-        makes `test_tx_line_survives_a_chatty_log` meaningful — without it the
-        test would pass no matter how the lookup was implemented."""
+        """Mirrors log_query.logs_window closely enough to hold the contract:
+
+        * `port` actually filters, and every requested port is recorded. Without
+          this the tests would still pass if `_confirm_tx` stopped scoping its
+          queries, and a `Started Tx` from a *different* attached node could
+          falsely confirm our send — a live risk on a bench where several nodes
+          share a channel.
+        * `grep` is applied BEFORE the max_lines cap, and the cap keeps the most
+          recent N. Emulating that ordering is what makes
+          `test_tx_line_survives_a_chatty_log` meaningful.
+        """
         grep = kwargs.get("grep")
         max_lines = kwargs.get("max_lines", 200)
+        port = kwargs.get("port")
+        state["ports_queried"].append(port)
+
         lines = state["log_lines"]
+        if port is not None:
+            lines = [line for line in lines if line.get("port") == port]
         if grep is not None:
             import re
 
@@ -154,6 +171,21 @@ def test_tx_line_survives_a_chatty_log(stub_query):
     stub_query["log_lines"] += [_log_line(f"Router: sniffing {i}") for i in range(500)]
     confirmed, _latency, reason = stub_query["server"]._confirm_tx(PID, "/dev/ttyACM1", 5.0)
     assert confirmed is True, f"grep-filtered lookup should survive log volume: {reason}"
+
+
+def test_tx_on_another_port_does_not_confirm(stub_query):
+    """A `Started Tx` for our id but logged against a *different* node must not
+    confirm. Packet ids are only 32 bits and several nodes commonly share a
+    bench and a channel, so an unscoped query could confirm off another radio's
+    logs. Guards that `_confirm_tx` keeps passing `port` down."""
+    stub_query["log_lines"] = [
+        _log_line("Started Tx (id=0x8738a6d9 fr=0x1 to=0xffffffff)", port="/dev/ttyUSB0"),
+    ]
+    confirmed, _latency, _reason = stub_query["server"]._confirm_tx(PID, "/dev/ttyACM1", 0.5)
+    assert confirmed is not True, "must not confirm from another port's logs"
+    assert "/dev/ttyACM1" in stub_query["ports_queried"], (
+        f"queries must be scoped to the target port, saw {stub_query['ports_queried']}"
+    )
 
 
 def test_truncated_packet_window_is_flagged_when_unobservable(stub_query):

--- a/tests/unit/test_wait_for_tx.py
+++ b/tests/unit/test_wait_for_tx.py
@@ -5,11 +5,17 @@
 
 The original implementation polled the recorder's *packet* stream for the
 packet it had just sent. That stream is fed by the `meshtastic.receive` pubsub
-topic (see `recorder/recorder.py`), which carries packets the node **received**
-— a node's own transmission is never published there. So the check could never
-succeed for locally-originated traffic and reported `tx_confirmed: false` even
-when the message was verifiably delivered (reproduced on a T-Beam S3: the peer
-decoded the broadcast while the sender reported failure).
+topic (see `recorder/recorder.py`), which a self-originated packet never
+reaches: the firmware echoes the packet back but omits the now-redundant `from`
+field, and `MeshInterface._handlePacketFromRadio` treats a missing `from` as
+"Device returned a packet we sent, ignoring" and returns before publishing.
+
+So the check could never succeed for locally-originated traffic and reported
+`tx_confirmed: false` even when the message was verifiably delivered (reproduced
+on a T-Beam S3: the peer decoded the broadcast while the sender reported
+failure; separately an RTL-SDR observed the 0.32 s burst on air while the
+firmware-side check still said false). `rf_oracle.confirm_tx` documents the same
+constraint for its `firmware_self_reported_tx` field.
 
 The firmware does log the transmission, with the packet id in lowercase hex:
 

--- a/tests/unit/test_wait_for_tx.py
+++ b/tests/unit/test_wait_for_tx.py
@@ -1,0 +1,129 @@
+# SPDX-FileCopyrightText: Meshtastic contributors
+# SPDX-License-Identifier: GPL-3.0-only
+
+"""`send_text(wait_for_tx=True)` must confirm against evidence that can exist.
+
+The original implementation polled the recorder's *packet* stream for the
+packet it had just sent. That stream is fed by the `meshtastic.receive` pubsub
+topic (see `recorder/recorder.py`), which carries packets the node **received**
+— a node's own transmission is never published there. So the check could never
+succeed for locally-originated traffic and reported `tx_confirmed: false` even
+when the message was verifiably delivered (reproduced on a T-Beam S3: the peer
+decoded the broadcast while the sender reported failure).
+
+The firmware does log the transmission, with the packet id in lowercase hex:
+
+    enqueue for send (id=0x8738a6d9 ...)     <- queued, may still never key up
+    Started Tx (id=0x8738a6d9 ...)           <- the radio actually transmitted
+
+`Started Tx` is the signal that matters: the linger bug (PR #18) was precisely
+a packet that got *enqueued* and then killed before airtime, so confirming on
+the enqueue line would reintroduce a false positive.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+PID = 2268636889  # 0x8738a6d9 — a real id observed on hardware
+
+
+def _log_line(text: str) -> dict[str, Any]:
+    return {"ts": 1784837044.0, "port": "/dev/ttyACM1", "line": text}
+
+
+@pytest.fixture
+def stub_query(monkeypatch):
+    """Stub the recorder queries; tests set `state` to shape what's visible.
+
+    `server` is imported lazily (inside the fixture, not at module scope) —
+    importing it at import time wires the recorder's pubsub subscriptions
+    before conftest's session fixture registers its own, which makes pubsub
+    reject the latter with a ListenerMismatchError. Same pattern as
+    `test_mcp_surface.py`.
+    """
+    from meshtastic_mcp import server
+
+    state: dict[str, Any] = {"log_lines": [], "packets": [], "server": server}
+
+    def fake_logs_window(*_a, **kwargs):
+        grep = kwargs.get("grep")
+        lines = state["log_lines"]
+        if grep is not None:
+            import re
+
+            rx = re.compile(grep)
+            lines = [line for line in lines if rx.search(line["line"])]
+        return {"lines": lines, "total_matched": len(lines)}
+
+    def fake_packets_window(*_a, **_kw):
+        return {"packets": state["packets"], "total_matched": len(state["packets"])}
+
+    monkeypatch.setattr(server.log_query, "logs_window", fake_logs_window)
+    monkeypatch.setattr(server.log_query, "packets_window", fake_packets_window)
+    monkeypatch.setattr(server.time, "sleep", lambda _s: None)
+    return state
+
+
+def test_confirms_on_started_tx_log(stub_query):
+    """The firmware's `Started Tx (id=0x...)` line confirms transmission."""
+    stub_query["log_lines"] = [
+        _log_line("enqueue for send (id=0x8738a6d9 fr=0xf8f277b5 to=0xffffffff)"),
+        _log_line("Started Tx (id=0x8738a6d9 fr=0xf8f277b5 to=0xffffffff len=102)"),
+    ]
+    confirmed, _latency, reason = stub_query["server"]._confirm_tx(PID, "/dev/ttyACM1", 5.0)
+    assert confirmed is True, f"expected confirmation from Started Tx, got {reason}"
+
+
+def test_enqueue_alone_is_not_confirmation(stub_query):
+    """`enqueue for send` without `Started Tx` must NOT confirm — that is exactly
+    the PR #18 failure mode (queued, then killed before airtime)."""
+    stub_query["log_lines"] = [
+        _log_line("enqueue for send (id=0x8738a6d9 fr=0xf8f277b5 to=0xffffffff)"),
+    ]
+    confirmed, _latency, _reason = stub_query["server"]._confirm_tx(PID, "/dev/ttyACM1", 0.5)
+    assert confirmed is False, "enqueue alone must not count as transmitted"
+
+
+def test_other_packet_id_does_not_confirm(stub_query):
+    """A `Started Tx` for a different packet must not confirm ours."""
+    stub_query["log_lines"] = [_log_line("Started Tx (id=0xdeadbeef fr=0x1 to=0xffffffff)")]
+    confirmed, _latency, _reason = stub_query["server"]._confirm_tx(PID, "/dev/ttyACM1", 0.5)
+    assert confirmed is False
+
+
+def test_rebroadcast_in_packet_stream_confirms(stub_query):
+    """A neighbour's rebroadcast carries our packet id back to us — also proof
+    it reached the air, even with no log capture."""
+    stub_query["packets"] = [{"id": PID, "portnum": "TEXT_MESSAGE_APP"}]
+    confirmed, _latency, _reason = stub_query["server"]._confirm_tx(PID, "/dev/ttyACM1", 5.0)
+    assert confirmed is True
+
+
+def test_no_log_capture_reports_unknown_not_failure(stub_query):
+    """With no log lines captured at all there is no evidence channel, so the
+    result must be `None` (unknown) — NOT `False`, which reads as 'it failed'.
+    This is the regression that made a working mesh look broken."""
+    stub_query["log_lines"] = []
+    stub_query["packets"] = []
+    confirmed, _latency, reason = stub_query["server"]._confirm_tx(PID, "/dev/ttyACM1", 0.5)
+    assert confirmed is None, "no observability must be reported as unknown, not failure"
+    assert reason and "debug_log_api" in reason, f"reason should point at the fix: {reason}"
+
+
+def test_evidence_channel_present_but_no_tx_is_false(stub_query):
+    """When logs ARE flowing and no TX line appears, `False` is a real signal."""
+    stub_query["log_lines"] = [_log_line("Node status update: 0 online, 20 total")]
+    confirmed, _latency, _reason = stub_query["server"]._confirm_tx(PID, "/dev/ttyACM1", 0.5)
+    assert confirmed is False
+
+
+def test_missing_packet_id_reports_unknown(stub_query):
+    """Without a packet id there is nothing to match on — don't guess by
+    matching 'any recent TEXT packet', which the old code did."""
+    stub_query["log_lines"] = [_log_line("Started Tx (id=0x8738a6d9 fr=0x1 to=0xffffffff)")]
+    confirmed, _latency, reason = stub_query["server"]._confirm_tx(None, "/dev/ttyACM1", 0.5)
+    assert confirmed is None
+    assert reason and "packet id" in reason

--- a/tests/unit/test_wait_for_tx.py
+++ b/tests/unit/test_wait_for_tx.py
@@ -49,17 +49,32 @@ def stub_query(monkeypatch):
     state: dict[str, Any] = {"log_lines": [], "packets": [], "server": server}
 
     def fake_logs_window(*_a, **kwargs):
+        """Mirrors log_query.logs_window: grep is applied BEFORE the max_lines
+        cap, and the cap keeps the most recent N. Emulating the cap is what
+        makes `test_tx_line_survives_a_chatty_log` meaningful — without it the
+        test would pass no matter how the lookup was implemented."""
         grep = kwargs.get("grep")
+        max_lines = kwargs.get("max_lines", 200)
         lines = state["log_lines"]
         if grep is not None:
             import re
 
             rx = re.compile(grep)
             lines = [line for line in lines if rx.search(line["line"])]
-        return {"lines": lines, "total_matched": len(lines)}
+        matched = len(lines)
+        capped = lines[-max_lines:] if max_lines else lines
+        return {
+            "lines": capped,
+            "total_matched": matched,
+            "dropped": max(0, matched - max_lines),
+        }
 
     def fake_packets_window(*_a, **_kw):
-        return {"packets": state["packets"], "total_matched": len(state["packets"])}
+        return {
+            "packets": state["packets"],
+            "total_matched": len(state["packets"]),
+            "dropped": state.get("packets_dropped", 0),
+        }
 
     monkeypatch.setattr(server.log_query, "logs_window", fake_logs_window)
     monkeypatch.setattr(server.log_query, "packets_window", fake_packets_window)
@@ -118,6 +133,32 @@ def test_evidence_channel_present_but_no_tx_is_false(stub_query):
     stub_query["log_lines"] = [_log_line("Node status update: 0 online, 20 total")]
     confirmed, _latency, _reason = stub_query["server"]._confirm_tx(PID, "/dev/ttyACM1", 0.5)
     assert confirmed is False
+
+
+def test_tx_line_survives_a_chatty_log(stub_query):
+    """The TX line must be found even when swamped by unrelated firmware chatter.
+
+    `logs_window` applies `grep` *before* its max_lines cap, so pushing the
+    packet-id pattern down as the filter keeps the one line we need from being
+    truncated away. An unfiltered 2 min window on real hardware measured
+    total_matched=455 / dropped=395, so this is a live failure mode.
+    """
+    stub_query["log_lines"] = [_log_line(f"Node status update: {i} online") for i in range(500)]
+    stub_query["log_lines"].append(_log_line("Started Tx (id=0x8738a6d9 fr=0x1 to=0xffffffff)"))
+    stub_query["log_lines"] += [_log_line(f"Router: sniffing {i}") for i in range(500)]
+    confirmed, _latency, reason = stub_query["server"]._confirm_tx(PID, "/dev/ttyACM1", 5.0)
+    assert confirmed is True, f"grep-filtered lookup should survive log volume: {reason}"
+
+
+def test_truncated_packet_window_is_flagged_when_unobservable(stub_query):
+    """No log channel + a truncated packet window => we cannot rule out that a
+    rebroadcast was dropped, so say so rather than implying clean observation."""
+    stub_query["log_lines"] = []
+    stub_query["packets"] = []
+    stub_query["packets_dropped"] = 4200
+    confirmed, _latency, reason = stub_query["server"]._confirm_tx(PID, "/dev/ttyACM1", 0.5)
+    assert confirmed is None
+    assert "truncated" in reason, f"truncation should be surfaced: {reason}"
 
 
 def test_missing_packet_id_reports_unknown(stub_query):


### PR DESCRIPTION
## Problem (hardware-reproduced)

`send_text(wait_for_tx=True)` returns `tx_confirmed: false` for messages that **are** delivered.

Reproduced on a T-Beam S3 → Heltec V3 pair: the peer decoded the broadcast (packet id `4041547107` matching the sent id, SNR 5.5 / RSSI −45) while the sender reported failure. An agent trusting `tx_confirmed` would conclude a healthy mesh was broken.

## Root cause

The check polled the recorder's **packet** stream for the packet it had just sent:

```python
window = log_query.packets_window(start="-1m", portnum="TEXT_MESSAGE_APP", max=50)
```

That stream is fed by the `meshtastic.receive` pubsub topic (`recorder/recorder.py:145`), which carries only packets the node **received**. A node's own transmission is never published there, so the confirmation could never succeed for locally-originated traffic — a structural false negative, not a timing issue.

Confirmed on hardware: **zero** `TEXT_MESSAGE_APP` packets in the recorder across four sends, one of which a second node provably received.

## Fix

The firmware logs the transmission, with the packet id in lowercase hex:

```
enqueue for send (id=0x8738a6d9 ...)   <- queued, may still never key up
Started Tx (id=0x8738a6d9 ...)         <- the radio actually transmitted
```

`_confirm_tx` matches `Started Tx`, plus a neighbour's rebroadcast arriving back with our id (also proof it reached the air, and works with no log capture).

Deliberately **not** `enqueue for send`: a packet can be enqueued and then killed before airtime — precisely the bug fixed in #18 — so matching the enqueue line would trade a false negative for a false positive.

### `tx_confirmed` is now three-valued

Absence of evidence is not evidence of failure. The log path only reaches the recorder when `set_debug_log_api(True)` is on (or a `serial_session` taps the port).

| value | meaning |
| --- | --- |
| `true` | transmission observed |
| `false` | logs were flowing and showed no TX — a real failure signal |
| `null` | not observable — **not** a failure; `tx_unconfirmed_reason` points at `set_debug_log_api(True)` |

Also drops the old `packet_id is None` fallback that confirmed on *any* recent TEXT packet — it could match an unrelated message from another node.

## Docs

`AGENTS.md` documented the same broken pattern (`packets_window` to confirm a local send). Corrected in the workflow section and added to the anti-patterns list, since that guidance actively leads agents into this trap.

## Validation

Hardware, on the same T-Beam that reported `false`:

- `tx_confirmed=True`, latency 0.07 s
- `True` on a second independent node (Heltec V3)
- `null` + the guidance reason when no logs are captured

7 new unit tests covering all three states, both evidence sources, the enqueue-is-not-confirmation case, and the wrong-packet-id case. 29 passed across `test_wait_for_tx` / `test_mcp_surface` / `test_tool_annotations` / `test_linger_tx_race`. ruff + mypy clean.

Found while exercising the MCP after #18 merged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved “wait for transmission” confirmation by validating over-the-air transmission evidence.
  - Transmission status is now tri-state: confirmed, not confirmed, or unknown (with an explanatory reason when unknown).

- **Documentation**
  - Rewrote “send a message and confirm delivery” guidance, including correct waiting/timeout practices and interpretation of confirmation/ack signals.
  - Clarified why local sends don’t appear as observable receive/packet-window evidence.

- **Tests**
  - Added unit tests covering confirmed/not-confirmed/unknown cases and edge conditions (e.g., log truncation and port scoping).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->