### PR TITLE
fix(tests): read power-off from the hub flag everywhere, not OS enumeration

### DIFF
--- a/src/meshtastic_mcp/uhubctl.py
+++ b/src/meshtastic_mcp/uhubctl.py
@@ -218,14 +218,28 @@ def device_on_port(location: str, port: int) -> bool:
     powered/present. Prefer it over OS USB enumeration: on macOS a device
     RETAINS a zombie entry in ``ioreg`` / ``system_profiler`` / ``/dev`` for an
     unbounded time after a VBUS cut, so those sources report a powered-off
-    device as still present. The hub reports the disconnect immediately."""
+    device as still present. The hub reports the disconnect immediately.
+
+    Raises `UhubctlError` when the slot itself can't be seen (hub missing from
+    the listing, or no such port on it). That case must NOT be reported as
+    "no device attached": a caller polling for absence would take a hub that
+    vanished — unplugged, re-lettered, or a permission failure — as proof that
+    power was cut, and pass a test that never actually observed a disconnect.
+    """
     for hub in list_hubs():
         if hub["location"] != location:
             continue
         for p in hub["ports"]:
             if p["port"] == port:
                 return p.get("device_vid") is not None
-    return False
+        raise UhubctlError(
+            f"hub {location} has no port {port} — cannot read its connect flag "
+            f"(ports: {[p['port'] for p in hub['ports']]})"
+        )
+    raise UhubctlError(
+        f"hub {location} is not in the uhubctl listing — cannot read the connect "
+        f"flag for port {port}. Absence is UNKNOWN, not confirmed."
+    )
 
 
 def resolve_target(role: str) -> tuple[str, int]:

--- a/tests/mesh/test_nexthop_multihop_recovery.py
+++ b/tests/mesh/test_nexthop_multihop_recovery.py
@@ -39,6 +39,7 @@ from typing import Any
 
 import pytest
 
+from meshtastic_mcp import uhubctl
 from meshtastic_mcp.connection import connect
 from tests import _power
 from tests._port_discovery import resolve_port_by_role
@@ -281,14 +282,21 @@ def test_multihop_relay_recovery(
                 is not None
             ), "baseline multi-hop delivery failed — skipping recovery to avoid a false result"
 
-    # Power the relay OFF.
+    # Power the relay OFF. Absence MUST come from the hub connect flag: the
+    # legacy OS-enumeration check asks "is any device with this role's VID still
+    # present anywhere", which can never go false when the relay is one of the
+    # three same-VID (0x239a) nRF52 boards — the other two stay powered. That
+    # raised TimeoutError, which this except swallowed into a pytest.skip, so the
+    # whole multi-hop recovery test quietly skipped every single run.
+    relay_slot: tuple[str, int] | None = None
     try:
-        _power.power_off(relay_role)
-        _power.wait_for_absence(relay_role, timeout_s=15.0)
+        relay_slot = uhubctl.resolve_target(relay_role)
+        _power.power_off(relay_role, resolved=relay_slot)
+        _power.wait_for_absence(relay_role, timeout_s=15.0, resolved=relay_slot)
     except Exception as exc:
         try:
-            _power.power_on(relay_role)
-            resolve_port_by_role(relay_role, timeout_s=30.0)
+            _power.power_on(relay_role, resolved=relay_slot)
+            resolve_port_by_role(relay_role, timeout_s=30.0, require_openable=True)
         except Exception:
             pass
         pytest.skip(f"can't power-control relay {relay_role!r}: {exc}")
@@ -305,15 +313,15 @@ def test_multihop_relay_recovery(
             assert pkt is not None
             time.sleep(8.0)  # let retransmissions + route decay run
     except Exception as exc:
-        _power.power_on(relay_role)
-        resolve_port_by_role(relay_role, timeout_s=30.0)
+        _power.power_on(relay_role, resolved=relay_slot)
+        resolve_port_by_role(relay_role, timeout_s=30.0, require_openable=True)
         raise AssertionError(f"TX crashed sending across a downed relay: {exc}") from exc
 
     # Power the relay back ON and let it re-enumerate + boot.
-    _power.power_on(relay_role)
+    _power.power_on(relay_role, resolved=relay_slot)
     time.sleep(0.5)
     try:
-        resolve_port_by_role(relay_role, timeout_s=30.0)
+        resolve_port_by_role(relay_role, timeout_s=30.0, require_openable=True)
     except Exception:
         pass
     time.sleep(8.0)

--- a/tests/mesh/test_peer_offline_recovery.py
+++ b/tests/mesh/test_peer_offline_recovery.py
@@ -143,10 +143,17 @@ def test_peer_offline_then_recovers(
                 lambda pkt: pkt.get("decoded", {}).get("text") == unique_pre,
                 timeout=30,
             )
-            assert got is not None, (
-                f"baseline directed send ({tx_role}→{rx_role}) didn't land — "
-                "skipping offline test to avoid false positive"
-            )
+            # Report WHAT the RX actually saw. Whether the collector was dead
+            # (saw nothing at all) or the peer refused just our directed frame
+            # (saw other traffic) picks the fix, and the bare "didn't land"
+            # message could not tell those apart — so don't guess, capture it.
+            if got is None:
+                seen = [p.get("decoded", {}).get("text") for p in rx.snapshot()]
+                pytest.fail(
+                    f"baseline directed send ({tx_role}→{rx_role}) didn't land — "
+                    f"skipping offline test to avoid a false positive. RX observed "
+                    f"{len(seen)} text packet(s): {seen!r}"
+                )
 
     # Step 3: power off RX. Resolve its hub slot NOW, while it's still up — a
     # powered-off device can't be VID-resolved, and keying power on/off + the

--- a/tests/recovery/test_power_cycle_roundtrip.py
+++ b/tests/recovery/test_power_cycle_roundtrip.py
@@ -49,26 +49,34 @@ def test_power_cycle_preserves_node_identity(
 
     # The pre_info handshake (and baked_single's earlier probe) can leave a serial
     # fd open on a daemon close-thread (connection._close_bounded abandons a slow
-    # close after 5s). On macOS a held fd pins the CDC node in the IORegistry, so
-    # a VBUS cut would NOT remove the device from list_devices until that fd
-    # closes — which is what made wait_for_absence time out. Drain it (and clear
-    # any leaked in-process port lock) BEFORE cutting power.
+    # close after 5s). Drain it (and clear any leaked in-process port lock) BEFORE
+    # cutting power so the CDC node tears down cleanly and the next open isn't
+    # fighting a stale handle.
+    #
+    # NB: draining is NOT what makes the absence check work. macOS retains a
+    # zombie of a powered-off device in ioreg/`/dev` even with no fd held, which
+    # is why absence is read from the hub connect flag below rather than from OS
+    # enumeration.
     _power.drain_port_fd(pre_port, timeout_s=8.0)
 
     try:
-        # Power off; confirm THIS device's node disappears (match the exact path,
-        # not just the VID, so a second same-VID adapter can't spoof presence).
+        # Power off; confirm the device leaves THIS hub slot. The slot is
+        # strictly more specific than a /dev path — it can't be spoofed by a
+        # same-VID sibling — and unlike OS enumeration it reports the
+        # disconnect immediately instead of retaining a macOS zombie of the
+        # powered-off device (which is what made this check time out).
         _power.power_off(role, resolved=slot)
         try:
-            _power.wait_for_absence(role, timeout_s=20.0, expected_port=pre_port)
+            _power.wait_for_absence(role, timeout_s=20.0, resolved=slot)
         except TimeoutError:
             # A racy/incomplete first VBUS cut — re-issue once before giving up.
             _power.power_off(role, resolved=slot)
             try:
-                _power.wait_for_absence(role, timeout_s=15.0, expected_port=pre_port)
+                _power.wait_for_absence(role, timeout_s=15.0, resolved=slot)
             except TimeoutError:
                 pytest.fail(
-                    f"device {role!r} (port {pre_port}) stayed visible after power_off (twice)"
+                    f"device {role!r} stayed attached to hub slot "
+                    f"{slot[0]}:{slot[1]} after power_off (twice)"
                 )
 
         # Power back on + re-discover. ensure_port_responsive re-enumerates a
@@ -76,7 +84,7 @@ def test_power_cycle_preserves_node_identity(
         # below hits a live device, not a stale ghost.
         _power.power_on(role, resolved=slot)
         time.sleep(0.5)  # head-start before polling
-        new_port = resolve_port_by_role(role, timeout_s=30.0)
+        new_port = resolve_port_by_role(role, timeout_s=30.0, require_openable=True)
         new_port = port_recovery.ensure_port_responsive(new_port, role=role, reenum_timeout_s=30.0)
 
         post_info = info.device_info(port=new_port, timeout_s=10.0)

--- a/tests/recovery/test_recovery_ladder.py
+++ b/tests/recovery/test_recovery_ladder.py
@@ -20,7 +20,10 @@ from tests import _power, _recovery
 from tests._port_discovery import resolve_port_by_role
 
 
-@pytest.mark.timeout(180)
+# The ladder body — heal (reboot attempt → power_cycle) → re-resolve → identity
+# handshake — has never actually executed on this bench: every run died at the
+# absence check before reaching it, so 180 s was never a measured budget.
+@pytest.mark.timeout(360)
 def test_ladder_recovers_a_dead_node(baked_single: dict[str, object]) -> None:
     role = baked_single["role"]
     port = baked_single["port"]
@@ -29,20 +32,29 @@ def test_ladder_recovers_a_dead_node(baked_single: dict[str, object]) -> None:
     healthy, detail = recovery.is_healthy(port, timeout_s=5.0)
     assert healthy, f"{role} not healthy before test: {detail}"
 
-    # Resolve the hub slot ONCE, while the device is still visible — once it's
-    # powered off, resolve_target can't find it (its VID is gone from every hub)
-    # and would raise, so the finally could never restore the bench.
+    # Resolve the hub slot ONCE, up front. Env pins (seeded by
+    # conftest.pytest_configure) resolve even a powered-off board, but resolving
+    # here keeps one authority for both the cut and the restore.
     slot = uhubctl.resolve_target(role)
 
     # Wedge it: cut power so a soft reboot can't reach it.
     _power.power_off(role, resolved=slot)
-    _power.wait_for_absence(role, timeout_s=10.0)
+    # Absence MUST come from the hub's connect flag for this slot. The legacy
+    # OS-enumeration check is unusable here twice over: macOS retains a zombie of
+    # a powered-off device indefinitely, AND the VID-any predicate is
+    # unsatisfiable for the nRF52 roles — t_echo, heltec_t114 and rak4631 all
+    # report 0x239a, so cutting one leaves two siblings enumerated and the
+    # "no device with this VID anywhere" condition can never become true.
+    _power.wait_for_absence(role, timeout_s=10.0, resolved=slot)
     try:
         # reboot fails (it's gone) → power_cycle revives it.
         report = _recovery.heal(port, role=role)
     finally:
         _power.power_on(role, resolved=slot)  # never leave it dark for the next test
-        resolve_port_by_role(role, timeout_s=30.0)
+        # require_openable: the hub flag flips back the moment VBUS returns, but
+        # an nRF52 CDC can re-enumerate on a path that lists and then vanishes.
+        # Don't hand the next test a port that won't open.
+        resolve_port_by_role(role, timeout_s=30.0, require_openable=True)
 
     assert report["recovered"], f"ladder did not recover {role}: {report}"
     assert report["final_step"] in ("power_cycle", "reappeared"), report
@@ -53,7 +65,7 @@ def test_ladder_recovers_a_dead_node(baked_single: dict[str, object]) -> None:
     )
 
     # Identity preserved — a hard reset, not a re-flash.
-    new_port = resolve_port_by_role(role, timeout_s=30.0)
+    new_port = resolve_port_by_role(role, timeout_s=30.0, require_openable=True)
     time.sleep(2.0)
     post = info.device_info(port=new_port, timeout_s=10.0)
     assert post.get("my_node_num") == node_num, (

--- a/tests/test_00_bake.py
+++ b/tests/test_00_bake.py
@@ -136,12 +136,21 @@ def _prepare_nrf52_for_upload(port: str) -> str:
         except Exception as exc:
             print(f"[bake] {port}: inter-round power-cycle unavailable ({exc}); re-touching")
             continue
+        # `uhubctl.cycle` blocks through off→delay→on, so the slot's connect
+        # flag is already back to True the moment it returns — it proves nothing
+        # about the board being ready. And macOS can still be reporting the
+        # PRE-cut node on this slot (it retains a zombie of a powered-off device),
+        # so the first candidate is frequently a stale path that accepts nothing:
+        # the touch then lands on a dead node and the round is wasted. Require a
+        # path that actually OPENS before touching it.
         deadline = time.monotonic() + _DFU_REENUM_TIMEOUT_S
         while time.monotonic() < deadline:
             candidate = port_recovery.port_on_slot(hub, slot)
             if candidate:
-                port = candidate
-                break
+                openable, _ = port_recovery.port_openable(candidate, exclusive=True, timeout=1.0)
+                if openable:
+                    port = candidate
+                    break
             time.sleep(0.5)
         time.sleep(2.0)  # app boot settle — a touch mid-boot is ignored
     if not result.get("ok"):

--- a/tests/unit/test_hub_power_probe.py
+++ b/tests/unit/test_hub_power_probe.py
@@ -33,8 +33,13 @@ def test_device_on_port_reads_hub_connect_flag(monkeypatch):
     monkeypatch.setattr(uhubctl, "list_hubs", lambda: hubs)
     assert uhubctl.device_on_port("20-3", 7) is True
     assert uhubctl.device_on_port("20-3", 5) is False
-    assert uhubctl.device_on_port("20-3", 3) is False  # unknown port
-    assert uhubctl.device_on_port("99-9", 7) is False  # unknown hub
+    # A slot we cannot SEE is not the same as a slot with nothing on it. If the
+    # hub drops out of the listing, reporting False would let an absence poll
+    # conclude "power was cut" without ever observing a disconnect.
+    with pytest.raises(uhubctl.UhubctlError):
+        uhubctl.device_on_port("20-3", 3)  # no such port on this hub
+    with pytest.raises(uhubctl.UhubctlError):
+        uhubctl.device_on_port("99-9", 7)  # hub not in the listing
 
 
 def test_wait_for_absence_returns_when_hub_drops_device(monkeypatch):


### PR DESCRIPTION
## Problem

Nightly #10 failed 14 tests. Six were the recovery tier — and they were never
flakes, they could not have passed.

`tests/_power.wait_for_absence`'s legacy branch asks *"is any device carrying this
role's VID still present anywhere?"*. On this bench `t_echo`, `heltec_t114` and
`rak4631` **all enumerate as 0x239a**, so cutting one leaves two siblings powered
and the predicate is **unsatisfiable**. Independently, macOS retains a zombie of a
powered-off device in `ioreg`/`/dev` indefinitely, so even the VID-unique
`esp32s3` never went absent either.

`bda233e` introduced the hub-connect-flag path but converted **one of five** call
sites. The other four were left on the broken branch.

## Fixes

- **`test_recovery_ladder` / `test_power_cycle_roundtrip`** — pass the hub slot
  they had *already resolved* into `wait_for_absence`. Both now re-resolve with
  `require_openable`, so a flapping nRF52 CDC can't hand the next test a path that
  vanishes on open. The ladder's 180 s budget was never a measured number (every
  run died at the absence check before the body ran) → 360 s.
- **`test_nexthop_multihop_recovery`** — same broken call, but wrapped in
  `except Exception → pytest.skip`. Whenever the relay was an nRF52 the entire
  multi-hop recovery test **skipped silently on every run** — invisible coverage
  loss inside the 143 skips, never surfacing as a failure. (The file also never
  imported `uhubctl`.)
- **`uhubctl.device_on_port`** — raise instead of returning `False` when the slot
  can't be seen. A hub missing from the listing was indistinguishable from an
  empty port, so an absence poll would accept a *vanished hub* as proof that power
  had been cut.
- **`test_00_bake`** — `uhubctl.cycle` blocks through off→delay→on, so the connect
  flag is already `True` on return and proves nothing; macOS may still be
  reporting the pre-cut node. The post-cycle wait accepted that stale path
  instantly and touched a dead node, wasting the round. Now requires a path that
  actually opens. (T114 DFU entry; its failed bake is why the T114 sits on the
  default channel and every T114 mesh pair skips.)
- **`test_peer_offline_recovery`** — the one genuine mesh failure now reports what
  the RX actually observed, so the next occurrence distinguishes "collector was
  dead" from "peer refused our directed frame" instead of being guessed at.

## Verification

`ruff` clean; `tests/unit/test_hub_power_probe.py` + `test_port_reconnect_hardening.py`
**13 passed**, including the new `device_on_port` raise-on-unseeable-slot contract.
Hardware run of the recovery tier attached below.

## Not included

`ui fn_f5` timeout and `admin port-busy` remain. An adversarial review showed the
obvious fix for the UI hang would shorten the node-DB handshake from 30 s to 8 s
for **every production serial call** — a field regression. Those need narrower
treatment and are deliberately left out of this batch.
