### PR TITLE
fix(android): locate built APK by tree search, not a hardcoded module dir

### DIFF
--- a/scripts/build_android_apk.sh
+++ b/scripts/build_android_apk.sh
@@ -51,9 +51,26 @@ echo ">> building Meshtastic-Android ($VARIANT) at $SHA"
 chmod +x ./gradlew
 ./gradlew --no-daemon "$VARIANT"
 
-# Locate the produced APK.  Prefer the authoritative path from `android describe`
-# (build-target metadata incl. output artifacts); fall back to globbing, preferring a
-# universal artifact so we never install an arch-specific split on the x86_64 emulator.
+# Build type is the trailing PascalCase word of the variant (assembleFdroidDebug
+# -> debug, assembleRelease -> release). Gradle always writes the APK under a
+# .../<buildType>/ dir, so we scope the search to it — matching a release APK
+# when we built debug (or vice-versa) would silently install the wrong thing.
+BUILD_TYPE="$(printf '%s' "$VARIANT" | sed -E 's/.*([A-Z][a-z]+)$/\1/' | tr '[:upper:]' '[:lower:]')"
+
+# Locate the produced APK. Prefer the authoritative path from `android describe`
+# (build-target metadata incl. output artifacts) when that CLI is present and
+# reports one; otherwise search the tree. Do NOT hardcode the module dir: the app
+# module has moved between Meshtastic-Android layouts (`app/` -> `androidApp/`),
+# which silently broke this script's old `app/build/outputs/apk` glob. Instead
+# glob every `*/build/outputs/apk/**` (library modules emit .aar, not .apk, so an
+# .apk match is the app), scoped to this build type, preferring a universal
+# artifact so we never install an arch-specific split on the x86_64 emulator.
+# androidTest / unsigned artifacts are never installable, so exclude them.
+_find_apk() {  # $1 = -name pattern
+  find . -type f -path '*/build/outputs/apk/*' -path "*/${BUILD_TYPE}/*" \
+    -name "$1" ! -name '*unsigned*' ! -path '*androidTest*' 2>/dev/null | sort | head -1
+}
+
 APK=""
 if command -v android >/dev/null 2>&1; then
   APK="$(android describe --project_dir . 2>/dev/null \
@@ -67,10 +84,13 @@ for p in (univ or cands):
     if os.path.isfile(p): print(p); break' 2>/dev/null)"
 fi
 if [ -z "$APK" ]; then
-  APK="$(find app/build/outputs/apk -name '*universal*.apk' ! -name '*unsigned*' 2>/dev/null | sort | head -1)"
-  [ -n "$APK" ] || APK="$(find app/build/outputs/apk -name '*.apk' ! -name '*unsigned*' 2>/dev/null | sort | head -1)"
+  APK="$(_find_apk '*universal*.apk')"
+  [ -n "$APK" ] || APK="$(_find_apk '*.apk')"
 fi
-[ -n "$APK" ] && [ -f "$APK" ] || { echo "no APK produced under app/build/outputs/apk" >&2; exit 1; }
+[ -n "$APK" ] && [ -f "$APK" ] || {
+  echo "no installable ${BUILD_TYPE} APK found under any */build/outputs/apk (variant $VARIANT)" >&2
+  exit 1
+}
 
 if [ -n "$DEST" ]; then
   cp "$APK" "$DEST"


### PR DESCRIPTION
## Problem

`scripts/build_android_apk.sh` locates the built APK by globbing `app/build/outputs/apk`. Current Meshtastic-Android renamed the app module `app/` → `androidApp/`, so that glob matches nothing and the script exits 1 **after a fully successful Gradle build**:

```
no APK produced under app/build/outputs/apk
```

## Impact

This silently breaks the **`android-e2e` CI job** whenever `android_ref` is set. That job installs Google's `android` CLI only *after* the build step (`.github/workflows/ci.yml`), so `command -v android` is false during the build and CI relies **entirely** on this fallback glob — the exact path that no longer exists. The build passes, then artifact resolution fails.

Reproduced locally against a current checkout: Gradle `BUILD SUCCESSFUL`, script errors, no APK.

## Fix

Stop hardcoding the module dir. Search every `*/build/outputs/apk/**` (library modules emit `.aar`, not `.apk`, so an `.apk` match is the app), scoped to the variant's build type via a `/<buildType>/` path component derived from the variant name (`assembleFdroidDebug` → `debug`), excluding `androidTest`/`unsigned` artifacts and preferring a universal APK over an arch split.

- **Layout-agnostic** — survives the `app/` → `androidApp/` move and any future one.
- **No freshness marker** — so it also works on an incremental build where Gradle leaves the APK `UP-TO-DATE` (a marker-based approach would wrongly reject that).
- Build-type scoping means we never install a `release` APK when `debug` was built, or vice-versa.

The `android describe` primary path and the `--dest` / `android-sha=` contract are unchanged.

## Verification

**End-to-end against a real checkout** (`androidApp` @ `34140eaf2`), including an incremental rebuild (295 up-to-date tasks):

```
>> copied -> .../apk-fix-verify.apk
android-sha=34140eaf2          # the line CI parses
SCRIPT_EXIT=0
```

Selected `androidApp/build/outputs/apk/fdroid/debug/androidApp-fdroid-universal-debug.apk` (62M universal, valid APK).

**Selection logic against a fixture** with decoys — unsigned release, `androidTest` apk, library `.aar`, arch splits:
- new logic → the universal debug apk
- old glob → nothing (the bug)

`BUILD_TYPE` derivation checked for `assembleFdroidDebug`/`assembleRelease`/`assembleDebug`/`assembleGoogleFdroidRelease`. `bash -n` clean; SPDX header intact.