### PR TITLE
feat(nightly): flag self-contradictory local-model summaries

### DIFF
--- a/src/meshtastic_mcp/web/services/nightly_analysis.py
+++ b/src/meshtastic_mcp/web/services/nightly_analysis.py
@@ -86,6 +86,74 @@ VISION_QUESTION = (
     "Does this device screen show an error, crash, garbled rendering, or a blank/frozen display?"
 )
 
+# BEHAVIOR_SYSTEM tells the model to say "nothing notable" when a window is
+# clean, and small models take that opening even when the window is not clean:
+# in a 3-run bench on raw soak logs, granite4:tiny-h led every single reply with
+# "SOAK window clean, no reboots" and then listed a watchdog reboot underneath.
+# An operator skimming the first line reads the opposite of the truth. Detect
+# that shape and label it rather than depending on which model is configured.
+_ALL_CLEAR_RE = re.compile(
+    r"nothing notable"
+    r"|(?:window|log|soak|night)\b[^.\n]{0,24}\bclean\b"
+    r"|\bno (?:reboots?|issues|anomalies|errors|problems|failures)\b",
+    re.IGNORECASE,
+)
+# "window is not clean" / "far from clean" is an honest dirty report, not a claim.
+_NEGATED_CLEAN_RE = re.compile(
+    r"\b(?:not|isn't|wasn't|never|hardly|far from|other than)\b[^.\n]{0,24}\bclean\b",
+    re.IGNORECASE,
+)
+_ANOMALY_RE = re.compile(
+    r"\b(?:reboot|watchdog|wdt|brownout|crc|retransmi\w*|panic|crash|"
+    r"stack overflow|corrupt|silence|silent|timeout|storm)\b",
+    re.IGNORECASE,
+)
+# A clause that denies something uses anomaly words innocently ("no reboots or
+# unexpected silence observed"), so it must not count as anomaly evidence.
+_NEGATED_CLAUSE_RE = re.compile(r"\b(?:no|not|never|without|n't)\b", re.IGNORECASE)
+# ...except when the denial IS the finding ("no packets from !abc for 3600s").
+_ABSENCE_ANOMALY_RE = re.compile(
+    r"\bno (?:packets?|traffic|response|data|telemetry|contact|beacons?|heartbeats?)\b",
+    re.IGNORECASE,
+)
+CONTRADICTION_NOTE = (
+    "[guard] model claimed an all-clear but also listed anomalies below; "
+    "trust the bullets, not the claim"
+)
+
+
+def _clauses(text: str) -> list[str]:
+    """Split into clauses so a denial's scope stays local to its own sentence."""
+    out: list[str] = []
+    for line in text.splitlines():
+        out.extend(c for c in re.split(r"[;.]", line) if c.strip())
+    return out
+
+
+def flag_contradictory_all_clear(text: str) -> tuple[str, bool]:
+    """Prefix a warning when model output claims all-clear *and* lists anomalies.
+
+    Returns ``(text, flagged)``. Works clause by clause: a negated clause cannot
+    supply anomaly evidence, so an honest "no reboots or unexpected silence"
+    on a clean window does not trip the check on its own wording, and a negated
+    claim ("window is not clean") is not read as an all-clear. Absence findings
+    ("no packets from X") still count as anomalies.
+    """
+    if not text.strip():
+        return text, False
+    clauses = _clauses(text)
+    claimed = any(_ALL_CLEAR_RE.search(c) and not _NEGATED_CLEAN_RE.search(c) for c in clauses)
+    if not claimed:
+        return text, False
+    for c in clauses:
+        if _ABSENCE_ANOMALY_RE.search(c):
+            return f"{CONTRADICTION_NOTE}\n{text}", True
+        if _NEGATED_CLAUSE_RE.search(c):
+            continue
+        if _ANOMALY_RE.search(c):
+            return f"{CONTRADICTION_NOTE}\n{text}", True
+    return text, False
+
 
 @dataclass
 class Observation:
@@ -646,6 +714,7 @@ class Analyzer:
     async def _behavioral_logs(self) -> None:
         by_serial = self._soak_lines_by_serial()
         device_summaries: dict[str, str] = {}
+        flagged_devices: set[str] = set()
         for serial, recs in by_serial.items():
             chunks = self._chunks_for(recs)
             if not chunks:
@@ -670,7 +739,12 @@ class Analyzer:
                 if part.strip():
                     parts.append(part.strip())
             if parts:
-                device_summaries[serial] = "\n".join(parts)
+                # Record the flag but feed the model its own raw text: the note
+                # is operator-directed and must not steer the reduce prompt.
+                summary = "\n".join(parts)
+                if flag_contradictory_all_clear(summary)[1]:
+                    flagged_devices.add(serial)
+                device_summaries[serial] = summary
         if not device_summaries:
             return
         det = "\n".join(
@@ -695,13 +769,24 @@ class Analyzer:
         except local_model.LocalModelError as exc:
             log.info("behavioral fleet reduce failed: %s", exc)
             return
+        fleet, fleet_flagged = flag_contradictory_all_clear(fleet)
+        # A device-level contradiction still matters even if the reduce
+        # paraphrased it away, so carry those flags into the severity.
+        flagged = fleet_flagged or bool(flagged_devices)
         self.out.observations.append(
             Observation(
-                severity="info",
+                severity="warn" if flagged else "info",
                 category="behavior",
-                summary="local-model behavioral summary (draft — verify before acting)",
+                summary=(
+                    "local-model behavioral summary contradicted itself (draft — verify)"
+                    if flagged
+                    else "local-model behavioral summary (draft — verify before acting)"
+                ),
                 evidence=[ln for ln in fleet.splitlines() if ln.strip()][:30],
-                data={"devices": sorted(device_summaries)},
+                data={
+                    "devices": sorted(device_summaries),
+                    "contradictory": sorted(flagged_devices),
+                },
             )
         )
 

--- a/src/meshtastic_mcp/web/services/nightly_analysis.py
+++ b/src/meshtastic_mcp/web/services/nightly_analysis.py
@@ -104,13 +104,18 @@ _NEGATED_CLEAN_RE = re.compile(
     re.IGNORECASE,
 )
 _ANOMALY_RE = re.compile(
-    r"\b(?:reboot|watchdog|wdt|brownout|crc|retransmi\w*|panic|crash|"
+    # reboot\w* so the verb form counts too — "!a4c1 rebooted twice" is the
+    # same finding as "a reboot on !a4c1", and \breboot\b misses it.
+    r"\b(?:reboot\w*|watchdog|wdt|brownout|crc|retransmi\w*|panic|crash|"
     r"stack overflow|corrupt|silence|silent|timeout|storm)\b",
     re.IGNORECASE,
 )
 # A clause that denies something uses anomaly words innocently ("no reboots or
 # unexpected silence observed"), so it must not count as anomaly evidence.
 _NEGATED_CLAUSE_RE = re.compile(r"\b(?:no|not|never|without|n't)\b", re.IGNORECASE)
+# A contrast flips the sentence back to reporting: whatever follows is its own
+# clause, outside the scope of the denial that preceded it.
+_CONTRAST_RE = re.compile(r"\b(?:but|however|although|though|yet|except that)\b", re.IGNORECASE)
 # ...except when the denial IS the finding ("no packets from !abc for 3600s").
 _ABSENCE_ANOMALY_RE = re.compile(
     r"\bno (?:packets?|traffic|response|data|telemetry|contact|beacons?|heartbeats?)\b",
@@ -123,10 +128,16 @@ CONTRADICTION_NOTE = (
 
 
 def _clauses(text: str) -> list[str]:
-    """Split into clauses so a denial's scope stays local to its own sentence."""
+    """Split into clauses so a denial's scope stays local to its own sentence.
+
+    Contrast conjunctions split too: "no reboots, but !a4c1 rebooted twice"
+    is a denial followed by the real finding, and without the split the whole
+    sentence reads as negated — hiding the very evidence the guard looks for.
+    """
     out: list[str] = []
     for line in text.splitlines():
-        out.extend(c for c in re.split(r"[;.]", line) if c.strip())
+        for sentence in re.split(r"[;.]", line):
+            out.extend(c for c in _CONTRAST_RE.split(sentence) if c.strip())
     return out
 
 

--- a/tests/unit/test_nightly_analysis.py
+++ b/tests/unit/test_nightly_analysis.py
@@ -283,3 +283,83 @@ def test_device_rows_shape(tmp_path, monkeypatch):
         await db.close()
 
     asyncio.run(go())
+
+
+# --- contradiction guard -------------------------------------------------
+# BEHAVIOR_SYSTEM invites "nothing notable" on a clean window, and small models
+# take that opening even when the window is dirty. These cases are verbatim
+# model output from a granite4:tiny-h vs phi4-mini bench on raw soak logs.
+
+GRANITE_CONTRADICTION = """- SOAK window clean, no reboots or unexpected silence observed
+- Multiple brownout warnings at 14:10:50 and 14:10:51 due to low vbat (3.21V)
+- Reboot occurred at 14:11:10 after watchdog timeout on node !a4c1382b
+- Several retransmission storms involving node !7f2e9910 with TEXT_MESSAGE_APP"""
+
+
+def test_flag_contradictory_all_clear_catches_leading_false_all_clear():
+    out, flagged = na.flag_contradictory_all_clear(GRANITE_CONTRADICTION)
+    assert flagged
+    assert out.startswith(na.CONTRADICTION_NOTE)
+    assert GRANITE_CONTRADICTION in out  # original text preserved below the note
+
+
+def test_flag_contradictory_all_clear_allows_an_honest_all_clear():
+    # a genuinely clean window says so and lists nothing; "no reboots" is the
+    # accurate claim here and must not trip the guard on its own wording
+    for text in ("nothing notable", "- nothing notable in this window", "- no reboots observed"):
+        out, flagged = na.flag_contradictory_all_clear(text)
+        assert not flagged, text
+        assert out == text
+
+
+def test_flag_contradictory_all_clear_ignores_plain_anomaly_report():
+    text = "- Reboot at 14:11:10 after watchdog timeout on !a4c1382b\n- CRC mismatch x5"
+    out, flagged = na.flag_contradictory_all_clear(text)
+    assert not flagged
+    assert out == text
+
+
+def test_flag_contradictory_all_clear_handles_empty():
+    assert na.flag_contradictory_all_clear("") == ("", False)
+    assert na.flag_contradictory_all_clear("   ") == ("   ", False)
+
+
+def test_flag_contradictory_all_clear_ignores_negated_clean_claim():
+    # an honest dirty report phrased as a denial must not read as an all-clear
+    for text in (
+        "- SOAK window is not clean; watchdog reboot at 02:14",
+        "- the night was far from clean: brownout vbat=3.21V then a reboot",
+    ):
+        out, flagged = na.flag_contradictory_all_clear(text)
+        assert not flagged, text
+        assert out == text
+
+
+def test_flag_contradictory_all_clear_allows_multi_item_honest_denial():
+    # "no reboots or unexpected silence" denies both; `silence` must not be
+    # harvested from that clause as if it were anomaly evidence
+    text = "- nothing notable\n- no reboots or unexpected silence observed"
+    out, flagged = na.flag_contradictory_all_clear(text)
+    assert not flagged
+    assert out == text
+
+
+def test_flag_contradictory_all_clear_counts_absence_findings_as_anomalies():
+    # a denial that IS the finding still contradicts an all-clear
+    text = "- nothing notable this window\n- no packets from !c81d44a0 for 3600s"
+    _, flagged = na.flag_contradictory_all_clear(text)
+    assert flagged
+
+
+def test_flag_contradictory_all_clear_catches_scoped_self_contradiction():
+    # verbatim phi4-mini output on a CLEAN window: it hallucinated anomalies and
+    # then declared the same topic unremarkable. The claim is scoped ("regarding
+    # unexpected silence") rather than global, and still contradicts the bullets.
+    text = (
+        "- Repeated packets with varying RSSI and SNR, indicating potential "
+        "retransmission storm.\n"
+        "- Nothing notable regarding unexpected silence, as all expected device "
+        "transmissions are logged."
+    )
+    _, flagged = na.flag_contradictory_all_clear(text)
+    assert flagged

--- a/tests/unit/test_nightly_analysis.py
+++ b/tests/unit/test_nightly_analysis.py
@@ -363,3 +363,23 @@ def test_flag_contradictory_all_clear_catches_scoped_self_contradiction():
     )
     _, flagged = na.flag_contradictory_all_clear(text)
     assert flagged
+
+
+def test_flag_contradictory_all_clear_sees_evidence_after_a_contrast():
+    # the granite4 shape with the anomaly hung off a contrast: the denial scopes
+    # only to its own clause, so the reboot after "but" is still evidence
+    for text in (
+        "- SOAK window clean, no reboots seen, but !a4c1382b rebooted twice",
+        "- nothing notable; no errors, however a watchdog reboot hit !c81d44a0",
+    ):
+        out, flagged = na.flag_contradictory_all_clear(text)
+        assert flagged, text
+        assert out.startswith(na.CONTRADICTION_NOTE)
+
+
+def test_flag_contradictory_all_clear_allows_an_honest_contrast():
+    # a contrast that introduces no anomaly must still read as clean
+    text = "- nothing notable, but the run finished early"
+    out, flagged = na.flag_contradictory_all_clear(text)
+    assert not flagged
+    assert out == text


### PR DESCRIPTION
## Summary

Detect when the nightly behavioral pass emits an "all clear" while also listing anomalies, and label it instead of trusting whichever local model happens to be configured.

## Motivation

`BEHAVIOR_SYSTEM` tells the model to say *"nothing notable"* when a window is clean, and small models take that opening even when the window is not clean. Benchmarking the fast lane on a 16 KB soak window with planted anomalies, `granite4:tiny-h` opened **every** reply with `"SOAK window clean, no reboots or unexpected silence observed"` and then listed the watchdog reboot two bullets down. A bench operator skimming the first line reads the opposite of the truth.

This is a property of the prompt, not of one model: `BEHAVIOR_SYSTEM`'s "say nothing notable if clean" instruction is what supplies the opening. The guard is therefore model-independent, so swapping `MESHTASTIC_MCP_LOCAL_FAST`/`_MODEL` cannot silently reintroduce it.

## Approach

`flag_contradictory_all_clear()` is a pure function that works clause by clause, which is what keeps it from crying wolf:

- a negated clause cannot supply anomaly evidence, so an honest `"no reboots or unexpected silence observed"` on a genuinely clean night stays quiet
- a negated claim (`"window is not clean"`) is not read as an all-clear
- absence findings (`"no packets from !c81d44a0 for 3600s"`) still count as anomalies

Device-level flags feed the fleet observation's severity via `data["contradictory"]`, so a contradiction detected at map stage still surfaces even if the reduce paraphrases it away. The note is never folded into the text handed back to the model, so the reduce prompt is not steered by operator-directed text.

## Test plan

Gates: `ruff check .`, `ruff format --check .`, `mypy` (no issues, 101 files), `python scripts/check_spdx.py`, `pytest tests/unit` (681 passed, 52 skipped). No hardware/firmware tier touched; this is analyzer-only.

8 unit tests cover the leading contradiction, honest all-clears, plain anomaly reports, negated clean claims, multi-item denials, absence findings, scoped self-contradiction, and empty input. Several use verbatim model output.

Also validated against live models on the real prompt, since canned strings cannot prove this:

| window | model | guard fires |
|---|---|---|
| dirty | `granite4:tiny-h` | 4/4 (caught) |
| dirty | `phi4-mini` | 0/4 (correctly silent) |
| clean | `granite4:tiny-h` | 0/4 (correctly silent) |

It also caught phrasings not literally encoded in the pattern: *"clean overall, but:"*, *"clean except for:"*, *"clean with no notable issues reported"*.

Note: these tests live in `test_nightly_analysis.py`, which `importorskip`s `fastapi`/`aiosqlite`. CI runs `--all-extras` so they execute there; a bare `[test]` install skips them. The guard itself needs neither, but its module transitively imports `aiosqlite`.

## Checklist

- [x] Gates pass (ruff, mypy — no new `ignore_errors`/`# noqa`, pytest unit tier)
- [x] New MCP tools have read/destructive/openWorld annotations; destructive ones take `confirm` — n/a, no new tools
- [x] Core changes import/run with no firmware checkout
- [x] DCO sign-off (`git commit -s`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added consistency checks to nightly analysis reports to identify contradictory “all-clear” conclusions.
  * Contradictory device or fleet findings are now clearly marked with warning severity and include affected devices.
  * Reports provide more informative messaging when anomaly evidence conflicts with a clean status.

* **Tests**
  * Added coverage for contradictory, valid, empty, and negated analysis statements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->