### PR TITLE
fix(doctor): resolve meshtasticd headers against the real include path

### DIFF
--- a/src/meshtastic_mcp/doctor.py
+++ b/src/meshtastic_mcp/doctor.py
@@ -393,6 +393,12 @@ def _c_include_dirs() -> list[Path]:
     found: list[Path] = [Path(d) for d in _DEFAULT_INCLUDE_DIRS]
 
     for var in _INCLUDE_PATH_VARS:
+        # Empty components are dropped on purpose. GCC does read them as "the current working
+        # directory" (verified: `CPATH=:/other` resolves <probe.h> from the compile's cwd), but
+        # the cwd that would matter is PlatformIO's during `pio run`, not this process's when
+        # someone happens to run `doctor`. Honouring it here would resolve against the wrong
+        # directory and make the probe answer differently depending on where it was invoked
+        # from — green inside any tree that vendors a yaml-cpp/, while the build still fails.
         found.extend(Path(e) for e in os.environ.get(var, "").split(os.pathsep) if e)
 
     for var in _INCLUDE_FLAG_VARS:

--- a/src/meshtastic_mcp/doctor.py
+++ b/src/meshtastic_mcp/doctor.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 import os
 import platform
 import re
+import shlex
 import shutil
 import subprocess
 import sys
@@ -347,16 +348,70 @@ _MESHTASTICD_DEPS_MAC: tuple[tuple[str, str], ...] = (
     ("openssl@3", "opt/openssl@3/include/openssl/ssl.h"),
 )
 
-# Debian: (apt package, a header that proves it is installed).
+# Debian: (apt package, header path relative to an include root).
 # argp is part of glibc on Debian, so argp.h comes from libc6-dev — there is no libargp-dev to
 # install, and naming one would make the fix line fail with "Unable to locate package". The
 # standalone formula only exists where the platform libc lacks argp, which is why macOS needs it.
+#
+# Root-relative for the same reason the macOS entries are prefix-relative: hard-coding
+# /usr/include reports every package missing on any toolchain that keeps its headers elsewhere —
+# Nix, Homebrew-on-Linux, a --prefix build, a cross sysroot — and then tells the user to install
+# what they already have. Resolved against _c_include_dirs().
 _MESHTASTICD_DEPS_DEBIAN: tuple[tuple[str, str], ...] = (
-    ("libc6-dev", "/usr/include/argp.h"),
-    ("libyaml-cpp-dev", "/usr/include/yaml-cpp/yaml.h"),
-    ("libuv1-dev", "/usr/include/uv.h"),
-    ("libssl-dev", "/usr/include/openssl/ssl.h"),
+    ("libc6-dev", "argp.h"),
+    ("libyaml-cpp-dev", "yaml-cpp/yaml.h"),
+    ("libuv1-dev", "uv.h"),
+    ("libssl-dev", "openssl/ssl.h"),
 )
+
+# The FHS roots every Linux toolchain searches without being told.
+_DEFAULT_INCLUDE_DIRS: tuple[str, ...] = ("/usr/include", "/usr/local/include")
+
+# Environment variables GCC and Clang read as bare directory lists (os.pathsep-separated).
+_INCLUDE_PATH_VARS: tuple[str, ...] = ("CPATH", "CPLUS_INCLUDE_PATH", "C_INCLUDE_PATH")
+
+# Environment variables carrying compiler *flags*, from which include dirs must be parsed.
+# NIX_CFLAGS_COMPILE is how a Nix shell hands its headers to the wrapped compiler; it is a
+# plain string of `-isystem <dir>` pairs and nothing else on PATH reveals those directories.
+_INCLUDE_FLAG_VARS: tuple[str, ...] = ("NIX_CFLAGS_COMPILE", "CXXFLAGS", "CFLAGS")
+
+# Flags that take the directory as the FOLLOWING argument, rather than glued on as -I<dir>.
+_INCLUDE_FLAGS_WITH_ARG: frozenset[str] = frozenset({"-I", "-isystem", "-idirafter", "-iquote"})
+
+
+def _c_include_dirs() -> list[Path]:
+    """Include roots a C/C++ compile on this machine would actually search.
+
+    The FHS defaults plus anything the environment adds, because "is the header installed"
+    and "is the header at /usr/include" are not the same question. Order is preserved and
+    duplicates dropped so the result reads like a real search path.
+
+    Deliberately environment-only: no compiler is spawned. This runs on every `doctor` call,
+    must never raise, and a subprocess would add a failure mode (and a timeout) to a probe
+    whose whole job is to be cheap and reliable.
+    """
+    found: list[Path] = [Path(d) for d in _DEFAULT_INCLUDE_DIRS]
+
+    for var in _INCLUDE_PATH_VARS:
+        found.extend(Path(e) for e in os.environ.get(var, "").split(os.pathsep) if e)
+
+    for var in _INCLUDE_FLAG_VARS:
+        try:
+            tokens = shlex.split(os.environ.get(var, ""))
+        except ValueError:
+            # Unbalanced quotes in someone's CFLAGS must not take the whole doctor down.
+            continue
+        expect_dir = False
+        for token in tokens:
+            if expect_dir:
+                found.append(Path(token))
+                expect_dir = False
+            elif token in _INCLUDE_FLAGS_WITH_ARG:
+                expect_dir = True
+            elif token.startswith("-I"):
+                found.append(Path(token[2:]))
+
+    return list(dict.fromkeys(found))
 
 
 def _brew_prefix() -> Path | None:
@@ -408,7 +463,14 @@ def _meshtasticd_build_check() -> Check:
         # Probe on Linux too. Returning ok unconditionally made this a check in name only: a
         # Debian user missing a package got a green tick and then the exact missing-header build
         # failure this exists to pre-empt.
-        missing = [pkg for pkg, header in _MESHTASTICD_DEPS_DEBIAN if not Path(header).exists()]
+        #
+        # Searched across the real include path, not just /usr/include — see _c_include_dirs.
+        include_dirs = _c_include_dirs()
+        missing = [
+            pkg
+            for pkg, header in _MESHTASTICD_DEPS_DEBIAN
+            if not any((root / header).exists() for root in include_dirs)
+        ]
         installer, env = "sudo apt install", "native"
 
     if not missing:

--- a/tests/unit/test_meshtasticd_build_deps.py
+++ b/tests/unit/test_meshtasticd_build_deps.py
@@ -233,6 +233,30 @@ def test_include_dirs_are_deduplicated_and_ordered(monkeypatch: pytest.MonkeyPat
     assert dirs == [Path("/usr/include"), Path("/one")]
 
 
+def test_empty_include_path_components_are_not_treated_as_cwd(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """GCC reads an empty CPATH component as the compile's cwd. We deliberately do not.
+
+    The cwd that would matter is PlatformIO's during `pio run`, not this process's when
+    someone runs `doctor`. Honouring it would resolve against the wrong directory and make
+    the probe answer differently depending on where it was invoked from — reporting ok inside
+    any tree that happens to vendor a yaml-cpp/ while the build still fails.
+    """
+    _touch(tmp_path / "yaml-cpp/yaml.h")
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(doctor, "_IS_MAC", False)
+    monkeypatch.setattr(doctor, "_DEFAULT_INCLUDE_DIRS", (str(tmp_path / "empty"),))
+    monkeypatch.setattr(
+        doctor, "_MESHTASTICD_DEPS_DEBIAN", (("libyaml-cpp-dev", "yaml-cpp/yaml.h"),)
+    )
+    _no_include_env(monkeypatch)
+    monkeypatch.setenv("CPATH", f"{os.pathsep}{tmp_path / 'nowhere'}")
+
+    assert Path.cwd() not in doctor._c_include_dirs()
+    assert doctor._meshtasticd_build_check().status == doctor.STATUS_MISSING
+
+
 # --- wiring ----------------------------------------------------------------
 
 

--- a/tests/unit/test_meshtasticd_build_deps.py
+++ b/tests/unit/test_meshtasticd_build_deps.py
@@ -14,6 +14,7 @@ a hard-coded one, so these tests pin a fake prefix instead of relying on the hos
 
 from __future__ import annotations
 
+import os
 from pathlib import Path
 
 import pytest
@@ -111,6 +112,12 @@ def test_missing_homebrew_is_reported_rather_than_silently_passing(
 # --- Linux -----------------------------------------------------------------
 
 
+def _no_include_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Blank every include-path variable so the host's own toolchain cannot leak in."""
+    for var in doctor._INCLUDE_PATH_VARS + doctor._INCLUDE_FLAG_VARS:
+        monkeypatch.delenv(var, raising=False)
+
+
 def test_linux_missing_packages_are_probed_not_assumed(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
@@ -120,11 +127,11 @@ def test_linux_missing_packages_are_probed_not_assumed(
     failure the check exists to pre-empt.
     """
     monkeypatch.setattr(doctor, "_IS_MAC", False)
+    monkeypatch.setattr(doctor, "_DEFAULT_INCLUDE_DIRS", (str(tmp_path / "empty"),))
     monkeypatch.setattr(
-        doctor,
-        "_MESHTASTICD_DEPS_DEBIAN",
-        (("libyaml-cpp-dev", str(tmp_path / "nope/yaml.h")),),
+        doctor, "_MESHTASTICD_DEPS_DEBIAN", (("libyaml-cpp-dev", "yaml-cpp/yaml.h"),)
     )
+    _no_include_env(monkeypatch)
 
     check = doctor._meshtasticd_build_check()
     assert check.status == doctor.STATUS_MISSING
@@ -135,13 +142,95 @@ def test_linux_missing_packages_are_probed_not_assumed(
 def test_linux_reports_ok_when_headers_are_present(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
-    header = _touch(tmp_path / "usr/include/uv.h")
+    _touch(tmp_path / "usr/include/uv.h")
     monkeypatch.setattr(doctor, "_IS_MAC", False)
-    monkeypatch.setattr(doctor, "_MESHTASTICD_DEPS_DEBIAN", (("libuv1-dev", str(header)),))
+    monkeypatch.setattr(doctor, "_DEFAULT_INCLUDE_DIRS", (str(tmp_path / "usr/include"),))
+    monkeypatch.setattr(doctor, "_MESHTASTICD_DEPS_DEBIAN", (("libuv1-dev", "uv.h"),))
+    _no_include_env(monkeypatch)
 
     check = doctor._meshtasticd_build_check()
     assert check.status == doctor.STATUS_OK
     assert check.fix == ""
+
+
+# --- include path beyond /usr/include --------------------------------------
+#
+# The probe used to stat /usr/include/<header> and nothing else, so any toolchain keeping its
+# headers elsewhere — Nix, Homebrew-on-Linux, a --prefix build, a cross sysroot — was told to
+# `sudo apt install` packages it already had, on distros where that command does not even exist.
+
+
+@pytest.mark.parametrize("var", ["CPATH", "CPLUS_INCLUDE_PATH", "C_INCLUDE_PATH"])
+def test_linux_honours_bare_include_path_variables(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, var: str
+) -> None:
+    elsewhere = tmp_path / "opt/include"
+    _touch(elsewhere / "yaml-cpp/yaml.h")
+    monkeypatch.setattr(doctor, "_IS_MAC", False)
+    monkeypatch.setattr(doctor, "_DEFAULT_INCLUDE_DIRS", (str(tmp_path / "empty"),))
+    monkeypatch.setattr(
+        doctor, "_MESHTASTICD_DEPS_DEBIAN", (("libyaml-cpp-dev", "yaml-cpp/yaml.h"),)
+    )
+    _no_include_env(monkeypatch)
+    monkeypatch.setenv(var, str(elsewhere))
+
+    assert doctor._meshtasticd_build_check().status == doctor.STATUS_OK
+
+
+def test_linux_honours_isystem_flags_from_a_nix_shell(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A Nix shell exports its headers only as `-isystem <dir>` in NIX_CFLAGS_COMPILE.
+
+    Nothing on PATH reveals those directories, so ignoring the variable is what made a fully
+    provisioned `nix develop` shell report libyaml-cpp-dev missing.
+    """
+    store = tmp_path / "nix/store/yaml-cpp/include"
+    _touch(store / "yaml-cpp/yaml.h")
+    monkeypatch.setattr(doctor, "_IS_MAC", False)
+    monkeypatch.setattr(doctor, "_DEFAULT_INCLUDE_DIRS", (str(tmp_path / "empty"),))
+    monkeypatch.setattr(
+        doctor, "_MESHTASTICD_DEPS_DEBIAN", (("libyaml-cpp-dev", "yaml-cpp/yaml.h"),)
+    )
+    _no_include_env(monkeypatch)
+    monkeypatch.setenv("NIX_CFLAGS_COMPILE", f"-frandom-seed=abc -isystem {store} -isystem /nope")
+
+    assert doctor._meshtasticd_build_check().status == doctor.STATUS_OK
+
+
+def test_linux_honours_glued_dash_i_flags(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """`-I<dir>` glued and `-I <dir>` separated are both legal; both must resolve."""
+    glued = tmp_path / "glued/include"
+    _touch(glued / "uv.h")
+    monkeypatch.setattr(doctor, "_IS_MAC", False)
+    monkeypatch.setattr(doctor, "_DEFAULT_INCLUDE_DIRS", (str(tmp_path / "empty"),))
+    monkeypatch.setattr(doctor, "_MESHTASTICD_DEPS_DEBIAN", (("libuv1-dev", "uv.h"),))
+    _no_include_env(monkeypatch)
+    monkeypatch.setenv("CXXFLAGS", f"-O2 -I{glued}")
+
+    assert doctor._meshtasticd_build_check().status == doctor.STATUS_OK
+
+
+def test_unbalanced_quotes_in_cflags_do_not_raise(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Every doctor probe is non-fatal; a malformed CFLAGS must not take the report down."""
+    monkeypatch.setattr(doctor, "_IS_MAC", False)
+    monkeypatch.setattr(doctor, "_DEFAULT_INCLUDE_DIRS", (str(tmp_path / "empty"),))
+    monkeypatch.setattr(doctor, "_MESHTASTICD_DEPS_DEBIAN", (("libuv1-dev", "uv.h"),))
+    _no_include_env(monkeypatch)
+    monkeypatch.setenv("CFLAGS", '-I"unterminated')
+
+    assert doctor._meshtasticd_build_check().status == doctor.STATUS_MISSING
+
+
+def test_include_dirs_are_deduplicated_and_ordered(monkeypatch: pytest.MonkeyPatch) -> None:
+    _no_include_env(monkeypatch)
+    monkeypatch.setattr(doctor, "_DEFAULT_INCLUDE_DIRS", ("/usr/include",))
+    monkeypatch.setenv("CPATH", f"/one{os.pathsep}/usr/include{os.pathsep}/one")
+
+    dirs = doctor._c_include_dirs()
+    assert dirs == [Path("/usr/include"), Path("/one")]
 
 
 # --- wiring ----------------------------------------------------------------


### PR DESCRIPTION
## The problem

The Linux branch of `_meshtasticd_build_check` stat'd `/usr/include/<header>` and nothing else. Any toolchain that keeps its headers elsewhere was therefore reported missing, and handed a `sudo apt install` line for packages it already had.

Found on a Nix host: inside a fully provisioned `nix develop` shell, `doctor` reported

```
meshtasticd-build-deps: missing
  missing: libyaml-cpp-dev. Without these `pio run -e native` fails with a missing-header error.
  fix: sudo apt install libyaml-cpp-dev
```

while `yaml-cpp` was on the compiler's include path the whole time — a scratch TU including `<yaml-cpp/yaml.h>` compiled and linked with `-lyaml-cpp` in that same shell. Nix is just how I hit it; the same bug affects Homebrew-on-Linux, a `--prefix` build, and cross sysroots.

## The fix

The Linux entries become root-relative and resolve against a new `_c_include_dirs()`:

- the FHS defaults (`/usr/include`, `/usr/local/include`)
- `CPATH`, `CPLUS_INCLUDE_PATH`, `C_INCLUDE_PATH` — bare directory lists GCC/Clang read directly
- include flags parsed out of `NIX_CFLAGS_COMPILE`, `CXXFLAGS`, `CFLAGS` — `-I<dir>` glued, `-I <dir>` separated, `-isystem`, `-idirafter`, `-iquote`

This is the same lesson the macOS entries already encode: they are Homebrew-prefix-relative *because* hard-coding `/usr/local` reported every formula missing on Apple silicon. The Linux side hadn't learned it yet.

`NIX_CFLAGS_COMPILE` is the load-bearing one — a Nix shell hands its headers to the wrapped compiler as `-isystem <dir>` in that variable and nowhere else, so nothing on `PATH` reveals those directories.

## Design notes

**No compiler is spawned.** Shelling out to `cc -E` would be more accurate in principle, but this runs on every `doctor` call and the module's stated contract is that probing never raises. A subprocess would trade a cheap deterministic probe for one with a timeout and its own failure modes. Unbalanced quotes in someone's `CFLAGS` are caught rather than propagated, keeping that contract.

## Verification

Both directions, on a Nix host:

| context | before | after |
| --- | --- | --- |
| inside `nix develop` (yaml-cpp only via `NIX_CFLAGS_COMPILE`) | `missing` | `ok` |
| include variables cleared | `missing` | `missing`, apt fix intact |

So a genuinely missing Debian package is still caught — no false negative introduced.

Tests in `test_meshtasticd_build_deps.py` go 7 → 15, covering each environment variable, both `-I` spellings, dedup/ordering of the search path, and the malformed-`CFLAGS` guard. The two existing Linux tests move to the root-relative contract.

Gates from `CONTRIBUTING.md` all pass: `ruff check`, `ruff format --check`, `mypy` (102 files), `check_spdx.py`, `pytest tests/unit` (537 passed, 73 skipped).

## Deliberately not in scope

The fix line is still `sudo apt install` on **every** Linux, Fedora and Arch included. That is a real second bug, but it needs distro detection — happy to follow up separately if you'd like it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved native build prerequisite checks to locate required headers in standard and custom include directories.
  - Added support for include paths supplied through common compiler environment variables and flags.
  - Prevented malformed compiler flags from causing diagnostic checks to fail.
  - Improved handling of duplicate include paths and search ordering.

- **Tests**
  - Added coverage for custom include locations, Nix compiler flags, alternate `-I` formats, malformed quotes, and include-path deduplication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->