### PR TITLE
fix(device): protect snapshots and flash local binaries

### DIFF
--- a/src/meshtastic_mcp/config_snapshot.py
+++ b/src/meshtastic_mcp/config_snapshot.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import json
 import os
+import tempfile
 import time
 from pathlib import Path
 from typing import Any
@@ -43,6 +44,30 @@ def _snapshot_path(name: str) -> Path:
     return _snapshot_dir() / f"{safe}.json"
 
 
+def _write_private_json(path: Path, payload: dict[str, Any]) -> None:
+    """Atomically replace a snapshot with owner-only permissions."""
+    descriptor, temporary_name = tempfile.mkstemp(
+        dir=path.parent,
+        prefix=f".{path.name}.",
+        suffix=".tmp",
+    )
+    temporary_path = Path(temporary_name)
+    try:
+        os.chmod(temporary_path, 0o600)
+        with os.fdopen(descriptor, "w", encoding="utf-8") as file:
+            file.write(json.dumps(payload, indent=2, default=str))
+            file.flush()
+            os.fsync(file.fileno())
+        os.replace(temporary_path, path)
+    except BaseException:
+        try:
+            os.close(descriptor)
+        except OSError:
+            pass
+        temporary_path.unlink(missing_ok=True)
+        raise
+
+
 def capture(name: str, port: str | None = None) -> dict[str, Any]:
     """Capture the device's full config to a named snapshot.
 
@@ -57,7 +82,7 @@ def capture(name: str, port: str | None = None) -> dict[str, Any]:
         "port": port,
         "config": cfg.get("config", cfg),
     }
-    path.write_text(json.dumps(snapshot, indent=2, default=str), encoding="utf-8")
+    _write_private_json(path, snapshot)
     config = snapshot["config"]
     local = config.get("localConfig", {})
     module = config.get("moduleConfig", {})

--- a/src/meshtastic_mcp/flash.py
+++ b/src/meshtastic_mcp/flash.py
@@ -293,8 +293,8 @@ def _run_install_script(script: Path, port: str, binary: Path) -> dict[str, Any]
 
     t0 = time.monotonic()
     proc = subprocess.run(
-        [str(script), "-p", port, "-f", str(binary)],
-        cwd=str(config.firmware_root()),
+        [str(script), "-p", port, "-f", binary.name],
+        cwd=str(binary.parent),
         capture_output=True,
         text=True,
         timeout=pio.TIMEOUT_UPLOAD,

--- a/tests/unit/test_config_snapshot.py
+++ b/tests/unit/test_config_snapshot.py
@@ -6,6 +6,7 @@
 from __future__ import annotations
 
 import json
+import stat
 
 import pytest
 
@@ -21,6 +22,24 @@ def _isolate_snapshot_dir(tmp_path, monkeypatch):
 def _write_snapshot(name: str, config: dict) -> None:
     path = config_snapshot._snapshot_path(name)
     path.write_text(json.dumps({"name": name, "config": config}), encoding="utf-8")
+
+
+def test_capture_replaces_permissive_snapshot_with_owner_only_file(monkeypatch):
+    path = config_snapshot._snapshot_path("private")
+    path.write_text("stale", encoding="utf-8")
+    path.chmod(0o644)
+    monkeypatch.setattr(
+        config_snapshot.admin,
+        "get_config",
+        lambda section, port: {"config": {"localConfig": {"security": {"private_key": "secret"}}}},
+    )
+
+    config_snapshot.capture("private")
+
+    assert stat.S_IMODE(path.stat().st_mode) == 0o600
+    assert json.loads(path.read_text(encoding="utf-8"))["config"]["localConfig"]["security"] == {
+        "private_key": "secret"
+    }
 
 
 def test_flatten_nested_config():

--- a/tests/unit/test_erase_and_flash.py
+++ b/tests/unit/test_erase_and_flash.py
@@ -32,6 +32,7 @@ def test_erase_and_flash_resolves_esptool_and_adds_to_path() -> None:
     def _stub_subprocess_run(args, **kwargs):
         captured["env"] = kwargs.get("env", {})
         captured["args"] = args
+        captured["cwd"] = kwargs.get("cwd")
         # Return a successful result
         result = MagicMock()
         result.returncode = 0
@@ -71,6 +72,8 @@ def test_erase_and_flash_resolves_esptool_and_adds_to_path() -> None:
     assert "device-install.sh" in str(args[0])
     assert "-p" in args
     assert "/dev/ttyUSB0" in args
+    assert captured["cwd"] == str(factory_bin.parent)
+    assert args[-1] == factory_bin.name
 
 
 def test_update_flash_also_resolves_esptool() -> None:


### PR DESCRIPTION
## Summary

Write configuration snapshots atomically with owner-only permissions and run firmware installs from the selected binary directory so protected radio backups stay private and relative artifact paths resolve correctly.

## Test plan

On the rebased head, `ruff check .`, `ruff format --check .`, `.venv/bin/python -m mypy`, and `.venv/bin/python -m pytest -q tests/unit` pass with 538 tests passed and 75 skipped; the focused snapshot/flash tier passes all 11 tests, and the physical FA99 erase/flash/restore flow also passed.

## Checklist

- [x] Gates pass (ruff, mypy; no new `ignore_errors`/`# noqa`, pytest unit tier)
- [x] No new MCP tools were added; annotation requirements are unchanged
- [x] Core changes import/run with no firmware checkout
- [x] DCO sign-off (`git commit -s`)
