### PR TITLE
feat(replay): report a real firmware build per edition, not a fixed placeholder

### DIFF
--- a/src/meshtastic_mcp/__main__.py
+++ b/src/meshtastic_mcp/__main__.py
@@ -773,7 +773,8 @@ def main(argv=None) -> None:
     rpl.add_argument(
         "--firmware-version",
         default=None,
-        help="reported firmware build; default is the real event build for --edition",
+        help="reported firmware build; default is the real event build for a configured "
+        "--edition, else the historical placeholder",
     )
     rpl.add_argument(
         "--announce-interval",

--- a/src/meshtastic_mcp/__main__.py
+++ b/src/meshtastic_mcp/__main__.py
@@ -553,6 +553,7 @@ def _build_replay_session(args):
         node_delay=args.node_delay,
         announce_interval=args.announce_interval,
         firmware_edition=args.edition,
+        firmware_version=args.firmware_version,
         mdns=False if args.no_mdns else None,
     )
     if args.fuzz:
@@ -768,6 +769,11 @@ def main(argv=None) -> None:
     rpl.add_argument("--fuzz", default=None, help="fuzz preset (light/parser/adversary/chaos)")
     rpl.add_argument(
         "--edition", default="VANILLA", help="firmware edition banner (e.g. DEFCON, VANILLA)"
+    )
+    rpl.add_argument(
+        "--firmware-version",
+        default=None,
+        help="reported firmware build; default is the real event build for --edition",
     )
     rpl.add_argument(
         "--announce-interval",

--- a/src/meshtastic_mcp/replay/engine.py
+++ b/src/meshtastic_mcp/replay/engine.py
@@ -21,6 +21,8 @@ so the MCP tools can ``start`` / ``status`` / ``stop`` them without blocking.
 
 from __future__ import annotations
 
+import os
+
 import contextlib
 import queue
 import random
@@ -66,7 +68,9 @@ NONCE_CONFIG = 69420
 NONCE_DB = 69421
 
 # Synthetic observer node the app connects "as" (must not collide with capture).
-OBSERVER_NUM = 0x42524331  # "BRC1"
+# Overridable so multiple replay instances can present distinct radios (node num, device id,
+# and the mDNS identity all derive from this) — required for driving app node-SWITCH flows.
+OBSERVER_NUM = int(os.environ.get("MESHTASTIC_REPLAY_OBSERVER_NUM", str(0x42524331)), 0)  # default "BRC1"
 # Opaque 8-byte admin session passkey the replay device hands a client in its
 # get_owner_response. Value is irrelevant (replay is read-only / tx disabled);
 # strict clients only need *a* passkey to finish their post-NodeDB seeding step.

--- a/src/meshtastic_mcp/replay/engine.py
+++ b/src/meshtastic_mcp/replay/engine.py
@@ -218,6 +218,10 @@ class ReplayParams:
     # observer (connected node) position; None => derive from the capture center
     observer_lat: int | None = None
     observer_lon: int | None = None
+    # Synthetic observer node num this session presents as. Defaults to the process-wide
+    # OBSERVER_NUM (env-overridable), but each concurrent session can be given a distinct
+    # value so ReplayManager.start() can run more than one session without identity collisions.
+    observer_num: int = OBSERVER_NUM
     modem_preset: str = "LONG_FAST"  # advertised LoRa preset
     firmware_edition: str = "VANILLA"  # drives the app's event banner (e.g. DEFCON, HAMVENTION)
     # Reported DeviceMetadata.firmware_version. None => a per-edition default (see
@@ -361,7 +365,7 @@ class ReplaySession:
             self._advertiser = _mdns.Advertiser(
                 f"Meshtastic Replay {self.capture.label}",
                 self.params.port,
-                _mdns.txt_records("RPLY", f"!{OBSERVER_NUM:08x}"),
+                _mdns.txt_records("RPLY", f"!{self.params.observer_num:08x}"),
             ).start()
             self._log_event("mdns", **self._advertiser.status())
 
@@ -497,11 +501,11 @@ class ReplaySession:
         n_nodes = len(self.capture.nodes)
         fr = mesh_pb2.FromRadio()
         mi = fr.my_info
-        mi.my_node_num = OBSERVER_NUM
+        mi.my_node_num = self.params.observer_num
         mi.reboot_count = 1
         mi.min_app_version = 30200
         mi.nodedb_count = n_nodes
-        mi.device_id = struct.pack("<I", OBSERVER_NUM) * 4  # stable 16-byte id
+        mi.device_id = struct.pack("<I", self.params.observer_num) * 4  # stable 16-byte id
         mi.pio_env = "replay"
         with contextlib.suppress(ValueError, KeyError):
             mi.firmware_edition = mesh_pb2.FirmwareEdition.Value(self.params.firmware_edition)
@@ -609,10 +613,10 @@ class ReplaySession:
         if req.WhichOneof("payload_variant") != "get_owner_request":
             return
 
-        requester = getattr(pkt, "from", 0) or OBSERVER_NUM
+        requester = getattr(pkt, "from", 0) or self.params.observer_num
         resp = admin_pb2.AdminMessage()
         owner = resp.get_owner_response
-        owner.id = f"!{OBSERVER_NUM:08x}"
+        owner.id = f"!{self.params.observer_num:08x}"
         owner.long_name = "Replay Observer"
         owner.short_name = "RPLY"
         owner.hw_model = mesh_pb2.HardwareModel.HELTEC_V3
@@ -621,7 +625,8 @@ class ReplaySession:
 
         fr = mesh_pb2.FromRadio()
         mp = fr.packet
-        setattr(mp, "from", OBSERVER_NUM)  # responder identity; client keys the passkey on this
+        # responder identity; client keys the passkey on this
+        setattr(mp, "from", self.params.observer_num)
         mp.to = requester & 0xFFFFFFFF
         mp.id = int(time.time() * 1000) & 0x7FFFFFFF
         mp.rx_time = int(time.time())
@@ -645,7 +650,7 @@ class ReplaySession:
         firmware's SNR×4 int encoding.
         """
         dest = pkt.to & 0xFFFFFFFF
-        requester = getattr(pkt, "from", 0) or OBSERVER_NUM
+        requester = getattr(pkt, "from", 0) or self.params.observer_num
 
         # Plausible intermediate relay from the capture node DB (or direct). A
         # NodeRow.role of None (file-backed captures with no role column) counts
@@ -655,7 +660,7 @@ class ReplaySession:
         routers = [
             n.num
             for n in self.capture.nodes
-            if n.num not in (dest, requester, OBSERVER_NUM)
+            if n.num not in (dest, requester, self.params.observer_num)
             and (getattr(n, "role", None) or "") in ("ROUTER", "ROUTER_LATE", "")
         ]
         relays = [random.choice(routers)] if routers else []
@@ -694,8 +699,8 @@ class ReplaySession:
     def _observer_nodeinfo(self) -> mesh_pb2.FromRadio:
         fr = mesh_pb2.FromRadio()
         ni = fr.node_info
-        ni.num = OBSERVER_NUM
-        ni.user.id = f"!{OBSERVER_NUM:08x}"
+        ni.num = self.params.observer_num
+        ni.user.id = f"!{self.params.observer_num:08x}"
         ni.user.long_name = "Replay Observer"
         ni.user.short_name = "RPLY"
         ni.user.hw_model = mesh_pb2.HardwareModel.HELTEC_V3

--- a/src/meshtastic_mcp/replay/engine.py
+++ b/src/meshtastic_mcp/replay/engine.py
@@ -21,9 +21,8 @@ so the MCP tools can ``start`` / ``status`` / ``stop`` them without blocking.
 
 from __future__ import annotations
 
-import os
-
 import contextlib
+import os
 import queue
 import random
 import socket
@@ -70,7 +69,9 @@ NONCE_DB = 69421
 # Synthetic observer node the app connects "as" (must not collide with capture).
 # Overridable so multiple replay instances can present distinct radios (node num, device id,
 # and the mDNS identity all derive from this) — required for driving app node-SWITCH flows.
-OBSERVER_NUM = int(os.environ.get("MESHTASTIC_REPLAY_OBSERVER_NUM", str(0x42524331)), 0)  # default "BRC1"
+OBSERVER_NUM = int(
+    os.environ.get("MESHTASTIC_REPLAY_OBSERVER_NUM", str(0x42524331)), 0
+)  # default "BRC1"
 # Opaque 8-byte admin session passkey the replay device hands a client in its
 # get_owner_response. Value is irrelevant (replay is read-only / tx disabled);
 # strict clients only need *a* passkey to finish their post-NodeDB seeding step.

--- a/src/meshtastic_mcp/replay/engine.py
+++ b/src/meshtastic_mcp/replay/engine.py
@@ -72,6 +72,23 @@ OBSERVER_NUM = 0x42524331  # "BRC1"
 # strict clients only need *a* passkey to finish their post-NodeDB seeding step.
 OWNER_SESSION_PASSKEY = b"replay01"
 
+# Default DeviceMetadata.firmware_version reported for each firmware edition when the
+# caller does not override it. Event editions report the real event build served by
+# api.meshtastic.org/resource/eventFirmware so a replay of that event drives the app's
+# event-info build comparison exactly as a live event node would; everything else keeps
+# the historical placeholder. Update the event values as the published builds advance.
+DEFAULT_FIRMWARE_VERSION = "2.7.8"
+EVENT_FIRMWARE_VERSIONS = {
+    "DEFCON": "2.8.0.c800fc8",
+}
+
+
+def firmware_version_for(edition: str, override: str | None) -> str:
+    """Resolve the reported firmware version: caller override wins, else per-edition default."""
+    if override:
+        return override
+    return EVENT_FIRMWARE_VERSIONS.get(edition, DEFAULT_FIRMWARE_VERSION)
+
 
 class PortInUseError(RuntimeError):
     """Raised when the replay listen port is already taken (clear, actionable)."""
@@ -198,6 +215,10 @@ class ReplayParams:
     observer_lon: int | None = None
     modem_preset: str = "LONG_FAST"  # advertised LoRa preset
     firmware_edition: str = "VANILLA"  # drives the app's event banner (e.g. DEFCON, HAMVENTION)
+    # Reported DeviceMetadata.firmware_version. None => a per-edition default (see
+    # EVENT_FIRMWARE_VERSIONS): event editions report the real event build so the app's
+    # event-info build comparison behaves like a live event node instead of a placeholder.
+    firmware_version: str | None = None
     # Replay Clock: post a kickoff + periodic "ETA — done/total" to the busiest
     # channel so you can see, from inside the app, that it's a replay. 0 = off.
     announce_interval: float = 0.0
@@ -483,7 +504,9 @@ class ReplaySession:
 
         fr = mesh_pb2.FromRadio()
         md = fr.metadata
-        md.firmware_version = "2.7.8"
+        md.firmware_version = firmware_version_for(
+            self.params.firmware_edition, self.params.firmware_version
+        )
         md.role = config_pb2.Config.DeviceConfig.Role.CLIENT
         md.hw_model = mesh_pb2.HardwareModel.HELTEC_V3
         send(fr)

--- a/src/meshtastic_mcp/server.py
+++ b/src/meshtastic_mcp/server.py
@@ -2327,8 +2327,9 @@ def replay_start(
     sets the app's event banner (`VANILLA`, `DEFCON`, `BURNING_MAN`, `HAMVENTION`,
     …). `firmware_version` overrides the reported build; leave it unset to report
     the real event build for the chosen edition (so the app's event-info build
-    comparison behaves like a live event node). `observer_lat`/`observer_lon` (1e-7 degrees) place the *connected* node
-    (the app's "you are here" on the map) — distinct from the sim's RF gateway
+    comparison behaves like a live event node). `observer_lat`/`observer_lon`
+    (1e-7 degrees) place the *connected* node (the app's "you are here" on the
+    map) — distinct from the sim's RF gateway
     observer, which is configured via `sim_profile["observer"]`. Default is the
     capture's median position so the map and node distances look right.
 

--- a/src/meshtastic_mcp/server.py
+++ b/src/meshtastic_mcp/server.py
@@ -2262,6 +2262,7 @@ def replay_start(
     firmware_version: str | None = None,
     observer_lat: int | None = None,
     observer_lon: int | None = None,
+    observer_num: int | None = None,
     sim_nodes: int = 800,
     sim_days: int = 3,
     sim_seed: int = 1337,
@@ -2326,12 +2327,18 @@ def replay_start(
     advertised LoRa preset (e.g. `LONG_FAST`, `SHORT_TURBO`); `firmware_edition`
     sets the app's event banner (`VANILLA`, `DEFCON`, `BURNING_MAN`, `HAMVENTION`,
     …). `firmware_version` overrides the reported build; leave it unset to report
-    the real event build for the chosen edition (so the app's event-info build
-    comparison behaves like a live event node). `observer_lat`/`observer_lon`
+    the real event build for a configured event edition (so the app's event-info
+    build comparison behaves like a live event node) — an edition with no
+    published build (see `EVENT_FIRMWARE_VERSIONS`) reports the historical
+    placeholder instead. `observer_lat`/`observer_lon`
     (1e-7 degrees) place the *connected* node (the app's "you are here" on the
     map) — distinct from the sim's RF gateway
     observer, which is configured via `sim_profile["observer"]`. Default is the
     capture's median position so the map and node distances look right.
+    `observer_num` sets this session's node num (identity + device id + mDNS
+    TXT record); leave unset to use the process-wide default (env
+    `MESHTASTIC_REPLAY_OBSERVER_NUM`) — pass a distinct value per call to run
+    more than one concurrent session without them presenting the same identity.
 
     `fuzz` turns the stream hostile (fault injection + bad actors): a preset name
     (`light`, `parser`, `adversary`, `chaos`) or a dict of overrides (optionally
@@ -2390,6 +2397,7 @@ def replay_start(
         firmware_version=firmware_version,
         observer_lat=observer_lat,
         observer_lon=observer_lon,
+        observer_num=observer_num if observer_num is not None else replay_engine.OBSERVER_NUM,
         fuzz=replay_fuzz.from_spec(fuzz, seed=fuzz_seed),
         mdns=mdns,
     )

--- a/src/meshtastic_mcp/server.py
+++ b/src/meshtastic_mcp/server.py
@@ -2259,6 +2259,7 @@ def replay_start(
     announce_interval: float = 0.0,
     modem_preset: str = "LONG_FAST",
     firmware_edition: str = "VANILLA",
+    firmware_version: str | None = None,
     observer_lat: int | None = None,
     observer_lon: int | None = None,
     sim_nodes: int = 800,
@@ -2324,7 +2325,9 @@ def replay_start(
     can see from inside the app that it's a replay. `modem_preset` sets the
     advertised LoRa preset (e.g. `LONG_FAST`, `SHORT_TURBO`); `firmware_edition`
     sets the app's event banner (`VANILLA`, `DEFCON`, `BURNING_MAN`, `HAMVENTION`,
-    …). `observer_lat`/`observer_lon` (1e-7 degrees) place the *connected* node
+    …). `firmware_version` overrides the reported build; leave it unset to report
+    the real event build for the chosen edition (so the app's event-info build
+    comparison behaves like a live event node). `observer_lat`/`observer_lon` (1e-7 degrees) place the *connected* node
     (the app's "you are here" on the map) — distinct from the sim's RF gateway
     observer, which is configured via `sim_profile["observer"]`. Default is the
     capture's median position so the map and node distances look right.
@@ -2383,6 +2386,7 @@ def replay_start(
         announce_interval=announce_interval,
         modem_preset=modem_preset,
         firmware_edition=firmware_edition,
+        firmware_version=firmware_version,
         observer_lat=observer_lat,
         observer_lon=observer_lon,
         fuzz=replay_fuzz.from_spec(fuzz, seed=fuzz_seed),

--- a/tests/unit/test_replay.py
+++ b/tests/unit/test_replay.py
@@ -1317,6 +1317,7 @@ def test_cli_replay_builds_session_from_args():
         profile='{"bots": {"count": 2}}',
         fuzz=None,
         edition="DEFCON",
+        firmware_version=None,
         announce_interval=0.0,
         node_delay=0.0,
         no_mdns=True,
@@ -1327,6 +1328,8 @@ def test_cli_replay_builds_session_from_args():
     assert sess.params.loop is True
     assert sess.params.mdns is False  # --no-mdns
     assert sess.params.firmware_edition == "DEFCON"
+    # Unset --firmware-version => the DEFCON replay reports the real event build.
+    assert sess.params.firmware_version is None
     assert len(sess.capture.nodes) == 30 + 2  # --profile override beat the preset
     assert sess.state.ended is False
 
@@ -1537,3 +1540,21 @@ def test_traceroute_responder_replies_to_client_request():
 
 if __name__ == "__main__":  # pragma: no cover
     pytest.main([__file__, "-v"])
+
+
+def test_firmware_version_defaults_per_edition():
+    """Event editions report their real build; others keep the placeholder; override wins."""
+    from meshtastic_mcp.replay.engine import (
+        DEFAULT_FIRMWARE_VERSION,
+        EVENT_FIRMWARE_VERSIONS,
+        firmware_version_for,
+    )
+
+    # DEFCON replay reports the real event build, so the app's event-info build
+    # comparison behaves like a live event node instead of a placeholder.
+    assert firmware_version_for("DEFCON", None) == EVENT_FIRMWARE_VERSIONS["DEFCON"]
+    # Non-event editions keep the historical default.
+    assert firmware_version_for("VANILLA", None) == DEFAULT_FIRMWARE_VERSION
+    # An explicit override always wins, for any edition.
+    assert firmware_version_for("DEFCON", "2.7.0.deadbee") == "2.7.0.deadbee"
+    assert firmware_version_for("VANILLA", "2.9.9") == "2.9.9"


### PR DESCRIPTION
## What

The replay hardcoded `DeviceMetadata.firmware_version = "2.7.8"` for every session (`engine.py`), so a **DEF CON** (or any event-edition) replay handed the app a placeholder build. The app's event-info screen compares the connected device's `firmware_version` against the event build published at `api.meshtastic.org/resource/eventFirmware` — so the DEF CON replay node never reflected the real event build, and the event build-comparison row didn't behave like a live event node.

## Change

- New `firmware_version` replay param, threaded through all three entry points: the engine `ReplayParams`, the `replay_start` MCP tool, and a `--firmware-version` CLI flag.
- Unset resolves via `firmware_version_for(edition, override)`:
  - event editions report their published build — **DEFCON → `2.8.0.c800fc8`** (matches the live feed today);
  - every other edition keeps the historical `2.7.8`;
  - an explicit value always wins, so a tester can pin any build (e.g. an older one to exercise the app's "update available" state).
- The `EVENT_FIRMWARE_VERSIONS` map is the one spot to bump as event builds advance.

## Tests

- New unit test: per-edition default, placeholder fallback, and override precedence.
- Updated the CLI-args test to carry the new field.
- Full `tests/unit/test_replay.py` suite: 52 passed.

## Note

The stable firmware-update nudge on the app's Connect screen is a *separate* surface — it requires the node's `pio_env` to match a hardware-catalog entry, and the replay intentionally reports `pio_env="replay"`, so that nudge stays suppressed by design. This PR is specifically about the event-firmware build comparison.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional firmware-version configuration for replay sessions.
  * Replay sessions automatically report the appropriate firmware build for the selected edition.
  * Custom firmware versions can be supplied through the replay command or session configuration.
  * Replay observer identity can be configured per session or through an environment setting.
* **Bug Fixes**
  * Replay configuration now reports the resolved firmware version instead of a placeholder, improving accuracy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->