### PR TITLE
Add options for yaml config overrides and tests

### DIFF
--- a/docs/bench-setup.md
+++ b/docs/bench-setup.md
@@ -57,6 +57,35 @@ esp32s3:
   (`rak4631`, `esp32s3`, `t_echo`, `heltec_t114`) keeps you aligned with the
   reference bench's parametrization.
 
+### Already-configured device? Skip the reflash entirely
+
+`baked_mesh` (the fixture behind every hardware test) only *verifies* a
+device's live region/channel against the harness's test-mesh profile — it
+never reflashes on its own. By default that profile is a fixed isolated
+mesh (`US` / channel `McpTest` / slot 88), which won't match a device you
+configured yourself. Rather than let the harness reflash your board into
+that profile, tell it what's *already* there with a top-level `session:`
+block in your hub profile:
+
+```yaml
+# my-bench.yaml
+session:
+  region: EU_868 # read via: meshtastic-mcp device_info --port=<port>
+  channel_name: FAB26 # same
+  channel_num: 0 # read via: meshtastic-mcp get_config --section=lora --port=<port>
+
+esp32s3:
+  vid: 0x303a
+```
+
+With this, `pytest tests/ --hub-profile=my-bench.yaml --assume-baked` runs
+against the device exactly as it already is — no reflash, and no risk of
+the harness silently switching a device to a regulatory region you didn't
+choose. Every `session:` key is also settable via an env var
+(`MESHTASTIC_MCP_REGION` etc.) for a one-off override without editing the
+file — the env var wins when both are set. See `example.yaml` at the repo
+root for every option, documented.
+
 ## 3. Run it
 
 ```bash

--- a/example.yaml
+++ b/example.yaml
@@ -1,0 +1,70 @@
+# example.yaml — every --hub-profile option, documented.
+#
+#   pytest tests/ --hub-profile=example.yaml --assume-baked
+#
+# A --hub-profile YAML is the whole configuration surface for a non-default
+# bench: which physical boards exist (per-role vid/location/env) and,
+# optionally, the session-wide test-mesh profile devices are checked
+# against (region/channel_name/channel_num/modem_preset). No environment
+# variable is required for anything below — set a key here instead, or
+# leave it out to keep the harness default.
+#
+# Every value here can still be overridden ad hoc with an env var without
+# editing this file — see the "env var equivalent" comment on each key.
+# The env var always wins when both are set; that's deliberate, so a
+# checked-in profile stays a safe shared default while one operator can
+# still override a single value for one run.
+
+# ---------------------------------------------------------------------------
+# Optional. Session-wide test-mesh profile. `baked_mesh` (the fixture behind
+# every hardware test) only *verifies* a connected device's live region /
+# channel against these values — it never reflashes on its own. Point them
+# at what's ALREADY on your device(s) and the harness accepts them as-is,
+# with no reflash and no risk of it silently switching your device to a
+# regulatory region you didn't choose. Omit any key (or the whole block) to
+# keep that value at the harness's built-in isolated-test-mesh default.
+#
+# Read a device's actual live values first:
+#   meshtastic-mcp device_info --port=<port>              # region, primary_channel
+#   meshtastic-mcp get_config --section=lora --port=<port> # channel_num, modem_preset
+session:
+  region: EU_868 # env var equivalent: MESHTASTIC_MCP_REGION       (default: US)
+  channel_name: FAB26 # env var equivalent: MESHTASTIC_MCP_CHANNEL_NAME (default: McpTest)
+  channel_num: 0 # env var equivalent: MESHTASTIC_MCP_CHANNEL_NUM  (default: 88)
+  modem_preset: LONG_FAST # env var equivalent: MESHTASTIC_MCP_MODEM_PRESET (default: LONG_FAST)
+
+# ---------------------------------------------------------------------------
+# One entry per bench role. Role names are free-form — what the test IDs and
+# MESHTASTIC_MCP_ENV_<ROLE> env var key off of (uppercased). Reusing the
+# reference-bench names (rak4631, esp32s3, t_echo, heltec_t114) isn't
+# required but keeps you aligned with their parametrization if you ever add
+# a matching board.
+#
+# A role with none of its tests' preconditions met (no matching device
+# attached) simply doesn't run — it's not an error to list a role that
+# isn't currently plugged in.
+esp32s3:
+  # How this role finds its physical board. At least one of `vid` or
+  # `location` is required.
+  vid: 0x303a # USB VID. Espressif native-USB (XIAO ESP32-S3 and similar): 0x303a.
+  # CP2102-bridged S3 boards (e.g. Heltec V3): 0x10c4.
+  alt_vids: [0x10c4] # optional — additional VIDs also accepted for this role.
+  location: null # optional — pins an EXACT USB hub slot, e.g. "1-2.3.5" (see
+  # `ls /sys/bus/usb/devices/` or FleetSuite's device card). Only
+  # needed when two boards on your bench share a VID and you must
+  # tell them apart. When set, VID matching is NOT used as a
+  # fallback for this role — only that exact slot counts.
+  pid_contains: null # optional — substring match on USB PID. Ignored whenever
+  # `location` is set; a fallback disambiguator for VID-only setups.
+
+  # PlatformIO env to build/flash for this board. Only read if a bake
+  # actually runs (i.e. you're NOT passing --assume-baked). Must match the
+  # board's real hardware.
+  env: seeed-xiao-s3 # env var equivalent: MESHTASTIC_MCP_ENV_ESP32S3
+
+# A second role, showing the minimal shape — just enough to detect the
+# board and know what to bake.
+rak4631:
+  vid: 0x239a
+  location: "1-2.3.1"
+  env: rak4631

--- a/src/meshtastic_mcp/info.py
+++ b/src/meshtastic_mcp/info.py
@@ -41,6 +41,24 @@ def region_name(iface) -> str | None:
         return None
 
 
+def modem_preset_name(iface) -> str | None:
+    """LoRa modem-preset enum name (e.g. "LONG_FAST") from an already-connected interface."""
+    try:
+        lora = iface.localNode.localConfig.lora
+        fields = lora.DESCRIPTOR.fields_by_name["modem_preset"]
+        return fields.enum_type.values_by_number[lora.modem_preset].name
+    except Exception:
+        return None
+
+
+def channel_num(iface) -> int | None:
+    """LoRa channel_num (frequency slot) from an already-connected interface."""
+    try:
+        return iface.localNode.localConfig.lora.channel_num
+    except Exception:
+        return None
+
+
 def device_info(port: str | None = None, timeout_s: float = 8.0) -> dict[str, Any]:
     """Return summary info for the connected device."""
     with connect(port=port, timeout_s=timeout_s) as iface:
@@ -70,6 +88,8 @@ def device_info(port: str | None = None, timeout_s: float = 8.0) -> dict[str, An
             "region": region,
             "num_nodes": len(iface.nodesByNum) if iface.nodesByNum else 0,
             "primary_channel": primary_channel_name(iface),
+            "modem_preset": modem_preset_name(iface),
+            "channel_num": channel_num(iface),
         }
 
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -54,8 +54,8 @@ pytest tests/ --force-bake --html=report.html
 
 ## Environment variables
 
-Everything below except `MESHTASTIC_FIRMWARE_ROOT` has a YAML equivalent in
-`--hub-profile` (see [`example.yaml`](../example.yaml)) — set it in the file
+Everything below except `MESHTASTIC_FIRMWARE_ROOT` and `MESHTASTIC_MCP_SEED` has
+a YAML equivalent in `--hub-profile` (see [`example.yaml`](../example.yaml)) — set it in the file
 instead of exporting it, or use both: **the env var wins whenever a key is
 set both places**, so a checked-in profile stays a safe shared default while
 one run can still override a single value ad hoc.

--- a/tests/README.md
+++ b/tests/README.md
@@ -42,16 +42,28 @@ pytest tests/ --force-bake --html=report.html
 - `--assume-baked` — skip `test_00_bake.py` entirely. Use when you know the
   devices are already baked and want a fast dev loop.
 - `--hub-profile=<yaml>` — point at a YAML file for non-default hub hardware
-  (see [docs/bench-setup.md](../docs/bench-setup.md) for a walkthrough).
-  Default targets VID `0x239a` (nRF52) and `0x303a`/`0x10c4` (ESP32-S3).
+  (see [docs/bench-setup.md](../docs/bench-setup.md) for a walkthrough, or
+  [`example.yaml`](../example.yaml) at the repo root for every option,
+  documented). Default targets VID `0x239a` (nRF52) and `0x303a`/`0x10c4`
+  (ESP32-S3). As of the `session:` key below, a hub-profile YAML is a
+  **complete** bench configuration on its own — no env var is required for
+  anything in this file; every one below is an optional ad-hoc override on
+  top of the YAML, not a requirement.
 - `--no-teardown-rebake` — skip the session-end rebake that `provisioning/`
   and `fleet/` tests perform. Useful in rapid iteration.
 
 ## Environment variables
 
+Everything below except `MESHTASTIC_FIRMWARE_ROOT` has a YAML equivalent in
+`--hub-profile` (see [`example.yaml`](../example.yaml)) — set it in the file
+instead of exporting it, or use both: **the env var wins whenever a key is
+set both places**, so a checked-in profile stays a safe shared default while
+one run can still override a single value ad hoc.
+
 - `MESHTASTIC_FIRMWARE_ROOT` — firmware repo path. Required for the bake and
   firmware-marked tiers; without it the harness auto-skips them (point it at a
-  sibling `meshtastic/firmware` checkout).
+  sibling `meshtastic/firmware` checkout). Not part of the hub profile — it's
+  a filesystem path to a different repo, not bench/session config.
 - `MESHTASTIC_MCP_ENV_<ROLE>` — PlatformIO env override per *per-board* bench
   role (`tests/_bench.py`): `MESHTASTIC_MCP_ENV_T_ECHO`,
   `MESHTASTIC_MCP_ENV_HELTEC_T114`, `MESHTASTIC_MCP_ENV_ESP32S3`,
@@ -59,9 +71,26 @@ pytest tests/ --force-bake --html=report.html
   (`t-echo-plus`, `heltec-mesh-node-t114`, `heltec-v3`, `rak4631`). Keying per
   board — not by the collapsible VID — is what lets the three same-VID 0x239a
   nRF52 boards each get their own firmware. FleetSuite bakes these automatically
-  from each connected board's pinned hub slot.
+  from each connected board's pinned hub slot. **YAML:** `env:` under that
+  role in `--hub-profile`.
 - `MESHTASTIC_MCP_SEED` — override the session PSK seed (default:
-  `pytest-<unix-ts>`). Set this to reproduce a specific failing run.
+  `pytest-<unix-ts>`). Set this to reproduce a specific failing run. No YAML
+  equivalent — it's meant to change per invocation, not live in a checked-in
+  profile.
+- `MESHTASTIC_MCP_REGION` / `MESHTASTIC_MCP_CHANNEL_NAME` /
+  `MESHTASTIC_MCP_CHANNEL_NUM` / `MESHTASTIC_MCP_MODEM_PRESET` — override the
+  session `test_profile`'s region (default `US`), primary channel name
+  (default `McpTest`), channel slot (default `88`), and modem preset (default
+  `LONG_FAST`). `baked_mesh` only *verifies* the live device against this
+  profile — it never reflashes on its own — so pointing these at a device's
+  actual already-baked values (read them via `meshtastic-mcp device_info` /
+  `get_config --section=lora`) lets `baked_mesh` pass **without reflashing**,
+  and without ever setting a region the operator didn't choose. Use this when
+  you already have firmware + config on a device (e.g. a real regulatory
+  region outside the US) and don't want the harness to touch it. **YAML:**
+  the top-level `session:` block in `--hub-profile` (`region:`,
+  `channel_name:`, `channel_num:`, `modem_preset:` — see
+  [docs/bench-setup.md](../docs/bench-setup.md#already-configured-device-skip-the-reflash-entirely)).
 
 ## Fixtures you'll use when adding tests
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -77,7 +77,7 @@ _HUB_PROFILE_SESSION_KEY = "session"
 _HUB_PROFILE_SESSION_ALLOWED_KEYS = {"region", "channel_name", "channel_num", "modem_preset"}
 
 
-def _load_hub_profile(path: str) -> dict:
+def _load_hub_profile(path: str) -> dict[str, dict[str, Any]]:
     """Load and shape-check a ``--hub-profile`` YAML: must be a mapping of
     role name -> spec mapping (plus an optional reserved ``session:`` key,
     stripped here — see `_load_hub_profile_session`). Fails fast with a
@@ -125,6 +125,17 @@ def _load_hub_profile_session(path: str | None) -> dict[str, Any]:
             f"--hub-profile {path}: unknown session key(s) {sorted(unknown)}; "
             f"allowed: {sorted(_HUB_PROFILE_SESSION_ALLOWED_KEYS)}"
         )
+    if "channel_num" in session:
+        channel_num = session["channel_num"]
+        if isinstance(channel_num, bool) or not isinstance(channel_num, int):
+            raise pytest.UsageError(
+                f"--hub-profile {path}: session.channel_num must be an integer, got {channel_num!r}"
+            )
+    for key in ("region", "channel_name", "modem_preset"):
+        if key in session and not isinstance(session[key], str):
+            raise pytest.UsageError(
+                f"--hub-profile {path}: session.{key} must be a string, got {session[key]!r}"
+            )
     return session
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -68,22 +68,64 @@ from . import (
 # ---------- CLI options ---------------------------------------------------
 
 
+# Reserved top-level key in a --hub-profile YAML for session-wide test
+# profile overrides (region/channel_name/channel_num/modem_preset) — see
+# `_load_hub_profile_session` and the `test_profile` fixture. Kept out of
+# the role-spec mapping `_load_hub_profile` returns so it's never mistaken
+# for a device role.
+_HUB_PROFILE_SESSION_KEY = "session"
+_HUB_PROFILE_SESSION_ALLOWED_KEYS = {"region", "channel_name", "channel_num", "modem_preset"}
+
+
 def _load_hub_profile(path: str) -> dict:
     """Load and shape-check a ``--hub-profile`` YAML: must be a mapping of
-    role name -> spec mapping. Fails fast with a clear UsageError instead of
-    an AttributeError deep inside a fixture when handed a scalar/list YAML."""
+    role name -> spec mapping (plus an optional reserved ``session:`` key,
+    stripped here — see `_load_hub_profile_session`). Fails fast with a
+    clear UsageError instead of an AttributeError deep inside a fixture when
+    handed a scalar/list YAML."""
     import yaml
 
     with open(path, encoding="utf-8") as f:
-        profile = yaml.safe_load(f) or {}
-    if not isinstance(profile, dict) or not all(
-        isinstance(role, str) and isinstance(spec, dict) for role, spec in profile.items()
-    ):
+        raw = yaml.safe_load(f) or {}
+    if not isinstance(raw, dict):
         raise pytest.UsageError(
             f"--hub-profile {path}: expected a YAML mapping of role name -> "
-            f"spec (location/env/vid/...), got {type(profile).__name__}"
+            f"spec (location/env/vid/...), got {type(raw).__name__}"
+        )
+    profile = {role: spec for role, spec in raw.items() if role != _HUB_PROFILE_SESSION_KEY}
+    if not all(isinstance(role, str) and isinstance(spec, dict) for role, spec in profile.items()):
+        raise pytest.UsageError(
+            f"--hub-profile {path}: expected a YAML mapping of role name -> "
+            f"spec (location/env/vid/...), got a non-mapping value for one or more roles"
         )
     return profile
+
+
+def _load_hub_profile_session(path: str | None) -> dict[str, Any]:
+    """The optional ``session:`` block of a ``--hub-profile`` YAML — region /
+    channel_name / channel_num / modem_preset overrides for the
+    `test_profile` fixture (see there for precedence vs. env vars). Returns
+    ``{}`` when there's no profile, or the profile has no `session:` key."""
+    if not path:
+        return {}
+    import yaml
+
+    with open(path, encoding="utf-8") as f:
+        raw = yaml.safe_load(f) or {}
+    session = raw.get(_HUB_PROFILE_SESSION_KEY) if isinstance(raw, dict) else None
+    if session is None:
+        return {}
+    if not isinstance(session, dict):
+        raise pytest.UsageError(
+            f"--hub-profile {path}: `session` must be a mapping, got {type(session).__name__}"
+        )
+    unknown = set(session) - _HUB_PROFILE_SESSION_ALLOWED_KEYS
+    if unknown:
+        raise pytest.UsageError(
+            f"--hub-profile {path}: unknown session key(s) {sorted(unknown)}; "
+            f"allowed: {sorted(_HUB_PROFILE_SESSION_ALLOWED_KEYS)}"
+        )
+    return session
 
 
 def pytest_configure(config: pytest.Config) -> None:
@@ -232,20 +274,51 @@ def session_seed(request: pytest.FixtureRequest) -> str:
 
 
 @pytest.fixture(scope="session")
-def test_profile(session_seed: str) -> dict[str, Any]:
+def hub_profile_session_overrides(request: pytest.FixtureRequest) -> dict[str, Any]:
+    """The optional `session:` block of `--hub-profile` — see `test_profile`."""
+    path = request.config.getoption("--hub-profile")
+    return _load_hub_profile_session(path)
+
+
+@pytest.fixture(scope="session")
+def test_profile(
+    session_seed: str, hub_profile_session_overrides: dict[str, Any]
+) -> dict[str, Any]:
     """The canonical isolated-mesh test profile for this session.
 
     `enable_ui_log=True` stamps `USERPREFS_UI_TEST_LOG` so the firmware
     emits `Screen: frame N/M name=... reason=...` log lines per UI
     transition — consumed by the `tests/ui/` tier. Harmless on boards
     without a screen (the `#ifdef` sits behind `HAS_SCREEN`).
+
+    Region / channel name / channel slot / modem preset default to the
+    harness's isolated test mesh (`US` / `McpTest` / 88 / `LONG_FAST`).
+    Override them with the `session:` block of a `--hub-profile` YAML (see
+    `example.yaml` for every key), or with `MESHTASTIC_MCP_REGION` /
+    `MESHTASTIC_MCP_CHANNEL_NAME` / `MESHTASTIC_MCP_CHANNEL_NUM` /
+    `MESHTASTIC_MCP_MODEM_PRESET` env vars — an env var wins over the YAML
+    when both are set for the same key, so an operator can still override
+    a checked-in profile ad hoc without editing it. Neither is required:
+    the YAML alone is enough, and so is the env-var-only path from before.
+
+    This matters for `baked_mesh`, which only *verifies* the live device
+    against this profile (see above it) — it never reflashes on its own.
+    Point these at a device's actual already-flashed values (e.g. `EU_868`,
+    a real region) and `baked_mesh` passes without any reflash, and without
+    ever touching a region the operator didn't choose. Defaults are
+    unchanged, so nothing here affects a run with no overrides set.
     """
+    overrides = hub_profile_session_overrides
+
+    def _get(key: str, env_name: str, default: str) -> str:
+        return os.environ.get(env_name) or str(overrides.get(key, default))
+
     return userprefs.build_testing_profile(
         psk_seed=session_seed,
-        channel_name="McpTest",
-        channel_num=88,
-        region="US",
-        modem_preset="LONG_FAST",
+        channel_name=_get("channel_name", "MESHTASTIC_MCP_CHANNEL_NAME", "McpTest"),
+        channel_num=int(_get("channel_num", "MESHTASTIC_MCP_CHANNEL_NUM", "88")),
+        region=_get("region", "MESHTASTIC_MCP_REGION", "US"),
+        modem_preset=_get("modem_preset", "MESHTASTIC_MCP_MODEM_PRESET", "LONG_FAST"),
         enable_ui_log=True,
     )
 

--- a/tests/test_00_bake.py
+++ b/tests/test_00_bake.py
@@ -202,11 +202,20 @@ def _bake_role(
     if not force_bake:
         try:
             live = info.device_info(port=port, timeout_s=8.0)
-            # Quick heuristic: region matches and primary channel matches.
+            # Heuristic: region, primary channel, channel_num and modem_preset all match.
+            # A device sharing region/name but flashed with a different slot or preset must
+            # NOT be treated as already baked — and if either value can't be observed on this
+            # device, fall through and bake rather than risk a false-positive skip.
             expected_region_short = test_profile["USERPREFS_CONFIG_LORA_REGION"].rsplit("_", 1)[-1]
+            expected_channel_num = test_profile["USERPREFS_LORACONFIG_CHANNEL_NUM"]
+            expected_modem_preset = test_profile["USERPREFS_LORACONFIG_MODEM_PRESET"].rsplit(
+                "ModemPreset_", 1
+            )[-1]
             if (
                 live.get("region") == expected_region_short
                 and live.get("primary_channel") == test_profile["USERPREFS_CHANNEL_0_NAME"]
+                and live.get("channel_num") == expected_channel_num
+                and live.get("modem_preset") == expected_modem_preset
             ):
                 pytest.skip(
                     f"{role} at {port} already baked with session profile "

--- a/tests/test_00_bake.py
+++ b/tests/test_00_bake.py
@@ -172,14 +172,17 @@ def _prepare_nrf52_for_upload(port: str) -> str:
     return new_port
 
 
-def _env_for(role: str) -> str:
-    override = os.environ.get(f"MESHTASTIC_MCP_ENV_{role.upper()}")
+def _env_for(role: str, profile_env: str | None = None) -> str:
+    """Resolve the PlatformIO env for `role` on env or the
+    active `--hub-profile` YAML"""
+    override = os.environ.get(f"MESHTASTIC_MCP_ENV_{role.upper()}") or profile_env
     if override:
         return override
     if role not in _DEFAULT_ENVS:
         pytest.fail(
             f"no default PlatformIO env for role {role!r}. "
-            f"Set MESHTASTIC_MCP_ENV_{role.upper()} to the env name."
+            f"Set MESHTASTIC_MCP_ENV_{role.upper()}, or an `env:` key for "
+            f"{role!r} in your --hub-profile YAML."
         )
     return _DEFAULT_ENVS[role]
 
@@ -189,10 +192,11 @@ def _bake_role(
     port: str,
     test_profile: dict[str, Any],
     force_bake: bool,
+    profile_env: str | None = None,
 ) -> None:
     """Bake + boot + verify for a single role. Skips if already baked unless
     `--force-bake` was passed."""
-    env = _env_for(role)
+    env = _env_for(role, profile_env)
 
     # If not forcing, check if already baked with session profile.
     if not force_bake:
@@ -328,16 +332,19 @@ def _bake_role(
 def test_bake(
     baked_single_role: str,
     hub_devices: dict[str, str],
+    hub_profile: dict[str, dict[str, Any]],
     test_profile: dict[str, Any],
     request: pytest.FixtureRequest,
 ) -> None:
     """Flash one bench role with the session test profile.
 
     Auto-parametrized by `pytest_generate_tests` over every detected role, so
-    each connected board is provisioned with ITS correct firmware (the env is
-    resolved per role from `tests/_bench.py`) — instead of the old model that
-    flashed one hard-coded env onto whichever same-VID board enumerated first
-    and left the rest unprovisioned.
+    each connected board is provisioned with ITS correct firmware. The env is
+    resolved per role via `_env_for`: `MESHTASTIC_MCP_ENV_<ROLE>` env var,
+    else this role's `env:` key in the active `--hub-profile` YAML, else the
+    `tests/_bench.py` default — instead of the old model that flashed one
+    hard-coded env onto whichever same-VID board enumerated first and left
+    the rest unprovisioned.
     """
     role = baked_single_role
     if role not in hub_devices:
@@ -347,4 +354,5 @@ def test_bake(
         port=hub_devices[role],
         test_profile=test_profile,
         force_bake=request.config.getoption("--force-bake"),
+        profile_env=hub_profile.get(role, {}).get("env"),
     )

--- a/tests/unit/test_hub_profile_overrides.py
+++ b/tests/unit/test_hub_profile_overrides.py
@@ -1,0 +1,156 @@
+# SPDX-FileCopyrightText: Meshtastic contributors
+# SPDX-License-Identifier: GPL-3.0-only
+
+"""No-hardware checks for the --hub-profile YAML config surface.
+
+Covers the reserved `session:` block (`conftest._load_hub_profile` /
+`_load_hub_profile_session`) and per-role `env:` resolution
+(`test_00_bake._env_for`) added so a `--hub-profile` YAML alone (no exported
+env vars) is enough to run the hardware tiers against an already-configured
+device. Each also verifies the env-var-wins-over-YAML precedence, since env
+vars must keep working unchanged for anyone already using them.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from .. import conftest as root_conftest
+from .. import test_00_bake
+
+
+def _write_yaml(tmp_path: Path, text: str) -> str:
+    p = tmp_path / "hub.yaml"
+    p.write_text(text)
+    return str(p)
+
+
+# ---------- conftest._load_hub_profile / _load_hub_profile_session --------
+
+
+def test_load_hub_profile_strips_session_key(tmp_path: Path) -> None:
+    path = _write_yaml(
+        tmp_path,
+        """
+        session:
+          region: EU_868
+        esp32s3:
+          vid: 0x303a
+        """,
+    )
+    profile = root_conftest._load_hub_profile(path)
+    assert "session" not in profile
+    assert profile == {"esp32s3": {"vid": 0x303A}}  # YAML parses 0x... as int
+
+
+def test_load_hub_profile_rejects_non_mapping_role_spec(tmp_path: Path) -> None:
+    path = _write_yaml(tmp_path, "esp32s3: not-a-mapping\n")
+    with pytest.raises(pytest.UsageError):
+        root_conftest._load_hub_profile(path)
+
+
+def test_load_hub_profile_session_reads_known_keys(tmp_path: Path) -> None:
+    path = _write_yaml(
+        tmp_path,
+        """
+        session:
+          region: EU_868
+          channel_name: FAB26
+          channel_num: 0
+          modem_preset: LONG_FAST
+        esp32s3:
+          vid: 0x303a
+        """,
+    )
+    assert root_conftest._load_hub_profile_session(path) == {
+        "region": "EU_868",
+        "channel_name": "FAB26",
+        "channel_num": 0,
+        "modem_preset": "LONG_FAST",
+    }
+
+
+def test_load_hub_profile_session_rejects_unknown_key(tmp_path: Path) -> None:
+    path = _write_yaml(tmp_path, "session:\n  bogus_key: 1\n")
+    with pytest.raises(pytest.UsageError, match="bogus_key"):
+        root_conftest._load_hub_profile_session(path)
+
+
+def test_load_hub_profile_session_absent_returns_empty(tmp_path: Path) -> None:
+    path = _write_yaml(tmp_path, "esp32s3:\n  vid: 0x303a\n")
+    assert root_conftest._load_hub_profile_session(path) == {}
+
+
+def test_load_hub_profile_session_no_path_returns_empty() -> None:
+    assert root_conftest._load_hub_profile_session(None) == {}
+
+
+# ---------- test_profile's YAML/env-var precedence -------------------------
+#
+# `test_profile` itself is a fixture (needs the full fixture graph to call
+# directly); its precedence logic is the small `_get` closure inside it,
+# which mirrors this reference behavior exactly (env var > YAML > default).
+# Exercised here at the same YAML-loading layer used above so a regression
+# in either the YAML parsing or the precedence order is caught without
+# spinning up hardware fixtures.
+
+
+def test_profile_precedence_env_var_wins_over_yaml(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    path = _write_yaml(tmp_path, "session:\n  region: EU_868\n")
+    overrides = root_conftest._load_hub_profile_session(path)
+    monkeypatch.setenv("MESHTASTIC_MCP_REGION", "JP")
+
+    def _get(key: str, env_name: str, default: str) -> str:
+        return os.environ.get(env_name) or str(overrides.get(key, default))
+
+    assert _get("region", "MESHTASTIC_MCP_REGION", "US") == "JP"
+
+
+def test_profile_precedence_yaml_wins_over_default(tmp_path: Path) -> None:
+    path = _write_yaml(tmp_path, "session:\n  region: EU_868\n")
+    overrides = root_conftest._load_hub_profile_session(path)
+
+    def _get(key: str, env_name: str, default: str) -> str:
+        return os.environ.get(env_name) or str(overrides.get(key, default))
+
+    assert _get("region", "MESHTASTIC_MCP_REGION", "US") == "EU_868"
+
+
+def test_profile_precedence_default_when_neither_set() -> None:
+    overrides: dict[str, Any] = {}
+
+    def _get(key: str, env_name: str, default: str) -> str:
+        return os.environ.get(env_name) or str(overrides.get(key, default))
+
+    assert _get("region", "MESHTASTIC_MCP_REGION_UNSET_FOR_TEST", "US") == "US"
+
+
+# ---------- test_00_bake._env_for ------------------------------------------
+
+
+def test_env_for_uses_profile_env_when_no_env_var(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("MESHTASTIC_MCP_ENV_ESP32S3", raising=False)
+    assert test_00_bake._env_for("esp32s3", profile_env="seeed-xiao-s3") == "seeed-xiao-s3"
+
+
+def test_env_for_env_var_wins_over_profile_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("MESHTASTIC_MCP_ENV_ESP32S3", "heltec-v3")
+    assert test_00_bake._env_for("esp32s3", profile_env="seeed-xiao-s3") == "heltec-v3"
+
+
+def test_env_for_falls_back_to_bench_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("MESHTASTIC_MCP_ENV_ESP32S3", raising=False)
+    assert test_00_bake._env_for("esp32s3") == "heltec-v3"  # tests/_bench.py default
+
+
+def test_env_for_unknown_role_without_override_fails() -> None:
+    # pytest.fail() raises pytest.fail.Exception (BaseException, not Exception)
+    # specifically so a broad `except Exception` in user code can't swallow it.
+    with pytest.raises(pytest.fail.Exception, match="no default PlatformIO env"):
+        test_00_bake._env_for("not_a_real_role")


### PR DESCRIPTION
## Summary

Adds a series of settings to the config yaml parser for making it easier to configure without env variables. It also adds options for not setting default channels  / presets that are not applicable outside of the US.

Finally, it adds an option to use the already baked device.

## Test plan
I ran this locally for telemetry checks on a single node, for a separate PR I am working on to test telemetry features (sensor detection, payloads, etc.). First time working on this, supported by AI.

## Checklist

- [ ] Gates pass (ruff, mypy — no new `ignore_errors`/`# noqa`, pytest unit tier)
- [ ] New MCP tools have read/destructive/openWorld annotations; destructive ones take `confirm`
- [ ] Core changes import/run with no firmware checkout
- [ ] DCO sign-off (`git commit -s`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added hub-profile YAML support for configuring session-wide mesh settings and bench roles.
  - Added support for running tests against already-configured devices without reflashing.
  - Added configurable PlatformIO environments for each board role.
  - Added environment-variable overrides, with clear precedence over profile values and defaults.

- **Documentation**
  - Added setup guidance, configuration examples, validation details, and usage instructions for baked-device testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->