### PR TITLE
Survive a client that disconnects during accept

### DIFF
--- a/src/meshtastic_mcp/replay/engine.py
+++ b/src/meshtastic_mcp/replay/engine.py
@@ -371,8 +371,16 @@ class ReplaySession:
                     continue
                 except OSError:
                     break
-                client.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
-                _set_send_timeout(client, self.params.send_timeout)
+                try:
+                    client.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
+                    _set_send_timeout(client, self.params.send_timeout)
+                except OSError:
+                    # The client vanished between accept() and configuration (macOS raises
+                    # EINVAL from setsockopt on a dead socket). Wait for the next client
+                    # instead of tearing down the whole accept loop.
+                    with contextlib.suppress(OSError):
+                        client.close()
+                    continue
                 self.state.client_addr = f"{addr[0]}:{addr[1]}"
                 self.state.connected = True
                 self._client = client


### PR DESCRIPTION
## Summary

A client that connects and immediately vanishes (two apps racing for one replay, a canceled probe) kills the replay entirely: `setsockopt` on the dead socket raises `EINVAL` on macOS, the accept loop dies, and the replay exits.

## What changed

The post-accept socket configuration moved inside a try; on `OSError` the dead socket is closed and the loop waits for the next client.

## Testing

Reproduced during Apple-app simulator testing — two simulators alternating against one replay killed it within minutes; with the fix the same rig survives client churn.