### PR TITLE
feat(replay): publish observer local stats

### DIFF
--- a/src/meshtastic_mcp/__main__.py
+++ b/src/meshtastic_mcp/__main__.py
@@ -791,7 +791,10 @@ def main(argv=None) -> None:
         "--stats-interval",
         type=float,
         default=5.0,
-        help="observer LocalStats cadence while replay packets flow (0 = initial snapshot only)",
+        help=(
+            "observer LocalStats cadence while packets flow "
+            "(0 = initial and non-looping final snapshots only)"
+        ),
     )
     rpl.add_argument(
         "--dupe-every",

--- a/src/meshtastic_mcp/__main__.py
+++ b/src/meshtastic_mcp/__main__.py
@@ -552,6 +552,8 @@ def _build_replay_session(args):
         loop=args.loop,
         node_delay=args.node_delay,
         announce_interval=args.announce_interval,
+        stats_interval=args.stats_interval,
+        dupe_every=args.dupe_every,
         firmware_edition=args.edition,
         firmware_version=args.firmware_version,
         mdns=False if args.no_mdns else None,
@@ -784,6 +786,18 @@ def main(argv=None) -> None:
         type=float,
         default=0.0,
         help="post in-app Replay Clock progress every N seconds (0 = off)",
+    )
+    rpl.add_argument(
+        "--stats-interval",
+        type=float,
+        default=5.0,
+        help="observer LocalStats cadence while replay packets flow (0 = initial snapshot only)",
+    )
+    rpl.add_argument(
+        "--dupe-every",
+        type=int,
+        default=0,
+        help="simulate a duplicate RX in LocalStats every Nth packet without sending it (0 = off)",
     )
     rpl.add_argument("--node-delay", type=float, default=0.005, help="node-DB pacing seconds")
     rpl.add_argument("--no-mdns", action="store_true", help="don't advertise via mDNS/Bonjour")

--- a/src/meshtastic_mcp/replay/engine.py
+++ b/src/meshtastic_mcp/replay/engine.py
@@ -26,6 +26,7 @@ import os
 import queue
 import random
 import socket
+import statistics
 import struct
 import threading
 import time
@@ -115,6 +116,45 @@ TELEMETRY_APP = portnums_pb2.PortNum.TELEMETRY_APP  # 67
 def _format_eta(seconds: float) -> str:
     s = max(0, int(seconds))
     return f"~{s // 60}m {s % 60}s left" if s >= 60 else f"~{s}s left"
+
+
+def _representative_radio_metrics(
+    packets: list[tuple[int, bytes, str]],
+) -> tuple[float, float]:
+    """Median radio load from captured DeviceMetrics, for observer LocalStats."""
+    channel_utilization: list[float] = []
+    air_util_tx: list[float] = []
+    packet = mesh_pb2.MeshPacket()
+    telemetry = telemetry_pb2.Telemetry()
+    for _rx_time, raw, _channel in packets:
+        packet.Clear()
+        try:
+            packet.ParseFromString(raw)
+        except Exception:
+            continue
+        if (
+            packet.WhichOneof("payload_variant") != "decoded"
+            or packet.decoded.portnum != TELEMETRY_APP
+        ):
+            continue
+        telemetry.Clear()
+        try:
+            telemetry.ParseFromString(packet.decoded.payload)
+        except Exception:
+            continue
+        if telemetry.WhichOneof("variant") != "device_metrics":
+            continue
+        metrics = telemetry.device_metrics
+        if metrics.HasField("channel_utilization"):
+            channel_utilization.append(float(metrics.channel_utilization))
+        if metrics.HasField("air_util_tx"):
+            air_util_tx.append(float(metrics.air_util_tx))
+
+    channel = statistics.median(channel_utilization) if channel_utilization else 0.0
+    air = statistics.median(air_util_tx) if air_util_tx else 0.0
+    channel = min(100.0, max(0.0, channel))
+    air = min(channel, max(0.0, air))
+    return round(channel, 3), round(air, 4)
 
 
 def local_ips() -> list[str]:
@@ -239,6 +279,12 @@ class ReplayParams:
     # Replay Clock: post a kickoff + periodic "ETA — done/total" to the busiest
     # channel so you can see, from inside the app, that it's a replay. 0 = off.
     announce_interval: float = 0.0
+    # Observer LocalStats cadence while replay packets flow. The initial snapshot is
+    # always sent before the bulk node DB; 0 disables only periodic updates.
+    stats_interval: float = 5.0
+    # Simulate a duplicate radio RX every Nth replay packet so LocalStats duplicate
+    # accounting is observable. Firmware suppresses these before the app; 0 disables.
+    dupe_every: int = 0
     # true SO_SNDTIMEO seconds; a stalled app can't hang our sends. 0 = none
     send_timeout: float = 10.0
     # mDNS/Bonjour advertisement (`_meshtastic._tcp` like real firmware, so
@@ -266,6 +312,9 @@ class _SessionState:
     client_addr: str | None = None
     packets_sent: int = 0
     injected: int = 0
+    stats_sent: int = 0  # LOCAL_STATS telemetry emitted for the observer node
+    stats_dupes: int = 0
+    dupe_source_packets: int = 0
     # wall-clock time the current connection's stream began emitting packets and
     # the streamed-packet count at that instant, so status can report the
     # *achieved* stream rate (self-verifying stress tests). Reset per connection
@@ -296,9 +345,19 @@ class ReplaySession:
                 raise ValueError(f"duration must be > 0 seconds (got {params.duration})")
             if window:
                 params.rate = len(window) / params.duration
+        if params.dupe_every < 0:
+            raise ValueError(f"dupe_every must be >= 0 packets (got {params.dupe_every})")
         self.capture = capture
         self.params = params
         self.window = window
+        # Ground the observer's advertised radio load in the capture itself rather
+        # than in synthetic noise: the median of every DeviceMetrics sample in the
+        # replay window. Computed once — the window never changes.
+        self._channel_utilization, self._air_util_tx = _representative_radio_metrics(window)
+        # Guards the observer LocalStats counters. `_send_db_phase` runs on the
+        # reader thread and can re-enter on a second want_config_id while the
+        # stream thread is already emitting periodic stats + counting duplicates.
+        self._stats_lock = threading.Lock()
         self.state = _SessionState(
             id=sid,
             params=params,
@@ -603,6 +662,7 @@ class ReplaySession:
     def _send_db_phase(self, send: Any, nonce: int) -> None:
         now = int(time.time())
         send(self._observer_nodeinfo())
+        self._send_observer_stats(send)
         if self.params.node_delay > 0:
             time.sleep(self.params.node_delay)
         for n in self.capture.nodes:
@@ -614,6 +674,38 @@ class ReplaySession:
         fr = mesh_pb2.FromRadio()
         fr.config_complete_id = nonce
         send(fr)
+
+    def _send_observer_stats(self, send: Any) -> None:
+        """Publish LocalStats from the connected observer.
+
+        Called from three sites — once before the bulk node DB (so the app has a
+        stats row before a large download can stall rendering), periodically from
+        the stream loop, and once at the end of a non-looping replay. The counters
+        are real: `num_packets_rx` is what the observer has actually been fed and
+        `num_rx_dupe` is the duplicate count `dupe_every` actually produced. Radio
+        load is the median of the capture's own DeviceMetrics, not synthetic.
+        Does not touch the replay rate counters.
+        """
+        with self._stats_lock:
+            next_tx = self.state.stats_sent + 1
+            now = int(time.time())
+            telemetry = telemetry_pb2.Telemetry()
+            telemetry.time = now
+            stats = telemetry.local_stats
+            stats.uptime_seconds = max(1, now - int(self.state.started_at))
+            stats.channel_utilization = self._channel_utilization
+            stats.air_util_tx = self._air_util_tx
+            stats.num_packets_tx = next_tx
+            stats.num_packets_rx = self.state.packets_sent + self.state.stats_dupes
+            stats.num_packets_rx_bad = 0
+            stats.num_rx_dupe = self.state.stats_dupes
+            stats.num_tx_relay = 0
+            # Self-inclusive census, like a real device's own LocalStats.
+            stats.num_online_nodes = len(self.capture.nodes) + 1
+            stats.num_total_nodes = len(self.capture.nodes) + 1
+            stats.noise_floor = random.randint(-105, -92)
+            send(self._local_telemetry_fr(telemetry))
+            self.state.stats_sent = next_tx
 
     def _handle_client_packet(self, pkt: mesh_pb2.MeshPacket, send: Any) -> None:
         """Answer admin round-trips and traceroute requests from the connected client.
@@ -796,7 +888,8 @@ class ReplaySession:
 
         The app dispatches TELEMETRY_APP by `packet.from`; the connected node's
         own telemetry (`from == connectedNode`) is treated as local. A random
-        packet id keeps the two per-tick packets distinct so neither is deduped.
+        packet id keeps successive observer packets (LOCAL_STATS on its own
+        cadence, DEVICE_METRICS on another) distinct so none of them is deduped.
         """
         fr = mesh_pb2.FromRadio()
         mp = fr.packet
@@ -829,51 +922,24 @@ class ReplaySession:
         d.uptime_seconds = uptime
         return self._local_telemetry_fr(tm)
 
-    def _local_stats(self) -> mesh_pb2.FromRadio:
-        """LOCAL_STATS for the observer: the mesh/network "Local Stats" view.
-
-        Distinct from device metrics — this drives the app's live-activity stats:
-        packets rx (the observer receives the whole replay feed, so this climbs),
-        packets tx (small — it mostly listens), online/total nodes = the mesh
-        size, plus a realistic negative noise floor.
-        """
-        now = int(time.time())
-        st = self.state
-        n_nodes = len(self.capture.nodes)
-        rx = st.packets_sent & 0xFFFFFFFF  # observer received everything streamed
-        tx = (st.injected + st.local_metrics_sent * 2) & 0xFFFFFFFF  # it TXes little
-        tm = telemetry_pb2.Telemetry()
-        tm.time = now
-        ls = tm.local_stats
-        ls.uptime_seconds = max(1, now - int(st.started_at))
-        ls.channel_utilization = self._local_chutil()
-        ls.air_util_tx = round(random.uniform(0.0, 1.5), 3)
-        ls.num_packets_tx = tx
-        ls.num_packets_rx = rx
-        ls.num_packets_rx_bad = 0
-        ls.num_rx_dupe = int(rx * 0.03)  # a few duplicates, as a real mesh sees
-        ls.num_tx_relay = 0
-        ls.num_online_nodes = n_nodes
-        ls.num_total_nodes = n_nodes
-        ls.noise_floor = random.randint(-105, -92)
-        return self._local_telemetry_fr(tm)
-
     def _local_metrics_loop(self, send: Any, client: socket.socket) -> None:
-        """Emit local device metrics + local stats every `local_metrics_interval` s.
+        """Emit local DEVICE_METRICS every `local_metrics_interval` seconds.
 
-        First tick fires a few seconds after connect (so the handshake's observer
-        NodeInfo lands first), then on the interval — matching firmware, which
-        reports its own telemetry shortly after boot and periodically thereafter.
+        LOCAL_STATS is not emitted here — it has its own, much tighter cadence in
+        `_send_observer_stats`. First tick fires a few seconds after connect (so
+        the handshake's observer NodeInfo lands first), then on the interval —
+        matching firmware, which reports its own telemetry shortly after boot and
+        periodically thereafter.
         """
         iv = self.params.local_metrics_interval
         if iv <= 0:
             return
         stop = self.state.stop
         # Wait for streaming to actually start before the first tick (a big node
-        # DB can take several seconds to download) so the first LOCAL_STATS shows
-        # a real packets-rx instead of 0 — bounded by the interval so device
-        # metrics still emit even if a stream never begins. Then a short grace
-        # lets a few packets flow.
+        # DB can take several seconds to download) so the first chutil reading
+        # reflects real load instead of an idle line — bounded by the interval so
+        # device metrics still emit even if a stream never begins. Then a short
+        # grace lets a few packets flow.
         waited = 0.0
         while self.state.stream_started_at is None and waited < iv:
             if stop.wait(0.5):
@@ -884,7 +950,6 @@ class ReplaySession:
         while not stop.is_set():
             try:
                 send(self._local_device_metrics())
-                send(self._local_stats())
             except (OSError, ConnectionError):
                 self._sever(client)
                 return
@@ -1006,6 +1071,9 @@ class ReplaySession:
         # the idle gap between connections doesn't dilute the reading.
         self.state.stream_started_at = time.time()
         self.state.stream_base = self.state.packets_sent - self.state.injected
+        next_stats_at = (
+            time.time() + p.stats_interval if p.stats_interval and p.stats_interval > 0 else None
+        )
         while not stop.is_set():
             prev: int | None = None
             pass_start = time.time()
@@ -1054,7 +1122,21 @@ class ReplaySession:
                         self._sever(client)
                         return
                     self.state.packets_sent += 1
+                    if p.dupe_every > 0:
+                        with self._stats_lock:
+                            self.state.dupe_source_packets += 1
+                            if self.state.dupe_source_packets % p.dupe_every == 0:
+                                self.state.stats_dupes += 1
                 done += 1
+                if next_stats_at is not None:
+                    now = time.time()
+                    if now >= next_stats_at:
+                        try:
+                            self._send_observer_stats(send)
+                        except (OSError, ConnectionError):
+                            self._sever(client)
+                            return
+                        next_stats_at = now + p.stats_interval
                 if announce:
                     now = time.time()
                     if now - last_ann >= p.announce_interval:
@@ -1071,6 +1153,11 @@ class ReplaySession:
                 with contextlib.suppress(OSError, ConnectionError):
                     self._announce(send, f"✅ Replay complete — {total} packets", ann_idx)
             if not p.loop:
+                try:
+                    self._send_observer_stats(send)
+                except (OSError, ConnectionError):
+                    self._sever(client)
+                    return
                 self.state.ended = True
                 return
 
@@ -1168,6 +1255,8 @@ def _status_dict(sess: ReplaySession) -> dict[str, Any]:
         "packets_total": st.packets_total,
         "packets_sent": st.packets_sent,
         "injected": st.injected,
+        "stats_sent": st.stats_sent,
+        "duplicates_seen": st.stats_dupes,
         "connected": st.connected,
         "client": st.client_addr,
         "ended": st.ended,

--- a/src/meshtastic_mcp/server.py
+++ b/src/meshtastic_mcp/server.py
@@ -2328,7 +2328,8 @@ def replay_start(
     periodic "ETA — done/total" progress message to the busiest channel, so you
     can see from inside the app that it's a replay. `stats_interval` controls how
     often the connected replay observer publishes LocalStats while replay packets
-    flow; 0 keeps only the initial pre-node-DB snapshot. `dupe_every` simulates a
+    flow; 0 disables periodic updates but keeps the initial pre-node-DB snapshot
+    and, for non-looping replays, the final snapshot. `dupe_every` simulates a
     duplicate radio RX every Nth replay packet and includes it in LocalStats; 0
     disables synthetic duplicates. `modem_preset` sets the
     advertised LoRa preset (e.g. `LONG_FAST`, `SHORT_TURBO`); `firmware_edition`

--- a/src/meshtastic_mcp/server.py
+++ b/src/meshtastic_mcp/server.py
@@ -2257,6 +2257,8 @@ def replay_start(
     node_delay: float = 0.01,
     channels: list[dict[str, Any]] | None = None,
     announce_interval: float = 0.0,
+    stats_interval: float = 5.0,
+    dupe_every: int = 0,
     modem_preset: str = "LONG_FAST",
     firmware_edition: str = "VANILLA",
     firmware_version: str | None = None,
@@ -2324,7 +2326,11 @@ def replay_start(
 
     `announce_interval` > 0 adds a "Replay Clock" node that posts a kickoff and a
     periodic "ETA — done/total" progress message to the busiest channel, so you
-    can see from inside the app that it's a replay. `modem_preset` sets the
+    can see from inside the app that it's a replay. `stats_interval` controls how
+    often the connected replay observer publishes LocalStats while replay packets
+    flow; 0 keeps only the initial pre-node-DB snapshot. `dupe_every` simulates a
+    duplicate radio RX every Nth replay packet and includes it in LocalStats; 0
+    disables synthetic duplicates. `modem_preset` sets the
     advertised LoRa preset (e.g. `LONG_FAST`, `SHORT_TURBO`); `firmware_edition`
     sets the app's event banner (`VANILLA`, `DEFCON`, `BURNING_MAN`, `HAMVENTION`,
     …). `firmware_version` overrides the reported build; leave it unset to report
@@ -2399,6 +2405,8 @@ def replay_start(
         limit_nodes=limit_nodes,
         node_delay=node_delay,
         announce_interval=announce_interval,
+        stats_interval=stats_interval,
+        dupe_every=dupe_every,
         modem_preset=modem_preset,
         firmware_edition=firmware_edition,
         firmware_version=firmware_version,

--- a/src/meshtastic_mcp/skills/meshtastic-e2e/references/replay-app-features.md
+++ b/src/meshtastic_mcp/skills/meshtastic-e2e/references/replay-app-features.md
@@ -77,18 +77,24 @@ st = replay_status(sid)
 expected count, the message list scrolls. Pair with the recorder’s `logs_window` on the app’s
 logcat for the same window if you ship logs there.
 
-**Local device metrics + local stats:** the connected node reports its own telemetry every
-`local_metrics_interval` seconds (default 300; `0` to disable), in **both** variants — so two app
-views populate for the device it's connected to:
+**Local device metrics + local stats:** the connected node reports its own telemetry via two
+independent, separately-paced `TELEMETRY_APP` variants, so two app views populate for the device
+it's connected to:
 - `DEVICE_METRICS` → the **Device Metrics** view (battery/voltage/uptime + a channel-utilization
-  that tracks the live replay rate).
+  that tracks the live replay rate). Paced by `local_metrics_interval` seconds (default 300;
+  `0` to disable).
 - `LOCAL_STATS` → the **Local Stats** / live-activity view (packets rx/tx, rx-dupe, online/total
-  nodes = the mesh size, noise floor, uptime); packets-rx climbs as the observer receives the feed.
+  nodes = the mesh size + 1 for the observer itself, noise floor, uptime); packets-rx climbs as
+  the observer receives the feed, and channel-util/air-util track the *median* of the capture's
+  own `DEVICE_METRICS` samples rather than the live rate. Paced by `stats_interval` seconds
+  (default 5; `0` keeps only the initial pre-node-DB snapshot). An initial snapshot always sends
+  before the bulk node DB, and a final one on replay end (non-looping).
 
 Assert via `poll_for_text` on an uptime/battery/online-nodes value, or that channel-util reads
-"busy" under a high-rate stress stream. `replay_status().local_metrics` reports the interval +
-emitted count. Note both are `TELEMETRY_APP` from the observer node — the app only logs a
-node's *own* telemetry to these views when `packet.from == connectedNode`.
+"busy" under a high-rate stress stream. `replay_status()` reports `local_metrics` (interval +
+emitted count) and `stats_sent`/`duplicates_seen` for the two paces separately. Note both variants
+are `TELEMETRY_APP` from the observer node — the app only logs a node's *own* telemetry to these
+views when `packet.from == connectedNode`.
 
 **Disconnect-survival is now guaranteed:** with `loop=True`, closing/backgrounding the app (or a
 `Connection reset by peer`) severs only *that* connection — the session keeps listening and the
@@ -202,6 +208,11 @@ internally) rather than hand-injecting the pair.
 - **Two `_meshtastic._tcp` advertisers look identical in the picker.** A real WiFi-mDNS node on the
   LAN and your replay session both show up; the replay row is `RPLY_<id>`. Match on that, or
   `--no-mdns` / `mdns=False` and connect by IP to be unambiguous.
+- **Use `dupe_every=N` to exercise app duplicate-health UI.** The replay observer simulates a
+  duplicate radio RX every Nth delivered packet and reports the cumulative count through
+  `LOCAL_STATS`; like firmware, it suppresses the duplicate `MeshPacket` before the app.
+  `stats_interval` controls how often the app receives the updated counter. Both accept `0` to
+  disable their periodic behavior.
 - **A requested rate that isn’t met means the machine is the bottleneck,** not the pacer — the pacer
   is drift-free up to the raw send ceiling (thousands/sec). If `achieved_rate` sits below
   `target_rate` at a modest rate, look at the *reader*: a backgrounded/slow app stops draining its

--- a/src/meshtastic_mcp/skills/meshtastic-e2e/references/replay-app-features.md
+++ b/src/meshtastic_mcp/skills/meshtastic-e2e/references/replay-app-features.md
@@ -87,8 +87,8 @@ it's connected to:
   nodes = the mesh size + 1 for the observer itself, noise floor, uptime); packets-rx climbs as
   the observer receives the feed, and channel-util/air-util track the *median* of the capture's
   own `DEVICE_METRICS` samples rather than the live rate. Paced by `stats_interval` seconds
-  (default 5; `0` keeps only the initial pre-node-DB snapshot). An initial snapshot always sends
-  before the bulk node DB, and a final one on replay end (non-looping).
+  (default 5; `0` disables periodic updates). An initial snapshot always sends before the bulk node
+  DB, and a final one on replay end (non-looping).
 
 Assert via `poll_for_text` on an uptime/battery/online-nodes value, or that channel-util reads
 "busy" under a high-rate stress stream. `replay_status()` reports `local_metrics` (interval +
@@ -211,8 +211,9 @@ internally) rather than hand-injecting the pair.
 - **Use `dupe_every=N` to exercise app duplicate-health UI.** The replay observer simulates a
   duplicate radio RX every Nth delivered packet and reports the cumulative count through
   `LOCAL_STATS`; like firmware, it suppresses the duplicate `MeshPacket` before the app.
-  `stats_interval` controls how often the app receives the updated counter. Both accept `0` to
-  disable their periodic behavior.
+  `stats_interval` controls how often the app receives the updated counter; `0` disables periodic
+  `LOCAL_STATS` updates but keeps the initial pre-node-DB snapshot and, for non-looping replays, the
+  final snapshot. `dupe_every=0` disables synthetic duplicates.
 - **A requested rate that isn’t met means the machine is the bottleneck,** not the pacer — the pacer
   is drift-free up to the raw send ceiling (thousands/sec). If `achieved_rate` sits below
   `target_rate` at a modest rate, look at the *reader*: a backgrounded/slow app stops draining its

--- a/tests/unit/test_replay.py
+++ b/tests/unit/test_replay.py
@@ -20,9 +20,11 @@ import time
 from collections import Counter
 
 import pytest
-from meshtastic.protobuf import mesh_pb2
+from meshtastic.protobuf import mesh_pb2, portnums_pb2, telemetry_pb2
 
-from meshtastic_mcp.replay import ReplayParams, ReplaySession, capture, fuzz, sim
+from meshtastic_mcp.replay import Capture, ReplayParams, ReplaySession, capture, fuzz, sim
+from meshtastic_mcp.replay import engine as replay_engine
+from meshtastic_mcp.replay.engine import OBSERVER_NUM, _representative_radio_metrics
 
 ALL_PORTNUMS = {1, 3, 4, 5, 6, 8, 34, 37, 65, 66, 67, 70, 71}
 
@@ -34,6 +36,28 @@ def _portnum_counts(cap) -> Counter:
         mp.ParseFromString(raw)
         counts[mp.decoded.portnum] += 1
     return counts
+
+
+def test_representative_radio_metrics_ignore_malformed_protobufs():
+    """Malformed capture rows must not hide later valid radio metrics."""
+    malformed_telemetry = mesh_pb2.MeshPacket()
+    malformed_telemetry.decoded.portnum = portnums_pb2.PortNum.TELEMETRY_APP
+    malformed_telemetry.decoded.payload = b"\x80"
+
+    telemetry = telemetry_pb2.Telemetry()
+    telemetry.device_metrics.channel_utilization = 42.0
+    telemetry.device_metrics.air_util_tx = 7.0
+    valid_telemetry = mesh_pb2.MeshPacket()
+    valid_telemetry.decoded.portnum = portnums_pb2.PortNum.TELEMETRY_APP
+    valid_telemetry.decoded.payload = telemetry.SerializeToString()
+
+    assert _representative_radio_metrics(
+        [
+            (0, b"\x80", "LongFast"),
+            (1, malformed_telemetry.SerializeToString(), "LongFast"),
+            (2, valid_telemetry.SerializeToString(), "LongFast"),
+        ]
+    ) == (42.0, 7.0)
 
 
 def test_sim_is_seeded_and_has_full_portnum_breadth():
@@ -121,7 +145,7 @@ def test_session_handshake_and_stream():
                 my_node = fr.my_info.my_node_num
             elif v == "node_info":
                 node_infos += 1
-            elif v == "packet":
+            elif v == "packet" and (my_node is None or getattr(fr.packet, "from") != my_node):
                 packets += 1
         client.close()
 
@@ -134,6 +158,161 @@ def test_session_handshake_and_stream():
         assert sess.state.packets_sent >= packets
     finally:
         sess.stop()
+
+
+def test_observer_local_stats_precede_bulk_database():
+    """The tvOS strip gets LocalStats before the large node DB can delay rendering."""
+    cap = sim.generate(nodes=12, days=1, seed=17, start=1_700_000_000)
+    sess = ReplaySession(
+        "stats",
+        cap,
+        ReplayParams(
+            host="127.0.0.1",
+            port=0,
+            rate=500,
+            loop=True,
+            node_delay=0,
+            stats_interval=0.02,
+            dupe_every=1,
+            mdns=False,
+        ),
+    )
+    sess.start()
+    client = socket.create_connection(("127.0.0.1", sess.params.port), timeout=1)
+    client.settimeout(0.25)
+    try:
+        _send_toradio(client, want_config_id=69420)
+        _send_toradio(client, want_config_id=69421)
+
+        my_node = None
+        database_complete = False
+        captured_node_infos_before_stats = 0
+        initial_database_complete = None
+        initial_captured_node_info_count = None
+        observer_stats: list[dict[str, int | float]] = []
+        streamed_packet_ids: Counter[tuple[int, int]] = Counter()
+        deadline = time.time() + 3
+        while time.time() < deadline and len(observer_stats) < 2:
+            try:
+                fr = _read_frame(client)
+            except TimeoutError:
+                continue
+            variant = fr.WhichOneof("payload_variant")
+            if variant == "my_info":
+                my_node = fr.my_info.my_node_num
+            elif (
+                variant == "node_info"
+                and not observer_stats
+                and my_node is not None
+                and fr.node_info.num != my_node
+            ):
+                captured_node_infos_before_stats += 1
+            elif variant == "config_complete_id" and fr.config_complete_id == 69421:
+                database_complete = True
+            elif variant == "packet" and my_node is not None:
+                packet = fr.packet
+                if getattr(packet, "from") != my_node:
+                    streamed_packet_ids[(getattr(packet, "from"), packet.id)] += 1
+                    continue
+                if packet.decoded.portnum != 67:
+                    continue
+                telemetry = telemetry_pb2.Telemetry()
+                telemetry.ParseFromString(packet.decoded.payload)
+                if telemetry.WhichOneof("variant") == "local_stats":
+                    if not observer_stats:
+                        initial_database_complete = database_complete
+                        initial_captured_node_info_count = captured_node_infos_before_stats
+                    stats = telemetry.local_stats
+                    observer_stats.append(
+                        {
+                            "channel_utilization": stats.channel_utilization,
+                            "air_util_tx": stats.air_util_tx,
+                            "num_packets_tx": stats.num_packets_tx,
+                            "num_packets_rx": stats.num_packets_rx,
+                            "num_rx_dupe": stats.num_rx_dupe,
+                            "num_online_nodes": stats.num_online_nodes,
+                            "num_total_nodes": stats.num_total_nodes,
+                        }
+                    )
+
+        assert my_node == 0x42524331
+        assert len(observer_stats) == 2
+        assert initial_database_complete is False
+        assert initial_captured_node_info_count == 0
+        initial, updated = observer_stats
+        assert initial["channel_utilization"] >= 0
+        assert initial["air_util_tx"] >= 0
+        assert initial["num_packets_tx"] == 1
+        assert updated["num_packets_tx"] == 2
+        assert updated["num_packets_rx"] > initial["num_packets_rx"]
+        assert initial["num_rx_dupe"] == 0
+        assert updated["num_rx_dupe"] > initial["num_rx_dupe"]
+        assert updated["num_rx_dupe"] <= updated["num_packets_rx"]
+        assert streamed_packet_ids
+        assert all(count == 1 for count in streamed_packet_ids.values())
+        assert initial["num_online_nodes"] == len(cap.nodes) + 1
+        assert initial["num_total_nodes"] == len(cap.nodes) + 1
+        assert sess.state.stats_sent >= 2
+        assert updated["num_packets_rx"] - updated["num_rx_dupe"] <= sess.state.packets_sent
+    finally:
+        client.close()
+        sess.stop()
+
+
+@pytest.mark.parametrize(
+    ("stats_interval", "packet_count", "clock_values", "exhausts_window"),
+    [
+        (0.0, 1, [0.0, 0.0, 0.0, 0.0, 0.0], True),
+        (1.0, 2, [0.0, 0.0, 0.0, 0.0, 0.0, 2.0, 2.0], False),
+    ],
+)
+def test_observer_stats_send_failure_severs_client(
+    monkeypatch, tmp_path, stats_interval, packet_count, clock_values, exhausts_window
+):
+    """Periodic and final LocalStats failures must sever only the current client."""
+    monkeypatch.setenv("MESHTASTIC_MCP_DATA_DIR", str(tmp_path))
+    packets = []
+    for packet_id in range(packet_count):
+        packet = mesh_pb2.MeshPacket()
+        setattr(packet, "from", packet_id + 1)
+        packet.id = packet_id + 1
+        packet.decoded.portnum = portnums_pb2.PortNum.TEXT_MESSAGE_APP
+        packet.decoded.payload = b"test"
+        packets.append((packet_id, packet.SerializeToString(), "LongFast"))
+    sess = ReplaySession(
+        "stats-send-failure",
+        Capture(channels=["LongFast"], packets=packets),
+        ReplayParams(rate=500, loop=False, stats_interval=stats_interval, mdns=False),
+    )
+    client = socket.socket()
+    severed = []
+    sent_portnums = []
+    clock = iter(clock_values)
+
+    def send(frame):
+        sent_portnums.append(frame.packet.decoded.portnum)
+        if frame.packet.decoded.portnum == portnums_pb2.PortNum.TELEMETRY_APP:
+            raise OSError("peer closed")
+
+    monkeypatch.setattr(
+        replay_engine,
+        "time",
+        type("Clock", (), {"time": lambda _self: next(clock, clock_values[-1])})(),
+    )
+    # Stub _sever so the assertion observes which client the failure path selected.
+    monkeypatch.setattr(sess, "_sever", severed.append)
+    try:
+        sess._stream(send, client)
+    finally:
+        client.close()
+
+    assert sent_portnums[-1] == portnums_pb2.PortNum.TELEMETRY_APP
+    assert sess.state.packets_sent == 1
+    assert (sess.state.packets_sent == len(sess.window)) is exhausts_window
+    assert sess.state.stats_sent == 0
+    assert severed == [client]
+    assert sess.state.stop.is_set() is False
+    assert sess.state.ended is False
 
 
 def test_get_owner_request_is_answered_for_strict_clients():
@@ -598,16 +777,27 @@ def test_client_disconnect_mid_stream_survives_with_loop():
                 time.sleep(0.05)
         return None
 
-    def _handshake_and_get_packet(client):
+    def _handshake_and_get_packets(client):
         client.settimeout(10)
         _send_toradio(client, want_config_id=69420)
         _send_toradio(client, want_config_id=69421)
+        local_stats_seen = False
+        streamed_packet_seen = False
         t0 = time.time()
-        while time.time() - t0 < 5:
+        while time.time() - t0 < 5 and not (local_stats_seen and streamed_packet_seen):
             fr = _read_frame(client)
-            if fr.WhichOneof("payload_variant") == "packet":
-                return True
-        return False
+            if fr.WhichOneof("payload_variant") != "packet":
+                continue
+            packet = fr.packet
+            if getattr(packet, "from") != OBSERVER_NUM:
+                streamed_packet_seen = True
+                continue
+            if packet.decoded.portnum != 67:
+                continue
+            telemetry = telemetry_pb2.Telemetry()
+            telemetry.ParseFromString(packet.decoded.payload)
+            local_stats_seen = telemetry.WhichOneof("variant") == "local_stats"
+        return local_stats_seen, streamed_packet_seen
 
     cap = sim.generate(nodes=20, days=1, seed=8, start=1_700_000_000)
     probe = socket.socket()
@@ -623,7 +813,7 @@ def test_client_disconnect_mid_stream_survives_with_loop():
     try:
         first = _connect(port)
         assert first is not None
-        assert _handshake_and_get_packet(first)  # stream is flowing
+        assert _handshake_and_get_packets(first) == (True, True)
         # hard-disconnect mid-stream (app closed / reset by peer)
         first.setsockopt(socket.SOL_SOCKET, socket.SO_LINGER, struct.pack("ii", 1, 0))
         first.close()
@@ -636,7 +826,7 @@ def test_client_disconnect_mid_stream_survives_with_loop():
         # and a reconnect must handshake + stream again
         second = _connect(port)
         assert second is not None, "listener gone after mid-stream disconnect"
-        assert _handshake_and_get_packet(second), "no stream after reconnect"
+        assert _handshake_and_get_packets(second) == (True, True)
         second.close()
     finally:
         sess.stop()
@@ -670,6 +860,12 @@ def test_duration_nonpositive_is_rejected():
     for bad in (0, -5.0):
         with pytest.raises(ValueError, match="duration"):
             ReplaySession("bad", cap, ReplayParams(host="127.0.0.1", port=0, duration=bad))
+
+
+def test_dupe_every_negative_is_rejected():
+    cap = sim.generate(nodes=10, days=1, seed=1, start=1_700_000_000)
+    with pytest.raises(ValueError, match="dupe_every"):
+        ReplaySession("bad", cap, ReplayParams(dupe_every=-1))
 
 
 def test_session_does_not_mutate_caller_params():
@@ -1319,6 +1515,8 @@ def test_cli_replay_builds_session_from_args():
         edition="DEFCON",
         firmware_version=None,
         announce_interval=0.0,
+        stats_interval=2.5,
+        dupe_every=17,
         node_delay=0.0,
         no_mdns=True,
         local_metrics_interval=300.0,
@@ -1328,25 +1526,45 @@ def test_cli_replay_builds_session_from_args():
     assert sess.params.rate == 140.0
     assert sess.params.loop is True
     assert sess.params.mdns is False  # --no-mdns
-    assert sess.params.local_metrics_interval == 300.0
     assert sess.params.firmware_edition == "DEFCON"
     # Unset --firmware-version => the DEFCON replay reports the real event build.
     assert sess.params.firmware_version is None
+    assert sess.params.stats_interval == 2.5
+    assert sess.params.dupe_every == 17
+    assert sess.params.local_metrics_interval == 300.0
     assert len(sess.capture.nodes) == 30 + 2  # --profile override beat the preset
     assert sess.state.ended is False
 
 
+def test_mcp_replay_start_wires_dupe_every(monkeypatch):
+    from meshtastic_mcp import server
+
+    cap = sim.generate(nodes=2, days=1, seed=1, start=1_700_000_000)
+    captured = None
+
+    class Manager:
+        def start(self, capture, params):
+            nonlocal captured
+            assert capture is cap
+            captured = params
+            return {"id": "test"}
+
+    monkeypatch.setattr(server, "_load_replay_capture", lambda *_args, **_kwargs: cap)
+    monkeypatch.setattr(server, "get_replay_manager", lambda: Manager())
+
+    assert server.replay_start(dupe_every=23, mdns=False) == {"id": "test"}
+    assert captured is not None
+    assert captured.dupe_every == 23
+
+
 # ── Local device metrics + local stats (connected node reports its own stats) ─
 def test_local_metrics_emit_both_device_metrics_and_local_stats():
-    """The connected/observer node must emit BOTH telemetry variants on the
-    interval: DEVICE_METRICS (battery/voltage/uptime → app "Device Metrics") and
-    LOCAL_STATS (packets rx/tx, online nodes → app "Local Stats"). Both are
-    TELEMETRY_APP (67) from OBSERVER_NUM; values track the live replay.
+    """The connected/observer node must emit BOTH telemetry variants: DEVICE_METRICS
+    (battery/voltage/uptime → app "Device Metrics", on `local_metrics_interval`) and
+    LOCAL_STATS (packets rx/tx, online nodes → app "Local Stats", on the independent
+    `stats_interval`). Both are TELEMETRY_APP (67) from OBSERVER_NUM, self-addressed;
+    values track the live replay.
     """
-    from meshtastic.protobuf import telemetry_pb2
-
-    from meshtastic_mcp.replay.engine import OBSERVER_NUM
-
     cap = sim.generate(nodes=20, days=1, seed=5, start=1_700_000_000)
     probe = socket.socket()
     probe.bind(("127.0.0.1", 0))
@@ -1356,7 +1574,13 @@ def test_local_metrics_emit_both_device_metrics_and_local_stats():
         "localmetrics",
         cap,
         ReplayParams(
-            host="127.0.0.1", port=port, rate=100, node_delay=0, local_metrics_interval=0.5
+            host="127.0.0.1",
+            port=port,
+            rate=100,
+            node_delay=0,
+            local_metrics_interval=0.5,
+            stats_interval=0.5,
+            mdns=False,
         ),
     )
     sess.start()
@@ -1374,15 +1598,24 @@ def test_local_metrics_emit_both_device_metrics_and_local_stats():
         _send_toradio(client, want_config_id=69420)
         _send_toradio(client, want_config_id=69421)
 
+        def _have_both(seen):
+            # The pre-node-DB LOCAL_STATS snapshot legitimately reports rx == 0;
+            # keep reading until a later one shows the streamed feed arriving.
+            ls = seen.get("local_stats")
+            if "device_metrics" not in seen or ls is None:
+                return False
+            return ls.local_stats.num_packets_rx > 0
+
         seen: dict[str, object] = {}
         t0 = time.time()
-        while time.time() - t0 < 5 and {"device_metrics", "local_stats"} - seen.keys():
+        while time.time() - t0 < 5 and not _have_both(seen):
             fr = _read_frame(client)
             if fr.WhichOneof("payload_variant") != "packet":
                 continue
             pkt = fr.packet
             if pkt.decoded.portnum != 67 or getattr(pkt, "from") != OBSERVER_NUM:
                 continue
+            assert pkt.to == OBSERVER_NUM  # local status, self-addressed — not mesh traffic
             tm = telemetry_pb2.Telemetry()
             tm.ParseFromString(pkt.decoded.payload)
             seen[tm.WhichOneof("variant")] = tm
@@ -1394,8 +1627,11 @@ def test_local_metrics_emit_both_device_metrics_and_local_stats():
         assert dm.uptime_seconds > 0 and dm.channel_utilization > 0
         ls = seen["local_stats"].local_stats
         assert ls.uptime_seconds > 0
-        assert ls.num_online_nodes == len(cap.nodes)  # mesh size
+        assert ls.num_online_nodes == len(cap.nodes) + 1  # mesh size + the observer itself
+        assert ls.num_total_nodes == len(cap.nodes) + 1
         assert ls.num_packets_rx > 0  # observer received the streamed feed
+        assert ls.num_packets_rx_bad == 0
+        assert ls.num_tx_relay == 0
         assert ls.noise_floor < 0  # realistic RF noise floor
     finally:
         sess.stop()

--- a/tests/unit/test_replay.py
+++ b/tests/unit/test_replay.py
@@ -796,7 +796,7 @@ def test_client_disconnect_mid_stream_survives_with_loop():
                 continue
             telemetry = telemetry_pb2.Telemetry()
             telemetry.ParseFromString(packet.decoded.payload)
-            local_stats_seen = telemetry.WhichOneof("variant") == "local_stats"
+            local_stats_seen |= telemetry.WhichOneof("variant") == "local_stats"
         return local_stats_seen, streamed_packet_seen
 
     cap = sim.generate(nodes=20, days=1, seed=8, start=1_700_000_000)


### PR DESCRIPTION
## Summary

Replay now publishes connected-observer LocalStats before bulk node data and periodically, with optional synthetic duplicate RX accounting that mirrors firmware suppression without forwarding duplicate packets to the app.

## Test plan

Portable tier: `ruff check .`, `ruff format --check .`, `mypy`, SPDX validation, and `pytest tests/unit` (540 passed, 75 skipped); physical app tier: Bonjour conference-stress replay on an Apple TV 4K (3rd generation) showed the duplicate count rise from 0 to 84 to 185 while RX increased.

## Checklist

- [x] Gates pass (ruff, mypy — no new `ignore_errors`/`# noqa`, pytest unit tier)
- [x] New MCP tools have read/destructive/openWorld annotations; destructive ones take `confirm` (satisfied: no new tools were added; existing `replay_start` annotations are unchanged)
- [x] Core changes import/run with no firmware checkout
- [x] DCO sign-off (`git commit -s`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Replay now supports configurable LocalStats update intervals.
  - Added an option to simulate duplicate packet receptions during replay.
  - Replay status includes observer radio metrics, duplicate counts, and telemetry counters.
  - Initial, periodic, and final statistics are reported with clearer channel and node metrics.

- **Bug Fixes**
  - Duplicate packets are suppressed from mesh output while cumulative duplicate counts remain available.
  - Invalid duplicate settings are rejected.
  - Malformed telemetry no longer disrupts metric reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->