### PR TITLE
Replay sim: richer node identity — names, emoji short names, 2.8 signed node data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,13 +10,16 @@ All notable changes are documented here. Format loosely follows
   look in the app: (1) **better names** via the optional `[sim]` extra (Faker — person names,
   usernames, `<name>'s <device>`, ham callsigns); the sim falls back to its built-in
   adjective+noun pools when Faker is absent, so it only *improves* names and nothing depends on
-  it. (2) **Emoji short names** — a large emoji pool with `emoji_short_fraction` (default 0.35)
-  of nodes using a single emoji short-name, as real meshes do. (3) **2.8 signed node data** —
-  `pki_fraction` (default 0.6) of nodes advertise a 32-byte PKC `public_key` in their NodeInfo,
-  and `key_verified_fraction` (default 0.15) of those carry `is_key_manually_verified`, so the
-  app shows the 2.8 key / verification state. All seeded/deterministic and PII-free (every value
-  generated). Name generation draws a per-node seed so the RNG stream is identical whether or not
-  Faker is installed.
+  it. (2) **Emoji short names** — a large emoji pool with `emoji_short_fraction` (default 0.5)
+  of attendee nodes using a single emoji short-name, plus role-**pun** emoji short-names for
+  infrastructure (routers get 🗼/📡/🛜/🕸️/…). (3) **2.8 signed node data** — `pki_fraction`
+  (default 0.33) of nodes advertise a 32-byte PKC `public_key` in their NodeInfo, and
+  `key_verified_fraction` (default 0.05, i.e. verification is rare) of those carry
+  `is_key_manually_verified`; and on a **2.8+ edition** (e.g. `firmware_edition="DEFCON"`) the
+  **connected/observer node itself is signed** (advertises a stable public key), so the app shows
+  the local node signed. All seeded/deterministic and PII-free (every value generated). Node
+  identity draws from a dedicated child RNG, so tuning these cosmetic fractions never shifts the
+  simulation/traffic stream (the realism bands stay put).
 - **Replay local device metrics + local stats** (`replay_start(local_metrics_interval=…)`,
   default 300 s; CLI `--local-metrics-interval`) — the connected/observer node now emits its own
   telemetry every N seconds, like real firmware reporting itself, in **both** variants:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ All notable changes are documented here. Format loosely follows
 ## [Unreleased]
 
 ### Added
+- **Richer synthetic node identity** (replay sim) — three improvements to how generated nodes
+  look in the app: (1) **better names** via the optional `[sim]` extra (Faker — person names,
+  usernames, `<name>'s <device>`, ham callsigns); the sim falls back to its built-in
+  adjective+noun pools when Faker is absent, so it only *improves* names and nothing depends on
+  it. (2) **Emoji short names** — a large emoji pool with `emoji_short_fraction` (default 0.35)
+  of nodes using a single emoji short-name, as real meshes do. (3) **2.8 signed node data** —
+  `pki_fraction` (default 0.6) of nodes advertise a 32-byte PKC `public_key` in their NodeInfo,
+  and `key_verified_fraction` (default 0.15) of those carry `is_key_manually_verified`, so the
+  app shows the 2.8 key / verification state. All seeded/deterministic and PII-free (every value
+  generated). Name generation draws a per-node seed so the RNG stream is identical whether or not
+  Faker is installed.
 - **Replay local device metrics + local stats** (`replay_start(local_metrics_interval=…)`,
   default 300 s; CLI `--local-metrics-interval`) — the connected/observer node now emits its own
   telemetry every N seconds, like real firmware reporting itself, in **both** variants:

--- a/README.md
+++ b/README.md
@@ -217,7 +217,11 @@ replay_status(); replay_stop()
   statistics of real ~1,800-node captures (Burning Man + DEF CON 33) — proportions only; every
   identity, position, and message is generated. `sim.fit_profile(capture)` derives such a profile
   from any capture. Traceroutes are emitted as request→response pairs with firmware `RouteDiscovery`
-  semantics so app traceroute logs populate.
+  semantics so app traceroute logs populate. **Node identity**: richer names via the optional
+  `[sim]` extra (Faker person names / usernames / callsigns; falls back to built-in pools),
+  `emoji_short_fraction` of nodes with single-emoji short names, and **2.8 signed node data** —
+  `pki_fraction` advertise a 32-byte `public_key`, a `key_verified_fraction` slice manually
+  verified — so the app shows keys/verification like real 2.8 firmware.
 - **BBS/bot plane** (`sim_profile={"bots": {"count": N}}`, off by default) — a meshing-around-style
   scene: auto-reply bots (ping→pong pile-ons, `cmd`/`motd`/`wx`/`joke`/games menus) egged on by
   attendees, tapback (emoji-reaction) storms incl. one legendary 100+-reaction broadcast, per-bot

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,10 @@ ui = [
   "rich-pixels>=3.0",
 ]
 ui-min = ["opencv-python-headless>=4.9", "numpy>=1.26"]
+# Richer synthetic node names for the replay sim (Faker person names/usernames/
+# callsigns). Optional: the sim falls back to its built-in adjective+noun pools
+# when Faker is absent, so this only *improves* names — nothing depends on it.
+sim = ["faker>=20"]
 # macOS menu-bar controller for the FleetSuite service (start/stop/status).
 # macOS-only; the service and nightly run fine without it. See scripts/install-menubar.sh.
 menubar = ["rumps>=0.4; sys_platform == 'darwin'"]

--- a/src/meshtastic_mcp/replay/capture.py
+++ b/src/meshtastic_mcp/replay/capture.py
@@ -60,6 +60,10 @@ class NodeRow:
     role: str | None = None
     lat_i: int | None = None
     lon_i: int | None = None
+    # 2.8 signed node data: the node's PKC public key (32 bytes) and whether the
+    # connected device has manually verified it. None => a pre-2.8 / keyless node.
+    public_key: bytes | None = None
+    key_verified: bool = False
 
 
 @dataclass
@@ -434,6 +438,9 @@ def node_to_nodeinfo(n: NodeRow, *, last_heard: int) -> mesh_pb2.NodeInfo:
     ni.user.short_name = n.short_name or ni.user.id[-4:]
     ni.user.hw_model = _enum(mesh_pb2.HardwareModel, n.hw_model)
     ni.user.role = _enum(config_pb2.Config.DeviceConfig.Role, n.role)
+    if n.public_key:  # 2.8 signed node data: PKC key + manual-verification flag
+        ni.user.public_key = n.public_key
+        ni.is_key_manually_verified = n.key_verified
     if n.lat_i and n.lon_i:
         ni.position.latitude_i = n.lat_i
         ni.position.longitude_i = n.lon_i

--- a/src/meshtastic_mcp/replay/engine.py
+++ b/src/meshtastic_mcp/replay/engine.py
@@ -727,6 +727,27 @@ class ReplaySession:
         except (OSError, ConnectionError):
             pass
 
+    def _firmware_is_28plus(self) -> bool:
+        """True when the reported firmware version is >= 2.8 (has PKC signing)."""
+        v = firmware_version_for(self.params.firmware_edition, self.params.firmware_version)
+        try:
+            major, minor = (int(x) for x in v.split(".")[:2])
+        except (ValueError, IndexError):
+            return False
+        return (major, minor) >= (2, 8)
+
+    def _observer_public_key(self) -> bytes:
+        """A stable, synthetic 32-byte PKC public key for the connected node.
+
+        Deterministic in the observer num so the same replay device always
+        presents the same key (and distinct instances present distinct keys).
+        """
+        import hashlib
+
+        return hashlib.sha256(
+            b"replay-observer-pubkey" + self.params.observer_num.to_bytes(4, "little")
+        ).digest()
+
     def _observer_nodeinfo(self) -> mesh_pb2.FromRadio:
         fr = mesh_pb2.FromRadio()
         ni = fr.node_info
@@ -736,6 +757,10 @@ class ReplaySession:
         ni.user.short_name = "RPLY"
         ni.user.hw_model = mesh_pb2.HardwareModel.HELTEC_V3
         ni.user.role = config_pb2.Config.DeviceConfig.Role.CLIENT
+        # On 2.8+ editions (e.g. DEFCON) the connected node runs PKC firmware, so
+        # it advertises its own public key — the app shows the local node signed.
+        if self._firmware_is_28plus():
+            ni.user.public_key = self._observer_public_key()
         # "you are here": params override, else the capture's median position, so
         # the app map centers on the mesh and node distances are sensible.
         pos = None

--- a/src/meshtastic_mcp/replay/sim.py
+++ b/src/meshtastic_mcp/replay/sim.py
@@ -181,10 +181,11 @@ PROFILE: dict = {
     # Node identity flavor: fraction of (non-router) nodes whose short name is a
     # single emoji (hugely common on real meshes); fraction of nodes running
     # 2.8+ firmware that advertise a PKC public key (signed node data); and of
-    # those, the fraction the connected device has manually key-verified.
-    "emoji_short_fraction": 0.35,
-    "pki_fraction": 0.6,
-    "key_verified_fraction": 0.15,
+    # those, the fraction the connected device has manually key-verified (rare —
+    # most users never verify).
+    "emoji_short_fraction": 0.5,
+    "pki_fraction": 0.33,
+    "key_verified_fraction": 0.05,
     # Observer / RF gateway model (see replay/observer.py): when enabled, the
     # generated "all traffic that exists" stream is filtered + duplicated into
     # what a single gateway at the venue would have heard — RF loss with
@@ -525,6 +526,26 @@ _EMOJI_SHORT = [
     "🐧",
     "🍄",
     "🌮",
+]
+
+# Infrastructure short-names lean into role puns — routers/relays/hubs get a
+# tower/antenna/relay-themed emoji instead of a terse abbreviation, because even
+# the backbone deserves a little personality.
+_INFRA_EMOJI = [
+    "🗼",  # tower
+    "📡",  # dish / relay
+    "🛰️",  # satellite
+    "🛜",  # wireless
+    "🕸️",  # the mesh itself
+    "🔀",  # a router, routing
+    "🚦",  # traffic control
+    "🏃",  # relay runner
+    "🧭",  # always points the way
+    "🗄️",  # the server rack
+    "🌐",  # the network
+    "📶",  # full bars, always
+    "⚡",  # mains-powered, never sleeps
+    "🎛️",  # the mixing board
 ]
 
 
@@ -1091,9 +1112,14 @@ def _build_nodes(
     cl_w = [(c, c[4]) for c in P["clusters"]]
     ridx = 0
     fake = _get_faker()  # None unless the [sim] extra is installed
-    emoji_frac = P.get("emoji_short_fraction", 0.35)
-    pki_frac = P.get("pki_fraction", 0.6)
-    verified_frac = P.get("key_verified_fraction", 0.15)
+    emoji_frac = P.get("emoji_short_fraction", 0.5)
+    pki_frac = P.get("pki_fraction", 0.33)
+    verified_frac = P.get("key_verified_fraction", 0.05)
+    # Node identity (names, emoji shorts, PKC keys) draws from a *child* RNG so
+    # tuning these cosmetic fractions never perturbs the simulation stream
+    # (positions, traffic, text) — otherwise a fraction tweak shifts every
+    # downstream packet and drifts the calibrated realism bands.
+    id_rng = random.Random(rng.getrandbits(64))
     for i in range(nodes):
         while True:
             num = rng.randint(0x10000000, 0xEFFFFFFF)
@@ -1108,20 +1134,24 @@ def _build_nodes(
             cl = _weighted_cluster(rng, cl_w)
         if role in ("ROUTER", "ROUTER_LATE") and ridx < len(_ROUTER_NAMES):
             long = _ROUTER_NAMES[ridx]
-            short = "".join(ch for ch in long if ch.isalnum())[:4].upper()
+            # infra nodes get a role-pun emoji short (cycled so the backbone
+            # shows distinct icons), not a terse abbreviation.
+            short = _INFRA_EMOJI[ridx % len(_INFRA_EMOJI)]
             ridx += 1
         else:
-            # per-node name seed keeps the outer rng stream identical whether or
-            # not Faker is installed (only the name string differs).
-            long = _gen_node_name(rng.getrandbits(32), fake)
+            # per-node name seed keeps names deterministic whether or not Faker
+            # is installed (only the name string differs).
+            long = _gen_node_name(id_rng.getrandbits(32), fake)
             short = (
-                rng.choice(_EMOJI_SHORT) if rng.random() < emoji_frac else _short_from_long(long)
+                id_rng.choice(_EMOJI_SHORT)
+                if id_rng.random() < emoji_frac
+                else _short_from_long(long)
             )
-        # 2.8 signed node data: a public key on the ~pki_frac of nodes running
-        # 2.8+ firmware, a slice of which the connected device has verified.
-        if rng.random() < pki_frac:
-            pubkey = bytes(rng.getrandbits(8) for _ in range(32))
-            verified = rng.random() < verified_frac
+        # 2.8 signed node data: a public key on ~pki_frac of nodes running 2.8+
+        # firmware, a slice of which the connected device has verified.
+        if id_rng.random() < pki_frac:
+            pubkey = bytes(id_rng.getrandbits(8) for _ in range(32))
+            verified = id_rng.random() < verified_frac
         else:
             pubkey, verified = None, False
         lat, lon = _jitter(rng, cl[1], cl[2], cl[3])
@@ -1495,6 +1525,8 @@ def generate(
     beacon_iv = P.get("beacon_interval", 1800)
     beacon_frac = P.get("beacon_fraction", 0.4)
     beacon_nodes = [m for m in routers if rng.random() < beacon_frac]
+    if not beacon_nodes and routers:  # always keep at least one beacon emitter
+        beacon_nodes = [routers[0]]  # so MESH_BEACON_APP is never absent
     for m in beacon_nodes:
         t = start_epoch + rng.randint(0, beacon_iv)
         while t < end_epoch:

--- a/src/meshtastic_mcp/replay/sim.py
+++ b/src/meshtastic_mcp/replay/sim.py
@@ -417,7 +417,7 @@ _ROUTER_NAMES = [
     "Datil-Gate",
     "SouthBaldy-HI",
     "Davenport-HI",
-    "BaseCamp-Core",
+    "BaseCamp",
 ]
 _ADJ = [
     "Solar",

--- a/src/meshtastic_mcp/replay/sim.py
+++ b/src/meshtastic_mcp/replay/sim.py
@@ -178,6 +178,13 @@ PROFILE: dict = {
     # MESH_BEACON_APP packets, and the broadcast interval in seconds.
     "beacon_fraction": 0.4,
     "beacon_interval": 1800,
+    # Node identity flavor: fraction of (non-router) nodes whose short name is a
+    # single emoji (hugely common on real meshes); fraction of nodes running
+    # 2.8+ firmware that advertise a PKC public key (signed node data); and of
+    # those, the fraction the connected device has manually key-verified.
+    "emoji_short_fraction": 0.35,
+    "pki_fraction": 0.6,
+    "key_verified_fraction": 0.15,
     # Observer / RF gateway model (see replay/observer.py): when enabled, the
     # generated "all traffic that exists" stream is filtered + duplicated into
     # what a single gateway at the venue would have heard — RF loss with
@@ -453,6 +460,134 @@ _NOUN = [
     "Tumbleweed",
     "Hawk",
 ]
+
+# Emoji short-names — Meshtastic short names are ≤4 UTF-8 bytes, and a single
+# emoji is a hugely popular choice on real meshes. Big pool so `--nodes 1600`
+# shows real variety, not the same 4 faces.
+_EMOJI_SHORT = [
+    "🥔",
+    "🔥",
+    "⚡",
+    "📡",
+    "🛰️",
+    "🗼",
+    "🌵",
+    "🏜️",
+    "🌄",
+    "🦅",
+    "🦉",
+    "🐇",
+    "🐢",
+    "🦎",
+    "🐍",
+    "🦂",
+    "🐝",
+    "🐺",
+    "🦊",
+    "🐉",
+    "👽",
+    "🤖",
+    "💀",
+    "🎃",
+    "👾",
+    "🕹️",
+    "🎛️",
+    "🔋",
+    "🔌",
+    "📶",
+    "🛜",
+    "🧭",
+    "⛺",
+    "🚐",
+    "🚙",
+    "🏔️",
+    "🌲",
+    "☀️",
+    "🌙",
+    "⭐",
+    "✨",
+    "☄️",
+    "🌈",
+    "❄️",
+    "🌊",
+    "🎯",
+    "🚀",
+    "🛸",
+    "🔭",
+    "🧲",
+    "💡",
+    "🔦",
+    "🗝️",
+    "🦄",
+    "🐙",
+    "🦖",
+    "🦕",
+    "🐧",
+    "🍄",
+    "🌮",
+]
+
+
+def _get_faker():
+    """Return a cached Faker instance if the optional [sim] extra is installed,
+    else None. Names fall back to the built-in adjective+noun pools when absent,
+    so Faker only *improves* names and nothing depends on it."""
+    if _get_faker._cache is not _UNSET:  # type: ignore[attr-defined]
+        return _get_faker._cache  # type: ignore[attr-defined]
+    try:
+        from faker import Faker
+
+        _get_faker._cache = Faker()  # type: ignore[attr-defined]
+    except Exception:
+        _get_faker._cache = None  # type: ignore[attr-defined]
+    return _get_faker._cache  # type: ignore[attr-defined]
+
+
+_UNSET = object()
+_get_faker._cache = _UNSET  # type: ignore[attr-defined]
+
+# Ham-style callsign parts for a callsign-flavored subset (no Faker needed).
+_CALL_PREFIX = ["K", "W", "N", "A", "KJ", "KD", "KC", "WA", "AB", "AC", "AD", "AA"]
+
+
+def _gen_node_name(name_seed: int, fake) -> str:
+    """A synthetic, human-ish node long-name from a per-node seed.
+
+    Deterministic in `name_seed` (its own RNG) so the outer sim RNG stream is
+    unaffected by whether Faker is installed. With Faker: a mix of person names,
+    handles, "<name>'s <device>", and callsigns. Without: the adjective+noun
+    pools. Every value is generated — no real capture identity is used.
+    """
+    r = random.Random(name_seed)
+    if fake is not None:
+        fake.seed_instance(name_seed)
+        style = r.random()
+        if style < 0.40:
+            return fake.name()
+        if style < 0.62:
+            return f"{fake.first_name()}'s {r.choice(_NOUN)}"
+        if style < 0.80:
+            return fake.user_name()
+        if style < 0.92:
+            return _callsign(r)
+        return f"{fake.city()} {r.choice(_NOUN)}"
+    return f"{r.choice(_ADJ)} {r.choice(_NOUN)}"
+
+
+def _callsign(r: random.Random) -> str:
+    """A ham-style callsign, e.g. `KJ7ABC` (synthetic — not a real license)."""
+    suffix = "".join(r.choice("ABCDEFGHIJKLMNOPQRSTUVWXYZ") for _ in range(3))
+    return f"{r.choice(_CALL_PREFIX)}{r.randint(0, 9)}{suffix}"
+
+
+def _short_from_long(long: str) -> str:
+    """A ≤4-char alnum short name derived from a long name (initials/prefix)."""
+    words = [w for w in "".join(c if c.isalnum() or c == " " else " " for c in long).split() if w]
+    if len(words) >= 2:
+        return (words[0][:2] + words[1][:2]).title()[:4]
+    alnum = "".join(c for c in long if c.isalnum())
+    return (alnum[:4] or "NODE").title()
+
 
 _CHATTER = {
     "LongFast": [
@@ -955,6 +1090,10 @@ def _build_nodes(
     used: set[int] = set()
     cl_w = [(c, c[4]) for c in P["clusters"]]
     ridx = 0
+    fake = _get_faker()  # None unless the [sim] extra is installed
+    emoji_frac = P.get("emoji_short_fraction", 0.35)
+    pki_frac = P.get("pki_fraction", 0.6)
+    verified_frac = P.get("key_verified_fraction", 0.15)
     for i in range(nodes):
         while True:
             num = rng.randint(0x10000000, 0xEFFFFFFF)
@@ -972,8 +1111,19 @@ def _build_nodes(
             short = "".join(ch for ch in long if ch.isalnum())[:4].upper()
             ridx += 1
         else:
-            a, n = rng.choice(_ADJ), rng.choice(_NOUN)
-            long, short = f"{a} {n}", (a[:2] + n[:2]).title()
+            # per-node name seed keeps the outer rng stream identical whether or
+            # not Faker is installed (only the name string differs).
+            long = _gen_node_name(rng.getrandbits(32), fake)
+            short = (
+                rng.choice(_EMOJI_SHORT) if rng.random() < emoji_frac else _short_from_long(long)
+            )
+        # 2.8 signed node data: a public key on the ~pki_frac of nodes running
+        # 2.8+ firmware, a slice of which the connected device has verified.
+        if rng.random() < pki_frac:
+            pubkey = bytes(rng.getrandbits(8) for _ in range(32))
+            verified = rng.random() < verified_frac
+        else:
+            pubkey, verified = None, False
         lat, lon = _jitter(rng, cl[1], cl[2], cl[3])
         mobile = role == "TRACKER" or cl[0] == "Rovers"
         # Talkativeness: real meshes are heavily skewed (top ~1% of nodes carry a
@@ -1011,6 +1161,8 @@ def _build_nodes(
                 role,
                 int(lat * 1e7),
                 int(lon * 1e7),
+                public_key=pubkey,
+                key_verified=verified,
             )
         )
         meta.append(
@@ -1655,6 +1807,8 @@ def _pl_nodeinfo(nr: NodeRow):
     u.short_name = nr.short_name or nr.node_id[-4:]
     u.hw_model = _enum(mesh_pb2.HardwareModel, nr.hw_model)
     u.role = _enum(config_pb2.Config.DeviceConfig.Role, nr.role)
+    if nr.public_key:  # 2.8 nodes advertise their PKC public key in NodeInfo
+        u.public_key = nr.public_key
     return u.SerializeToString()
 
 

--- a/src/meshtastic_mcp/replay/sim.py
+++ b/src/meshtastic_mcp/replay/sim.py
@@ -470,10 +470,10 @@ _EMOJI_SHORT = [
     "🔥",
     "⚡",
     "📡",
-    "🛰️",
+    "🛰",
     "🗼",
     "🌵",
-    "🏜️",
+    "🏜",
     "🌄",
     "🦅",
     "🦉",
@@ -491,8 +491,8 @@ _EMOJI_SHORT = [
     "💀",
     "🎃",
     "👾",
-    "🕹️",
-    "🎛️",
+    "🕹",
+    "🎛",
     "🔋",
     "🔌",
     "📶",
@@ -501,15 +501,15 @@ _EMOJI_SHORT = [
     "⛺",
     "🚐",
     "🚙",
-    "🏔️",
+    "🏔",
     "🌲",
-    "☀️",
+    "☀",
     "🌙",
     "⭐",
     "✨",
-    "☄️",
+    "☄",
     "🌈",
-    "❄️",
+    "❄",
     "🌊",
     "🎯",
     "🚀",
@@ -518,7 +518,7 @@ _EMOJI_SHORT = [
     "🧲",
     "💡",
     "🔦",
-    "🗝️",
+    "🗝",
     "🦄",
     "🐙",
     "🦖",
@@ -534,18 +534,18 @@ _EMOJI_SHORT = [
 _INFRA_EMOJI = [
     "🗼",  # tower
     "📡",  # dish / relay
-    "🛰️",  # satellite
+    "🛰",  # satellite
     "🛜",  # wireless
-    "🕸️",  # the mesh itself
+    "🕸",  # the mesh itself
     "🔀",  # a router, routing
     "🚦",  # traffic control
     "🏃",  # relay runner
     "🧭",  # always points the way
-    "🗄️",  # the server rack
+    "🗄",  # the server rack
     "🌐",  # the network
     "📶",  # full bars, always
     "⚡",  # mains-powered, never sleeps
-    "🎛️",  # the mixing board
+    "🎛",  # the mixing board
 ]
 
 

--- a/tests/unit/test_replay.py
+++ b/tests/unit/test_replay.py
@@ -291,6 +291,7 @@ def test_all_sim_data_is_synthetic(monkeypatch):
             assert 33_000_000_0 < n.lat_i < 35_000_000_0
             assert -109_000_000_0 < n.lon_i < -106_000_000_0
     # text payloads come only from the synthetic CHATTER pools (or range-test seq)
+    allowed_short = set(_sim._SHORT)
     pool = {t for msgs in _sim._CHATTER.values() for t in msgs}
     templates = [p.split("{h}")[0] for p in pool]
     for _ts, raw, _ch in cap.packets:
@@ -298,7 +299,7 @@ def test_all_sim_data_is_synthetic(monkeypatch):
         mp.ParseFromString(raw)
         if mp.decoded.portnum == 1:
             txt = mp.decoded.payload.decode("utf-8", "replace")
-            assert any(txt.startswith(t) for t in templates), txt
+            assert txt in allowed_short or any(txt.startswith(t) for t in templates), txt
 
 
 # ── Node identity: emoji short names + 2.8 signed node data ─────────────────

--- a/tests/unit/test_replay.py
+++ b/tests/unit/test_replay.py
@@ -309,16 +309,21 @@ def test_sim_emoji_shortnames_and_pki_keys():
     """
     from meshtastic_mcp.replay import capture, sim
 
-    cap = sim.generate(nodes=300, days=1, seed=8, start=1_700_000_000)
+    n = 600
+    cap = sim.generate(nodes=n, days=1, seed=8, start=1_700_000_000)
+    pki_frac = sim.PROFILE["pki_fraction"]
     emoji_pool = set(sim._EMOJI_SHORT)
-    emoji = [n for n in cap.nodes if n.short_name in emoji_pool]
-    keyed = [n for n in cap.nodes if n.public_key]
-    verified = [n for n in cap.nodes if n.key_verified]
-    assert len(emoji) > 30  # a meaningful emoji-short population
-    assert 0.4 * len(cap.nodes) < len(keyed) < 0.8 * len(cap.nodes)  # ~pki_fraction
-    assert all(len(n.public_key) == 32 for n in keyed)  # Curve25519-sized keys
-    assert verified  # some manually-verified
-    assert {n.num for n in verified}.issubset({n.num for n in keyed})  # verified ⊆ keyed
+    emoji = [x for x in cap.nodes if x.short_name in emoji_pool]
+    keyed = [x for x in cap.nodes if x.public_key]
+    verified = [x for x in cap.nodes if x.key_verified]
+    # emoji shorts apply to non-router nodes at emoji_short_fraction
+    assert len(emoji) > 0.35 * n  # ~half, minus routers + variance
+    # keyed ≈ pki_fraction of all nodes (±0.1 tolerance for a finite draw)
+    assert (pki_frac - 0.1) * n < len(keyed) < (pki_frac + 0.1) * n
+    assert all(len(x.public_key) == 32 for x in keyed)  # Curve25519-sized keys
+    # verified is a small slice (key_verified_fraction) of keyed — present but sparse
+    assert 0 < len(verified) < 0.2 * len(keyed)
+    assert {x.num for x in verified}.issubset({x.num for x in keyed})  # verified ⊆ keyed
 
     # the key + manual-verification flag reach the app via the node-DB NodeInfo
     ni = capture.node_to_nodeinfo(keyed[0], last_heard=1)
@@ -329,13 +334,47 @@ def test_sim_emoji_shortnames_and_pki_keys():
     assert not capture.node_to_nodeinfo(keyless, last_heard=1).user.public_key
 
 
+def test_infra_nodes_get_pun_emoji_shortnames():
+    """Infrastructure (router) nodes get a role-pun emoji short name, not an
+    abbreviation — the backbone gets personality too.
+    """
+    from meshtastic_mcp.replay import sim
+
+    cap = sim.generate(nodes=60, days=1, seed=3, start=1_700_000_000)
+    router_names = set(sim._ROUTER_NAMES)
+    infra = [n for n in cap.nodes if n.long_name in router_names]
+    assert infra  # the seeded infra core exists
+    assert all(n.short_name in set(sim._INFRA_EMOJI) for n in infra)
+
+
+def test_observer_is_signed_on_28_editions():
+    """The connected/observer node advertises its own PKC public key on a 2.8+
+    edition (e.g. DEFCON), so the app shows the local node signed — and not on a
+    pre-2.8 edition.
+    """
+    cap = sim.generate(nodes=5, days=1, seed=1, start=1_700_000_000)
+    signed = ReplaySession(
+        "d", cap, ReplayParams(host="127.0.0.1", port=0, firmware_edition="DEFCON")
+    )
+    ni = signed._observer_nodeinfo().node_info
+    assert len(ni.user.public_key) == 32  # DEFCON => 2.8 => signed
+    unsigned = ReplaySession(
+        "v", cap, ReplayParams(host="127.0.0.1", port=0, firmware_edition="VANILLA")
+    )
+    assert not unsigned._observer_nodeinfo().node_info.user.public_key  # 2.7.x => not signed
+
+
 def test_pki_and_emoji_fractions_are_tunable():
     from meshtastic_mcp.replay import sim
 
     prof = {"pki_fraction": 0.0, "emoji_short_fraction": 0.0}
     cap = sim.generate(nodes=100, days=1, seed=2, start=1_700_000_000, profile=prof)
     assert all(n.public_key is None for n in cap.nodes)  # PKI fully off
-    assert all(n.short_name not in set(sim._EMOJI_SHORT) for n in cap.nodes)
+    # emoji_short_fraction=0 disables *attendee* emoji shorts; infra nodes still
+    # get their role-pun emoji (that's not governed by the fraction).
+    router_names = set(sim._ROUTER_NAMES)
+    attendees = [n for n in cap.nodes if n.long_name not in router_names]
+    assert all(n.short_name not in set(sim._EMOJI_SHORT) for n in attendees)
 
 
 def test_faker_name_path_used_when_available():

--- a/tests/unit/test_replay.py
+++ b/tests/unit/test_replay.py
@@ -267,11 +267,15 @@ def _write_sqlite(path, cap) -> None:
     conn.close()
 
 
-def test_all_sim_data_is_synthetic():
+def test_all_sim_data_is_synthetic(monkeypatch):
     # The sim is informed by *aggregate stats* from real captures, but every
     # identity/position/message must be generated. Guard the PII vectors.
     from meshtastic_mcp.replay import sim as _sim
 
+    # Force the built-in name path (Faker off) so the guard is deterministic and
+    # independent of whether the optional [sim] extra is installed. Faker names
+    # are themselves synthetic; the pool path is the one with a checkable shape.
+    monkeypatch.setattr(_sim, "_get_faker", lambda: None)
     cap = _sim.generate(nodes=80, days=1, seed=5, start=1_700_000_000)
     router_names = set(_sim._ROUTER_NAMES)
     for n in cap.nodes:
@@ -295,6 +299,81 @@ def test_all_sim_data_is_synthetic():
         if mp.decoded.portnum == 1:
             txt = mp.decoded.payload.decode("utf-8", "replace")
             assert any(txt.startswith(t) for t in templates), txt
+
+
+# ── Node identity: emoji short names + 2.8 signed node data ─────────────────
+def test_sim_emoji_shortnames_and_pki_keys():
+    """A share of nodes get emoji short names, and ~pki_fraction advertise a
+    32-byte PKC public key (2.8 signed node data) with a verified subset — and
+    both ride the NodeInfo the app downloads.
+    """
+    from meshtastic_mcp.replay import capture, sim
+
+    cap = sim.generate(nodes=300, days=1, seed=8, start=1_700_000_000)
+    emoji_pool = set(sim._EMOJI_SHORT)
+    emoji = [n for n in cap.nodes if n.short_name in emoji_pool]
+    keyed = [n for n in cap.nodes if n.public_key]
+    verified = [n for n in cap.nodes if n.key_verified]
+    assert len(emoji) > 30  # a meaningful emoji-short population
+    assert 0.4 * len(cap.nodes) < len(keyed) < 0.8 * len(cap.nodes)  # ~pki_fraction
+    assert all(len(n.public_key) == 32 for n in keyed)  # Curve25519-sized keys
+    assert verified  # some manually-verified
+    assert {n.num for n in verified}.issubset({n.num for n in keyed})  # verified ⊆ keyed
+
+    # the key + manual-verification flag reach the app via the node-DB NodeInfo
+    ni = capture.node_to_nodeinfo(keyed[0], last_heard=1)
+    assert len(ni.user.public_key) == 32
+    assert capture.node_to_nodeinfo(verified[0], last_heard=1).is_key_manually_verified is True
+    # a keyless (pre-2.8) node advertises no key and is unverified
+    keyless = next(n for n in cap.nodes if not n.public_key)
+    assert not capture.node_to_nodeinfo(keyless, last_heard=1).user.public_key
+
+
+def test_pki_and_emoji_fractions_are_tunable():
+    from meshtastic_mcp.replay import sim
+
+    prof = {"pki_fraction": 0.0, "emoji_short_fraction": 0.0}
+    cap = sim.generate(nodes=100, days=1, seed=2, start=1_700_000_000, profile=prof)
+    assert all(n.public_key is None for n in cap.nodes)  # PKI fully off
+    assert all(n.short_name not in set(sim._EMOJI_SHORT) for n in cap.nodes)
+
+
+def test_faker_name_path_used_when_available():
+    """When Faker is present, node long-names come from it (richer than the
+    adj+noun pool); the generator stays deterministic in its per-node seed.
+    """
+    from meshtastic_mcp.replay import sim
+
+    class _StubFaker:
+        def __init__(self):
+            self._n = 0
+
+        def seed_instance(self, s):
+            self._n = s
+
+        def name(self):
+            return f"Person{self._n % 1000}"
+
+        def first_name(self):
+            return "Sam"
+
+        def user_name(self):
+            return f"user{self._n % 1000}"
+
+        def city(self):
+            return "Metropolis"
+
+    seed = 123456789
+    a = sim._gen_node_name(seed, _StubFaker())
+    b = sim._gen_node_name(seed, _StubFaker())
+    assert a == b  # deterministic in the seed
+    # a Faker-flavored name is not a bare "<Adj> <Noun>" from the fallback pool
+    adj, _, noun = a.partition(" ")
+    assert not (adj in sim._ADJ and noun in sim._NOUN) or "Person" in a or "user" in a
+    # fallback (no Faker) is the adjective+noun pool
+    fb = sim._gen_node_name(seed, None)
+    fadj, _, fnoun = fb.partition(" ")
+    assert fadj in sim._ADJ and fnoun in sim._NOUN
 
 
 # ── Fuzzer ───────────────────────────────────────────────────────────────────

--- a/uv.lock
+++ b/uv.lock
@@ -397,7 +397,7 @@ name = "clr-loader"
 version = "0.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cffi" },
+    { name = "cffi", marker = "sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/e4/46/7eea92b6aa2d68af78e049cbecec5f757f1aad44ecdecdc16bbad7eead51/clr_loader-0.3.1.tar.gz", hash = "sha256:2e073e9aaf49d1ae2f56ecba27987ad5fb68be4bcd9dd34a5bed8f0e4e128366", size = 86805, upload-time = "2026-04-18T17:49:44.287Z" }
 wheels = [
@@ -563,7 +563,7 @@ name = "cuda-bindings"
 version = "13.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cuda-pathfinder" },
+    { name = "cuda-pathfinder", marker = "python_full_version < '3.15' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/51/6b/457ca12dad3ee9bfcc9a545cfd6b64b359ba49de40f776f6e028e678f262/cuda_bindings-13.3.1-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c5879712accf6e14bb01aa5e67440eb84998b8d104b509cc7a6dc0b8f656a474", size = 6053539, upload-time = "2026-05-29T23:11:43.19Z" },
@@ -596,43 +596,43 @@ wheels = [
 
 [package.optional-dependencies]
 cublas = [
-    { name = "nvidia-cublas", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
-    { name = "nvidia-cuda-nvrtc", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cublas", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-cuda-nvrtc", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 cudart = [
-    { name = "nvidia-cuda-runtime", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cuda-runtime", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 cufft = [
-    { name = "nvidia-cufft", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
-    { name = "nvidia-nvjitlink", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cufft", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-nvjitlink", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 cufile = [
-    { name = "nvidia-cufile", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cufile", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 cupti = [
-    { name = "nvidia-cuda-cupti", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cuda-cupti", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 curand = [
-    { name = "nvidia-curand", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-curand", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 cusolver = [
-    { name = "nvidia-cublas", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
-    { name = "nvidia-cusolver", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
-    { name = "nvidia-cusparse", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
-    { name = "nvidia-nvjitlink", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cublas", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-cusolver", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-cusparse", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-nvjitlink", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 cusparse = [
-    { name = "nvidia-cusparse", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
-    { name = "nvidia-nvjitlink", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cusparse", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-nvjitlink", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 nvjitlink = [
-    { name = "nvidia-nvjitlink", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-nvjitlink", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 nvrtc = [
-    { name = "nvidia-cuda-nvrtc", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cuda-nvrtc", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 nvtx = [
-    { name = "nvidia-nvtx", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-nvtx", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 
 [[package]]
@@ -754,6 +754,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8a/0e/97c33bf5009bdbac74fd2beace167cab3f978feb69cc36f1ef79360d6c4e/exceptiongroup-1.3.1-py3-none-any.whl", hash = "sha256:a7a39a3bd276781e98394987d3a5701d0c4edffb633bb7a5144577f82c773598", size = 16740, upload-time = "2025-11-21T23:01:53.443Z" },
+]
+
+[[package]]
+name = "faker"
+version = "40.36.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "tzdata", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/98/d2/026af1e002bbc6df534d1f8262b18ec79a974f928e9290bfbfdfe7c7b2af/faker-40.36.0.tar.gz", hash = "sha256:754048c76c03afa7de83eee8f4bcee3cf668cbb7d995f54a4e9678db7f110308", size = 2025903, upload-time = "2026-07-24T21:11:33.088Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/50/9a/b947ed175ce9a0dcb070ccf3607f0ce8720cfb5ed1a36166a150b2acd5af/faker-40.36.0-py3-none-any.whl", hash = "sha256:82b9497d9cfe017048075bcf969298a74b1b6e39f5e4dad1211085d1133f7b62", size = 2062829, upload-time = "2026-07-24T21:11:31.37Z" },
 ]
 
 [[package]]
@@ -979,7 +991,7 @@ name = "importlib-metadata"
 version = "9.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "zipp" },
+    { name = "zipp", marker = "python_full_version < '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a9/01/15bb152d77b21318514a96f43af312635eb2500c96b55398d020c93d86ea/importlib_metadata-9.0.0.tar.gz", hash = "sha256:a4f57ab599e6a2e3016d7595cfd72eb4661a5106e787a95bcc90c7105b831efc", size = 56405, upload-time = "2026-03-20T06:42:56.999Z" }
 wheels = [
@@ -1415,6 +1427,9 @@ sdr = [
     { name = "pyrtlsdr" },
     { name = "pyrtlsdrlib" },
 ]
+sim = [
+    { name = "faker" },
+]
 tak = [
     { name = "meshtastic-tak" },
 ]
@@ -1456,6 +1471,7 @@ requires-dist = [
     { name = "coverage", extras = ["toml"], marker = "extra == 'test'", specifier = ">=7" },
     { name = "cryptography", marker = "extra == 'inject'", specifier = ">=42.0" },
     { name = "easyocr", marker = "(platform_machine != 'x86_64' and extra == 'ui') or (sys_platform != 'darwin' and extra == 'ui')", specifier = ">=1.7" },
+    { name = "faker", marker = "extra == 'sim'", specifier = ">=20" },
     { name = "fastapi", marker = "extra == 'web'", specifier = ">=0.110" },
     { name = "fastmcp", specifier = ">=3.4.5,<4" },
     { name = "mcp", specifier = ">=1.2" },
@@ -1488,7 +1504,7 @@ requires-dist = [
     { name = "textual", marker = "extra == 'test'", specifier = ">=0.50" },
     { name = "uvicorn", extras = ["standard"], marker = "extra == 'web'", specifier = ">=0.27" },
 ]
-provides-extras = ["dev", "inject", "menubar", "sdr", "tak", "test", "ui", "ui-min", "web"]
+provides-extras = ["dev", "inject", "menubar", "sdr", "sim", "tak", "test", "ui", "ui-min", "web"]
 
 [[package]]
 name = "meshtastic-tak"
@@ -1759,7 +1775,7 @@ name = "nvidia-cublas"
 version = "13.1.1.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cuda-nvrtc" },
+    { name = "nvidia-cuda-nvrtc", marker = "sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a7/a1/0bd24ee8c8d03adac032fd2909426a00c88f8c57961b1277ded97f91119f/nvidia_cublas-13.1.1.3-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:b7a210458267ac818974c53038fbec2e969d5c99f305ab15c72522fa9f001dd5", size = 542848918, upload-time = "2026-04-08T18:46:22.985Z" },
@@ -1798,7 +1814,7 @@ name = "nvidia-cudnn-cu13"
 version = "9.20.0.48"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas" },
+    { name = "nvidia-cublas", marker = "sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/56/c5/83384d846b2fd17c44bd499b36c75a45ed4f095fbbb2252294e89cea5c5c/nvidia_cudnn_cu13-9.20.0.48-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:e31454ae00094b0c55319d9d15b6fa2fc50a9e1c0f5c8c80fb75258234e731e1", size = 444574296, upload-time = "2026-03-09T19:28:27.751Z" },
@@ -1810,7 +1826,7 @@ name = "nvidia-cufft"
 version = "12.0.0.61"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink" },
+    { name = "nvidia-nvjitlink", marker = "sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8b/ae/f417a75c0259e85c1d2f83ca4e960289a5f814ed0cea74d18c353d3e989d/nvidia_cufft-12.0.0.61-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:2708c852ef8cd89d1d2068bdbece0aa188813a0c934db3779b9b1faa8442e5f5", size = 214053554, upload-time = "2025-09-04T08:31:38.196Z" },
@@ -1840,9 +1856,9 @@ name = "nvidia-cusolver"
 version = "12.0.4.66"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas" },
-    { name = "nvidia-cusparse" },
-    { name = "nvidia-nvjitlink" },
+    { name = "nvidia-cublas", marker = "sys_platform != 'win32'" },
+    { name = "nvidia-cusparse", marker = "sys_platform != 'win32'" },
+    { name = "nvidia-nvjitlink", marker = "sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c8/c3/b30c9e935fc01e3da443ec0116ed1b2a009bb867f5324d3f2d7e533e776b/nvidia_cusolver-12.0.4.66-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:02c2457eaa9e39de20f880f4bd8820e6a1cfb9f9a34f820eb12a155aa5bc92d2", size = 223467760, upload-time = "2025-09-04T08:33:04.222Z" },
@@ -1854,7 +1870,7 @@ name = "nvidia-cusparse"
 version = "12.6.3.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink" },
+    { name = "nvidia-nvjitlink", marker = "sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f8/94/5c26f33738ae35276672f12615a64bd008ed5be6d1ebcb23579285d960a9/nvidia_cusparse-12.6.3.3-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:80bcc4662f23f1054ee334a15c72b8940402975e0eab63178fc7e670aa59472c", size = 162155568, upload-time = "2025-09-04T08:33:42.864Z" },
@@ -2351,7 +2367,7 @@ name = "pyobjc-framework-cocoa"
 version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pyobjc-core" },
+    { name = "pyobjc-core", marker = "sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/51/34/fbe38a204643aa4e1b91391cdce07a34da565a69171ebcad08de7438a556/pyobjc_framework_cocoa-12.2.1.tar.gz", hash = "sha256:b94b37fe5730e5ae1fb0052912cd174e6ec329b0bfba4a012ae5db1014b5864b", size = 3125751, upload-time = "2026-06-19T16:20:05.159Z" }
 wheels = [
@@ -2370,8 +2386,8 @@ name = "pyobjc-framework-corebluetooth"
 version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pyobjc-core" },
-    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-core", marker = "sys_platform != 'win32'" },
+    { name = "pyobjc-framework-cocoa", marker = "sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/d4/91/c76f3c5e8e80c7047e43c4c05b3e6fda9a7cefad5aae85487007674c966c/pyobjc_framework_corebluetooth-12.2.1.tar.gz", hash = "sha256:7dbb285295097205bebbcb11f55161e5faa02111108fb7b17536176e31971eb0", size = 37568, upload-time = "2026-06-19T16:20:12.191Z" }
 wheels = [
@@ -2390,8 +2406,8 @@ name = "pyobjc-framework-libdispatch"
 version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pyobjc-core" },
-    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-core", marker = "sys_platform != 'win32'" },
+    { name = "pyobjc-framework-cocoa", marker = "sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/d9/3f/561653aff3f19873457c95c053f0298da517be89fdfc0ec35115ed5b7030/pyobjc_framework_libdispatch-12.2.1.tar.gz", hash = "sha256:0d24eda41c6c258135077f60d410e704bc7b5a67adcb2ca463918896c7363795", size = 40336, upload-time = "2026-06-19T16:20:56.371Z" }
 wheels = [
@@ -2410,8 +2426,8 @@ name = "pyobjc-framework-quartz"
 version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pyobjc-core" },
-    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-core", marker = "sys_platform != 'win32'" },
+    { name = "pyobjc-framework-cocoa", marker = "sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/3b/f6/2a8b84dbf1fe7c04dd96ea73d991678d4e09a909f51971ecc51629bb2ab4/pyobjc_framework_quartz-12.2.1.tar.gz", hash = "sha256:b3b8b6f71e66147f8ff9e6213864cc8527e3a0b1ee90835b93ce221f4802d9b0", size = 3215521, upload-time = "2026-06-19T16:21:30.199Z" }
 wheels = [
@@ -2430,8 +2446,8 @@ name = "pyobjc-framework-security"
 version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pyobjc-core" },
-    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-core", marker = "sys_platform != 'win32'" },
+    { name = "pyobjc-framework-cocoa", marker = "sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/44/b8/4267b802d8dba6de468e7d0765b05cc4e146fa376ed9f55e0b6461016bef/pyobjc_framework_security-12.2.1.tar.gz", hash = "sha256:d7831b1537f4346892e7f2f0e2b09d79bee98919b0767f4061278d0e03028f2d", size = 181065, upload-time = "2026-06-19T16:21:40.151Z" }
 wheels = [
@@ -2450,8 +2466,8 @@ name = "pyobjc-framework-uniformtypeidentifiers"
 version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pyobjc-core" },
-    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-core", marker = "sys_platform != 'win32'" },
+    { name = "pyobjc-framework-cocoa", marker = "sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/74/a1/108fa1e5a3dd8aff626f98fb97de370323b290404b04ffa2ef9420665ed3/pyobjc_framework_uniformtypeidentifiers-12.2.1.tar.gz", hash = "sha256:1fb89d13aa3c2df8e6d6536f6df3493fe5a6caefd2a5adebf17c5af3b29ed4a2", size = 20679, upload-time = "2026-06-19T16:21:55.739Z" }
 wheels = [
@@ -2463,8 +2479,8 @@ name = "pyobjc-framework-webkit"
 version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pyobjc-core" },
-    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-core", marker = "sys_platform != 'win32'" },
+    { name = "pyobjc-framework-cocoa", marker = "sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/11/d2/b230c594f70ecb970b4cef67bae2648d1bfa5b381e9b7e3710bf24ec8887/pyobjc_framework_webkit-12.2.1.tar.gz", hash = "sha256:a56acae55b50d549b20dff2921ad1099add8fbc377d0de09ddc2ba50957f7def", size = 332374, upload-time = "2026-06-19T16:22:01.988Z" }
 wheels = [
@@ -2746,7 +2762,7 @@ name = "pythonnet"
 version = "3.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "clr-loader" },
+    { name = "clr-loader", marker = "sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/05/57/da1992e44663b71365c6e842c8d7fa453d4ec45fb99a68cfee5b7e944d3c/pythonnet-3.1.0.tar.gz", hash = "sha256:7b34c382905d10a371509ffafd64cae0416305c28817738a9cd138336f4e9991", size = 250599, upload-time = "2026-05-23T20:30:21.578Z" }
 wheels = [
@@ -2867,7 +2883,7 @@ name = "qtpy"
 version = "2.4.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "packaging" },
+    { name = "packaging", marker = "sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/70/01/392eba83c8e47b946b929d7c46e0f04b35e9671f8bb6fc36b6f7945b4de8/qtpy-2.4.3.tar.gz", hash = "sha256:db744f7832e6d3da90568ba6ccbca3ee2b3b4a890c3d6fbbc63142f6e4cdf5bb", size = 66982, upload-time = "2025-02-11T15:09:25.759Z" }
 wheels = [
@@ -3109,7 +3125,7 @@ name = "rumps"
 version = "0.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-framework-cocoa", marker = "sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b2/e2/2e6a47951290bd1a2831dcc50aec4b25d104c0cf00e8b7868cbd29cf3bfe/rumps-0.4.0.tar.gz", hash = "sha256:17fb33c21b54b1e25db0d71d1d793dc19dc3c0b7d8c79dc6d833d0cffc8b1596", size = 39257, upload-time = "2022-10-15T05:15:10.386Z" }
 
@@ -3191,7 +3207,7 @@ resolution-markers = [
     "python_full_version < '3.12' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" } },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/7a/97/5a3609c4f8d58b039179648e62dd220f89864f56f7357f5d4f45c29eb2cc/scipy-1.17.1.tar.gz", hash = "sha256:95d8e012d8cb8816c226aef832200b1d45109ed4464303e997c5b13122b297c0", size = 30573822, upload-time = "2026-02-23T00:26:24.851Z" }
 wheels = [
@@ -3270,7 +3286,7 @@ resolution-markers = [
     "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.5.0", source = { registry = "https://pypi.org/simple" } },
+    { name = "numpy", version = "2.5.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a7/25/c2700dfaf6442b4effaa91af24ebce5dc9d31bb4a69706313aae70d72cd0/scipy-1.18.0.tar.gz", hash = "sha256:67b2ad2ad54c72ca6d04975a9b2df8c3638c34ddd5b28738e94fc2b57929d378", size = 30774447, upload-time = "2026-06-19T15:01:43.456Z" }
 wheels = [
@@ -3321,8 +3337,8 @@ name = "secretstorage"
 version = "3.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cryptography" },
-    { name = "jeepney" },
+    { name = "cryptography", marker = "sys_platform != 'win32'" },
+    { name = "jeepney", marker = "sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884, upload-time = "2025-11-23T19:02:53.191Z" }
 wheels = [
@@ -3471,7 +3487,7 @@ resolution-markers = [
     "python_full_version < '3.12' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" } },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c5/cb/2f6d79c7576e22c116352a801f4c3c8ace5957e9aced862012430b62e14f/tifffile-2026.3.3.tar.gz", hash = "sha256:d9a1266bed6f2ee1dd0abde2018a38b4f8b2935cb843df381d70ac4eac5458b7", size = 388745, upload-time = "2026-03-03T19:14:38.134Z" }
 wheels = [
@@ -3491,7 +3507,7 @@ resolution-markers = [
     "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.5.0", source = { registry = "https://pypi.org/simple" } },
+    { name = "numpy", version = "2.5.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b7/38/5e2ecef5af2f4fd4a89bb8d6240de9458bab4d51a4cbd97aeb3a0cd618e2/tifffile-2026.6.1.tar.gz", hash = "sha256:626c892c0e899d959b9438e7c0e1491dc154a7fead1f1f37a991724a50eceba9", size = 429694, upload-time = "2026-05-31T23:57:12.165Z" }
 wheels = [
@@ -3664,6 +3680,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
+]
+
+[[package]]
+name = "tzdata"
+version = "2026.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/92/ff/5a28bdfd8c3ebec42564ac7d0e54ca3db65044a9314a97f9564fa7a1e926/tzdata-2026.3.tar.gz", hash = "sha256:4a1518b8993086a7982523e071643f3c0e5f213e75b21318e78bcabfff9d1415", size = 198674, upload-time = "2026-07-10T08:50:37.887Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/6d/b53b99a9f2766d095985947a5782f1702cabb129a34f7a802d7197af832f/tzdata-2026.3-py2.py3-none-any.whl", hash = "sha256:dc096730c87af6cab1b171c9d532be840741ff5d459015e7f6947bd7d7e54931", size = 348168, upload-time = "2026-07-10T08:50:36.46Z" },
 ]
 
 [[package]]
@@ -3923,7 +3948,7 @@ name = "winrt-runtime"
 version = "3.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions" },
+    { name = "typing-extensions", marker = "sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/16/dd/acdd527c1d890c8f852cc2af644aa6c160974e66631289420aa871b05e65/winrt_runtime-3.2.1.tar.gz", hash = "sha256:c8dca19e12b234ae6c3dadf1a4d0761b51e708457492c13beb666556958801ea", size = 21721, upload-time = "2025-06-06T14:40:27.593Z" }
 wheels = [
@@ -3946,7 +3971,7 @@ name = "winrt-windows-devices-bluetooth"
 version = "3.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "winrt-runtime" },
+    { name = "winrt-runtime", marker = "sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b2/a0/1c8a0c469abba7112265c6cb52f0090d08a67c103639aee71fc690e614b8/winrt_windows_devices_bluetooth-3.2.1.tar.gz", hash = "sha256:db496d2d92742006d5a052468fc355bf7bb49e795341d695c374746113d74505", size = 23732, upload-time = "2025-06-06T14:41:20.489Z" }
 wheels = [
@@ -3969,7 +3994,7 @@ name = "winrt-windows-devices-bluetooth-advertisement"
 version = "3.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "winrt-runtime" },
+    { name = "winrt-runtime", marker = "sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/06/fc/7ffe66ca4109b9e994b27c00f3d2d506e6e549e268791f755287ad9106d8/winrt_windows_devices_bluetooth_advertisement-3.2.1.tar.gz", hash = "sha256:0223852a7b7fa5c8dea3c6a93473bd783df4439b1ed938d9871f947933e574cc", size = 16906, upload-time = "2025-06-06T14:41:21.448Z" }
 wheels = [
@@ -3992,7 +4017,7 @@ name = "winrt-windows-devices-bluetooth-genericattributeprofile"
 version = "3.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "winrt-runtime" },
+    { name = "winrt-runtime", marker = "sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/44/21/aeeddc0eccdfbd25e543360b5cc093233e2eab3cdfb53ad3cabae1b5d04d/winrt_windows_devices_bluetooth_genericattributeprofile-3.2.1.tar.gz", hash = "sha256:cdf6ddc375e9150d040aca67f5a17c41ceaf13a63f3668f96608bc1d045dde71", size = 38896, upload-time = "2025-06-06T14:41:22.687Z" }
 wheels = [
@@ -4015,7 +4040,7 @@ name = "winrt-windows-devices-enumeration"
 version = "3.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "winrt-runtime" },
+    { name = "winrt-runtime", marker = "sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/9e/dd/75835bfbd063dffa152109727dedbd80f6e92ea284855f7855d48cdf31c9/winrt_windows_devices_enumeration-3.2.1.tar.gz", hash = "sha256:df316899e39bfc0ffc1f3cb0f5ee54d04e1d167fbbcc1484d2d5121449a935cf", size = 23538, upload-time = "2025-06-06T14:41:26.787Z" }
 wheels = [
@@ -4038,7 +4063,7 @@ name = "winrt-windows-devices-radios"
 version = "3.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "winrt-runtime" },
+    { name = "winrt-runtime", marker = "sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/5e/02/9704ea359ad8b0d6faa1011f98fb477e8fb6eac5201f39d19e73c2407e7b/winrt_windows_devices_radios-3.2.1.tar.gz", hash = "sha256:4dc9b9d1501846049eb79428d64ec698d6476c27a357999b78a8331072e18a0b", size = 5908, upload-time = "2025-06-06T14:41:44.868Z" }
 wheels = [
@@ -4061,7 +4086,7 @@ name = "winrt-windows-foundation"
 version = "3.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "winrt-runtime" },
+    { name = "winrt-runtime", marker = "sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0c/55/098ce7ea0679efcc1298b269c48768f010b6c68f90c588f654ec874c8a74/winrt_windows_foundation-3.2.1.tar.gz", hash = "sha256:ad2f1fcaa6c34672df45527d7c533731fdf65b67c4638c2b4aca949f6eec0656", size = 30485, upload-time = "2025-06-06T14:41:53.344Z" }
 wheels = [
@@ -4084,7 +4109,7 @@ name = "winrt-windows-foundation-collections"
 version = "3.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "winrt-runtime" },
+    { name = "winrt-runtime", marker = "sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ef/62/d21e3f1eeb8d47077887bbf0c3882c49277a84d8f98f7c12bda64d498a07/winrt_windows_foundation_collections-3.2.1.tar.gz", hash = "sha256:0eff1ad0d8d763ad17e9e7bbd0c26a62b27215016393c05b09b046d6503ae6d5", size = 16043, upload-time = "2025-06-06T14:41:53.983Z" }
 wheels = [
@@ -4107,7 +4132,7 @@ name = "winrt-windows-storage-streams"
 version = "3.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "winrt-runtime" },
+    { name = "winrt-runtime", marker = "sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/00/50/f4488b07281566e3850fcae1021f0285c9653992f60a915e15567047db63/winrt_windows_storage_streams-3.2.1.tar.gz", hash = "sha256:476f522722751eb0b571bc7802d85a82a3cae8b1cce66061e6e758f525e7b80f", size = 34335, upload-time = "2025-06-06T14:43:23.905Z" }
 wheels = [


### PR DESCRIPTION
## Summary

Makes generated replay nodes look far more like a real mesh in the app, in three ways:

- **Better names** — the request was "add faker.js"; faker.js is JS and the sim is pure Python, so this uses the Python **`Faker`** package as an optional **`[sim]`** extra: person names, usernames, `<name>'s <device>`, and ham callsigns (e.g. `KJ9DCX`). The sim **falls back** to its built-in adjective+noun pools when Faker isn't installed, so it only *improves* names and nothing depends on it. Name generation draws a per-node seed, so the sim RNG stream is identical with or without Faker — determinism preserved.
- **Emoji short names** — a large emoji pool; `emoji_short_fraction` (default 0.35) of non-router nodes use a single-emoji short name, as real meshes do.
- **2.8 signed node data** — `pki_fraction` (default 0.6) of nodes advertise a 32-byte PKC `public_key` in their NodeInfo/User, and `key_verified_fraction` (default 0.15) of those carry `NodeInfo.is_key_manually_verified`, so the app shows the 2.8 key / verification state. The key rides both the streamed NodeInfo (`User.public_key`) and the node-DB download (`node_to_nodeinfo`).

All seeded and **PII-free** (every value generated — Faker output is synthetic too).

## Test plan
- `test_all_sim_data_is_synthetic` forces the built-in name path (Faker off via monkeypatch) so the PII guard is environment-independent.
- `test_sim_emoji_shortnames_and_pki_keys` — emoji-short population, ~`pki_fraction` keyed nodes with 32-byte keys, verified ⊆ keyed, and the key + verified flag on the wire in `node_to_nodeinfo`.
- `test_pki_and_emoji_fractions_are_tunable`, `test_faker_name_path_used_when_available` (Faker path via a stub — no dependency needed in CI).
- Gates green: ruff, mypy, **540** unit tests without the extra (fallback path) **and** the replay/realism suites with `[sim]` installed (Faker path). Verified both name paths are deterministic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added richer, deterministic replay-simulation identities with optional names, emoji labels, and infrastructure-themed naming.
  * Added configurable public-key and verification metadata for simulated nodes.
  * Added signed node information on compatible firmware editions.
  * Ensured generated data remains privacy-safe and reproducible, with reliable beacon generation.

* **Documentation**
  * Updated replay-simulation documentation with identity, signing, and optional enhanced name-generation details.
  * Documented fallback behavior when enhanced name generation is unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->