### PR TITLE
fix(atak): accept empty bootanim prop in wait_for_boot

### DIFF
--- a/src/meshtastic_mcp/emulator/atak.py
+++ b/src/meshtastic_mcp/emulator/atak.py
@@ -294,7 +294,9 @@ def wait_for_boot(serial: str, *, timeout: float = 300.0) -> None:
         anim = avd.adb(
             "shell", "getprop", "init.svc.bootanim", serial=serial, check=False
         ).stdout.strip()
-        if booted == "1" and anim == "stopped":
+        # `-no-boot-anim` (a fleet flag) leaves the bootanim service unstarted,
+        # so the prop is empty rather than "stopped".
+        if booted == "1" and anim in ("stopped", ""):
             return
         time.sleep(2)
     raise AtakError(f"{serial} did not finish booting within {timeout}s")

--- a/tests/unit/test_atak_fleet.py
+++ b/tests/unit/test_atak_fleet.py
@@ -181,3 +181,36 @@ def test_provision_tag_keyed_on_apk_bytes(tmp_path: Path) -> None:
     assert t1 != t2
     assert t1.startswith("provisioned_")
     assert t1 == atak.provision_tag(str(apk1))  # stable
+
+
+# ---------------------------------------------------------------------------
+# wait_for_boot
+# ---------------------------------------------------------------------------
+class _Adb:
+    def __init__(self, props: dict[str, str]) -> None:
+        self.props = props
+
+    def __call__(self, *args: str, **kw: object) -> object:
+        class R:
+            stdout = ""
+
+        r = R()
+        if args[:2] == ("shell", "getprop"):
+            r.stdout = self.props.get(args[2], "")
+        return r
+
+
+def test_wait_for_boot_accepts_no_boot_anim(monkeypatch: pytest.MonkeyPatch) -> None:
+    # `-no-boot-anim` (a fleet flag) means the bootanim service never starts,
+    # so the prop is empty rather than "stopped" — must still count as booted.
+    monkeypatch.setattr(atak.avd, "adb", _Adb({"sys.boot_completed": "1"}))
+    atak.wait_for_boot("emulator-5554", timeout=1)
+
+
+def test_wait_for_boot_waits_while_anim_running(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        atak.avd, "adb", _Adb({"sys.boot_completed": "1", "init.svc.bootanim": "running"})
+    )
+    monkeypatch.setattr(atak.time, "sleep", lambda _s: None)
+    with pytest.raises(atak.AtakError):
+        atak.wait_for_boot("emulator-5554", timeout=0.2)


### PR DESCRIPTION
The fleet boots with `-no-boot-anim`, which leaves the bootanim service unstarted — `init.svc.bootanim` reads empty, never `stopped` — so every cold `atak_fleet_up` timed out at 300 s despite `sys.boot_completed=1`. Reproduced on a fresh `medium_phone` clone; boot completes in ~37 s with the prop empty.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved emulator startup detection when boot animation is disabled or unavailable.
  * Emulators are now recognized as ready once system boot completes, while still rejecting instances with an active boot animation.
* **Tests**
  * Added coverage for successful boot detection and timeout behavior when boot animation remains active.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->