### PR TITLE
fix(atak): fleet headroom on the Play image + first-run walk resilience

### DIFF
--- a/docs/atak-cot.md
+++ b/docs/atak-cot.md
@@ -90,6 +90,25 @@ backgrounded tails.
 - **GeoChat needs ≥2 relayed clients.** Broadcast GeoChat to "All Chat Rooms" on
   a lone client stays local and never hits the wire — the relay (or a real peer)
   is what makes `b-t-f` chat transmit. This is why the relay rebroadcasts.
+- **Prefs go in `config/prefs/defaults` — no extension.** That is the only
+  file ATAK ingests (`PreferenceControl.ingestDefaults`, once at
+  `ATAKActivity` start, then deleted). A `.pref` in `config/prefs/` or
+  `import/` is never read. `provision()` uses it for the stream; the same
+  file sets `locationCallsign`, `locationTeam`, `atakRoleType` (e.g. `K9`),
+  and `locationReportingStrategy=Constant` (capitalised; `constant` is
+  silently ignored and you stay on the 180 s stationary default).
+- **Emulators on one host share a LAN** (`10.0.2.x`, ping works), so ATAK
+  learns peers' direct `ip:4242:tcp` endpoints and sends GeoChat
+  point-to-point — **bypassing the relay**. Set
+  `autoDisableMeshSAWhenStreaming=true` (`CommsMapComponent.setPreferStreamEndpoint`)
+  so chat + receipts go via the stream and get captured.
+- **Nothing but PLI auto-shares.** Markers, shapes, routes and R&B need an
+  explicit Send (details pane → Send → Broadcast); only SPI (5 s) and
+  "broadcast"-toggled markers repeat. 911 is one-shot per toggle in 5.6.
+  `t-x-d-d` is receive-only — inject it. See `atak-cot-emission.md`.
+- **Self-PLI speed comes only from the fix.** `drive_route` stamps
+  velocity on each `geo fix`; course still reflects the virtual compass
+  (no bearing parameter; `geo nmea` is ignored by current emulators).
 - **`t-x-c-t` is a real, undocumented type.** ATAK emits a client keepalive ping
   every few seconds; it is **not** in the TAKPacket-SDK fixture corpus.
 - **Lone-client reconnect cycle.** A single silent client is dropped by ATAK's

--- a/src/meshtastic_mcp/emulator/atak.py
+++ b/src/meshtastic_mcp/emulator/atak.py
@@ -29,7 +29,7 @@ Design, folding in the fleet-orchestration research:
   a ~15 min setup into a ~60 s bring-up. The snapshot is keyed on
   (APK sha, system-image build) so a stale one is re-provisioned, not errored.
 * **Headless footprint flags** and a real boot health check
-  (``sys.boot_completed`` + ``init.svc.bootanim=stopped``), matching what the CI
+  (``sys.boot_completed`` + ``init.svc.bootanim`` stopped or unstarted), matching what the CI
   emulator actions wait on.
 
 ``adb emu geo fix`` takes **longitude first** — a silent wrong-hemisphere trap
@@ -92,10 +92,12 @@ _FLEET_FLAGS = (
     "-noaudio",
     "-no-boot-anim",
     "-no-metrics",
+    # The Play image runs GMS dex2oat + Play Store after boot; at 2 cores / 2 GB
+    # the emulator ANRs through ATAK's first run.
     "-cores",
-    "2",
+    "3",
     "-memory",
-    "2048",
+    "4096",
     # ATAK-CIV is ~108 MB; the default 6 GB userdata is ~94% full out of the box.
     "-partition-size",
     "8192",
@@ -284,7 +286,7 @@ def boot(
 
 def wait_for_boot(serial: str, *, timeout: float = 300.0) -> None:
     """Block until ``serial`` reports ``sys.boot_completed=1`` AND the boot
-    animation has stopped — the health check the CI emulator actions use."""
+    animation is stopped or unstarted — the health check the CI emulator actions use."""
     deadline = time.time() + timeout
     avd.adb("wait-for-device", serial=serial, timeout=timeout, check=False)
     while time.time() < deadline:
@@ -412,6 +414,10 @@ def _walk_first_run(serial: str, *, timeout: float = 90.0) -> None:
     idx = 0
     while time.time() < deadline and idx < len(_FIRST_RUN_LABELS):
         label = _FIRST_RUN_LABELS[idx]
+        # A starved emulator throws an ANR dialog over the EULA; Wait, never Close app.
+        if avd.find_text("isn't responding", serial=serial) and _tap_label(serial, "Wait"):
+            time.sleep(1.5)
+            continue
         if _tap_label(serial, label):
             idx += 1
             time.sleep(1.5)
@@ -425,10 +431,13 @@ def _walk_first_run(serial: str, *, timeout: float = 90.0) -> None:
 def _tap_label(serial: str, label: str) -> bool:
     # avd._find_center handles center as a [x,y] list OR "[x,y]" string (the
     # emulator `android layout` path emits the latter) — don't re-unpack inline.
-    c = avd._find_center(
-        lambda el: el.get("text") == label and "clickable" in el.get("interactions", []),
-        serial=serial,
-    )
+    try:
+        c = avd._find_center(
+            lambda el: el.get("text") == label and "clickable" in el.get("interactions", []),
+            serial=serial,
+        )
+    except avd.EmulatorError:  # transient non-JSON dump mid-animation: not on screen
+        return False
     if c is None:
         return False
     avd.tap(c[0], c[1], serial=serial)
@@ -461,6 +470,17 @@ def provision(
         ATAK_PACKAGE,
         "MANAGE_EXTERNAL_STORAGE",
         "allow",
+        serial=serial,
+        check=False,
+    )
+    # Play Store background sync starves the headless emulator; ATAK needs none of it.
+    avd.adb(
+        "shell",
+        "pm",
+        "disable-user",
+        "--user",
+        "0",
+        "com.android.vending",
         serial=serial,
         check=False,
     )

--- a/src/meshtastic_mcp/emulator/atak.py
+++ b/src/meshtastic_mcp/emulator/atak.py
@@ -390,7 +390,12 @@ def stream_pref(host: str, port: int, *, name: str = "cotcapture") -> str:
 
 
 def push_stream_pref(serial: str, host: str, port: int, *, name: str = "cotcapture") -> None:
-    """Write the streaming-input pref into ATAK's config + import dirs."""
+    """Write the streaming-input pref where ATAK auto-loads it.
+
+    Only ``config/prefs/defaults`` (no extension) is ingested — once, at
+    ``ATAKActivity`` start, then deleted (``PreferenceControl.ingestDefaults``).
+    A ``.pref`` dropped there or in ``import/`` is never read.
+    """
     import tempfile
 
     pref = stream_pref(host, port, name=name)
@@ -398,11 +403,7 @@ def push_stream_pref(serial: str, host: str, port: int, *, name: str = "cotcaptu
         fh.write(pref)
         local = fh.name
     try:
-        for dest in (
-            "/sdcard/atak/config/prefs/cotcapture.pref",
-            "/sdcard/atak/import/cotcapture.pref",
-        ):
-            avd.adb("push", local, dest, serial=serial, check=False)
+        avd.adb("push", local, "/sdcard/atak/config/prefs/defaults", serial=serial, check=False)
     finally:
         Path(local).unlink(missing_ok=True)  # don't leave the temp pref on the host
 

--- a/src/meshtastic_mcp/emulator/atak.py
+++ b/src/meshtastic_mcp/emulator/atak.py
@@ -419,6 +419,14 @@ def push_stream_pref(serial: str, host: str, port: int, *, name: str = "cotcaptu
         Path(local).unlink(missing_ok=True)  # don't leave the temp pref on the host
 
 
+def _has_text(serial: str, token: str) -> bool:
+    """``avd.find_text`` that reads a transient bad layout dump as "not on screen"."""
+    try:
+        return avd.find_text(token, serial=serial)
+    except avd.EmulatorError:
+        return False
+
+
 def _walk_first_run(serial: str, *, timeout: float = 90.0) -> None:
     """Best-effort tap through ATAK's first-run dialogs (EULA → rationale →
     permission grants → device setup → battery)."""
@@ -427,7 +435,7 @@ def _walk_first_run(serial: str, *, timeout: float = 90.0) -> None:
     while time.time() < deadline and idx < len(_FIRST_RUN_LABELS):
         label = _FIRST_RUN_LABELS[idx]
         # A starved emulator throws an ANR dialog over the EULA; Wait, never Close app.
-        if avd.find_text("isn't responding", serial=serial) and _tap_label(serial, "Wait"):
+        if _has_text(serial, "isn't responding") and _tap_label(serial, "Wait"):
             time.sleep(1.5)
             continue
         if _tap_label(serial, label):
@@ -436,7 +444,7 @@ def _walk_first_run(serial: str, *, timeout: float = 90.0) -> None:
         else:
             time.sleep(1.0)
         # Bail once the map toolbar is up (nav menu button present).
-        if avd.find_text("Tools", serial=serial):
+        if _has_text(serial, "Tools"):
             return
 
 

--- a/src/meshtastic_mcp/emulator/atak.py
+++ b/src/meshtastic_mcp/emulator/atak.py
@@ -307,10 +307,20 @@ def wait_for_boot(serial: str, *, timeout: float = 300.0) -> None:
 # ---------------------------------------------------------------------------
 # GPS / movement (emulator console)
 # ---------------------------------------------------------------------------
-def set_position(serial: str, lat: float, lon: float) -> None:
+def set_position(serial: str, lat: float, lon: float, *, speed_mps: float | None = None) -> None:
     """Set the emulator's GPS fix. Args are (lat, lon) in map order; the console
-    `geo fix` wants longitude first, swapped here."""
-    avd.adb("emu", "geo", "fix", f"{lon:.7f}", f"{lat:.7f}", serial=serial, check=False)
+    `geo fix` wants longitude first, swapped here.
+
+    ``speed_mps`` rides along as geo fix's optional velocity (knots) — ATAK
+    reads ``Location.getSpeed()`` and never derives speed from successive
+    fixes, so without it every PLI reports ``speed="0.0"``. Bearing has no
+    geo fix parameter (and ``geo nmea`` is ignored by current emulators), so
+    ``<track course>`` still reflects the virtual compass, not the route.
+    """
+    args = ["emu", "geo", "fix", f"{lon:.7f}", f"{lat:.7f}"]
+    if speed_mps is not None:
+        args += ["280", "8", f"{speed_mps * 1.943844:.1f}"]  # alt m, satellites, knots
+    avd.adb(*args, serial=serial, check=False)
 
 
 def set_battery(serial: str, percent: int) -> None:
@@ -345,8 +355,9 @@ def drive_route(
     """Feed a moving GPS track along ``waypoints`` (each ``(lat, lon)``).
 
     Emits a fix every ``step_s`` seconds, spacing points so ground speed is
-    ~``speed_mps``, so ATAK derives a live course/speed from consecutive
-    positions (the emulator test provider reports only position, not velocity).
+    ~``speed_mps``, and stamps that speed on each fix so ATAK's PLI carries
+    it (ATAK does not derive speed from consecutive positions; course still
+    comes from the virtual compass — see ``set_position``).
     Blocks until the route completes or ``stop_event`` is set. Emulator-only —
     a physical device rejects mock location for self-PLI.
     """
@@ -364,9 +375,9 @@ def drive_route(
         for lat, lon in _interp(a, b, steps):
             if stop_event is not None and stop_event.is_set():
                 return
-            set_position(serial, lat, lon)
+            set_position(serial, lat, lon, speed_mps=speed_mps)
             time.sleep(step_s)
-    set_position(serial, *waypoints[-1])
+    set_position(serial, *waypoints[-1], speed_mps=0.0)
 
 
 # ---------------------------------------------------------------------------

--- a/src/meshtastic_mcp/replay/cot_relay.py
+++ b/src/meshtastic_mcp/replay/cot_relay.py
@@ -59,7 +59,13 @@ _SEQ_RE = re.compile(r"^(\d+)_")
 _EVENT_START = b"<event"
 _EVENT_END = b"</event>"
 _TYPE_RE = re.compile(rb'\btype="([^"]+)"')
-_CALLSIGN_RE = re.compile(rb'\bcallsign="([^"]+)"')
+# Station identity, in order of trust: the <contact> element (PLI, markers),
+# then GeoChat's senderCallsign. A bare callsign= would also match
+# <marti><dest callsign> — the *recipient* — and mislabel chat events.
+_CALLSIGN_RES = (
+    re.compile(rb'<contact\b[^>]*\bcallsign="([^"]+)"'),
+    re.compile(rb'\bsenderCallsign="([^"]+)"'),
+)
 
 # A single event above this size is almost certainly a framing error (unbounded
 # buffer growth from a client that never closes an <event>); cap defensively.
@@ -235,7 +241,7 @@ class CotRelay:
 
     def _save(self, raw: bytes, peer: _Peer) -> None:
         cot_type = _match(_TYPE_RE, raw, "unknown")
-        callsign = _match(_CALLSIGN_RE, raw, "")
+        callsign = next((m for m in (_match(r, raw, "") for r in _CALLSIGN_RES) if m), "")
         rec = {
             "seq": 0,
             "time": _utc_now(),

--- a/tests/unit/test_atak_fleet.py
+++ b/tests/unit/test_atak_fleet.py
@@ -290,3 +290,20 @@ def test_drive_route_passes_ground_speed_to_geo_fix(monkeypatch: pytest.MonkeyPa
     atak.drive_route("emulator-5554", [(41.71, -93.69), (41.7101, -93.69)], speed_mps=1.5, step_s=2)
     fix = next(c for c in calls if c[:3] == ("emu", "geo", "fix"))
     assert fix[5:] == ("280", "8", "2.9")  # alt m, satellites, knots (1.5 m/s)
+
+
+def test_walk_first_run_survives_bad_dump_on_text_check(monkeypatch: pytest.MonkeyPatch) -> None:
+    # The ANR / "Tools" checks run before _tap_label's own guard; a bad dump there
+    # must not abort provisioning.
+    calls = {"n": 0}
+
+    def find_text(tok: str, *, serial: str | None = None) -> bool:
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise atak.avd.EmulatorError("layout returned non-JSON")
+        return tok == "Tools"
+
+    monkeypatch.setattr(atak.avd, "find_text", find_text)
+    monkeypatch.setattr(atak.avd, "ui_dump", lambda **_k: [])
+    monkeypatch.setattr(atak.time, "sleep", lambda _s: None)
+    atak._walk_first_run("emulator-5554", timeout=5)  # returns once "Tools" is seen

--- a/tests/unit/test_atak_fleet.py
+++ b/tests/unit/test_atak_fleet.py
@@ -214,3 +214,54 @@ def test_wait_for_boot_waits_while_anim_running(monkeypatch: pytest.MonkeyPatch)
     monkeypatch.setattr(atak.time, "sleep", lambda _s: None)
     with pytest.raises(atak.AtakError):
         atak.wait_for_boot("emulator-5554", timeout=0.2)
+
+
+# ---------------------------------------------------------------------------
+# first-run walk resilience
+# ---------------------------------------------------------------------------
+def test_tap_label_tolerates_bad_layout_dump(monkeypatch: pytest.MonkeyPatch) -> None:
+    # `android layout` intermittently returns non-JSON on an animating screen;
+    # that must read as "label not on screen", not abort provisioning.
+    def boom(*_a: object, **_k: object) -> None:
+        raise atak.avd.EmulatorError("layout returned non-JSON")
+
+    monkeypatch.setattr(atak.avd, "ui_dump", boom)
+    assert atak._tap_label("emulator-5554", "I agree.") is False
+
+
+def test_walk_first_run_dismisses_anr(monkeypatch: pytest.MonkeyPatch) -> None:
+    # A starved emulator throws "System UI isn't responding" over ATAK's EULA;
+    # the walk must tap Wait (not Close app) and carry on.
+    screen = {"texts": ["System UI isn't responding", "Close app", "Wait"]}
+    taps: list[str] = []
+
+    def ui_dump(*, serial: str | None = None, diff: bool = False) -> list[dict[str, object]]:
+        return [
+            {"text": t, "interactions": ["clickable"], "center": [1, i]}
+            for i, t in enumerate(screen["texts"])
+        ]
+
+    def tap(x: int, y: int, *, serial: str | None = None) -> None:
+        label = screen["texts"][y]
+        taps.append(label)
+        if label == "Wait":
+            screen["texts"] = ["I agree.", "Tools"]
+        elif label == "I agree.":
+            screen["texts"] = ["Tools"]
+
+    monkeypatch.setattr(atak.avd, "ui_dump", ui_dump)
+    monkeypatch.setattr(atak.avd, "tap", tap)
+    monkeypatch.setattr(
+        atak.avd, "find_text", lambda tok, *, serial=None: any(tok in t for t in screen["texts"])
+    )
+    monkeypatch.setattr(atak.time, "sleep", lambda _s: None)
+    atak._walk_first_run("emulator-5554", timeout=5)
+    assert taps == ["Wait", "I agree."]
+
+
+def test_fleet_flags_give_play_image_headroom() -> None:
+    # The Play system image runs GMS dex2oat + Play Store after boot; at 2 cores /
+    # 2 GB the emulator ANRs through ATAK's first run.
+    flags = list(atak._FLEET_FLAGS)
+    assert flags[flags.index("-cores") + 1] == "3"
+    assert flags[flags.index("-memory") + 1] == "4096"

--- a/tests/unit/test_atak_fleet.py
+++ b/tests/unit/test_atak_fleet.py
@@ -265,3 +265,17 @@ def test_fleet_flags_give_play_image_headroom() -> None:
     flags = list(atak._FLEET_FLAGS)
     assert flags[flags.index("-cores") + 1] == "3"
     assert flags[flags.index("-memory") + 1] == "4096"
+
+
+def test_push_stream_pref_writes_the_defaults_file(monkeypatch: pytest.MonkeyPatch) -> None:
+    # ATAK only auto-loads config/prefs/defaults (no extension) at activity start
+    # (PreferenceControl.ingestDefaults); a .pref there is inert.
+    pushed: list[str] = []
+
+    def adb(*args: str, **kw: object) -> None:
+        if args[0] == "push":
+            pushed.append(args[2])
+
+    monkeypatch.setattr(atak.avd, "adb", adb)
+    atak.push_stream_pref("emulator-5554", "10.0.2.2", 8087)
+    assert pushed == ["/sdcard/atak/config/prefs/defaults"]

--- a/tests/unit/test_atak_fleet.py
+++ b/tests/unit/test_atak_fleet.py
@@ -279,3 +279,14 @@ def test_push_stream_pref_writes_the_defaults_file(monkeypatch: pytest.MonkeyPat
     monkeypatch.setattr(atak.avd, "adb", adb)
     atak.push_stream_pref("emulator-5554", "10.0.2.2", 8087)
     assert pushed == ["/sdcard/atak/config/prefs/defaults"]
+
+
+def test_drive_route_passes_ground_speed_to_geo_fix(monkeypatch: pytest.MonkeyPatch) -> None:
+    # ATAK reads Location.getSpeed(); the emulator only sets it from geo fix's
+    # optional velocity (knots). Without it every PLI reports speed="0.0".
+    calls: list[tuple[str, ...]] = []
+    monkeypatch.setattr(atak.avd, "adb", lambda *a, **k: calls.append(a))
+    monkeypatch.setattr(atak.time, "sleep", lambda _s: None)
+    atak.drive_route("emulator-5554", [(41.71, -93.69), (41.7101, -93.69)], speed_mps=1.5, step_s=2)
+    fix = next(c for c in calls if c[:3] == ("emu", "geo", "fix"))
+    assert fix[5:] == ("280", "8", "2.9")  # alt m, satellites, knots (1.5 m/s)

--- a/tests/unit/test_cot_relay.py
+++ b/tests/unit/test_cot_relay.py
@@ -149,3 +149,28 @@ def test_numbering_resumes_from_max_not_count(tmp_path: Path) -> None:
         a.close()
     assert (tmp_path / "0004_t-x-c-t.xml").exists()
     assert (tmp_path / "0003_a-f-G-U-C.xml").read_bytes() == PLI_EVENT  # not overwritten
+
+
+CHAT = (
+    b'<event version="2.0" uid="GeoChat.ANDROID-1.ANDROID-2.m1" type="b-t-f" '
+    b'time="2026-08-20T14:00:00Z" start="2026-08-20T14:00:00Z" stale="2026-08-21T14:00:00Z" how="h-g-i-g-o">'
+    b'<point lat="41.6" lon="-93.7" hae="250.0" ce="5.0" le="9999999.0"/>'
+    b'<detail><__chat chatroom="WYATT" id="ANDROID-2" senderCallsign="EARP"/>'
+    b'<remarks source="BAO.F.ATAK.ANDROID-1" to="ANDROID-2">howdy</remarks>'
+    b'<marti><dest callsign="WYATT"/></marti></detail></event>'
+)
+
+
+def test_chat_callsign_is_the_sender_not_the_marti_dest(tmp_path: Path) -> None:
+    # Real ATAK GeoChat carries the *recipient* in <marti><dest callsign> and the
+    # sender only as senderCallsign; a bare callsign= match attributes the event
+    # (and the peer's status row) to the wrong station.
+    with CotRelay(outdir=tmp_path, port=0) as relay:
+        a = _connect(relay.port)
+        a.sendall(PLI + CHAT)
+        _wait(lambda: relay.seq >= 2)
+        st = relay.status()
+        a.close()
+    records = [json.loads(ln) for ln in (tmp_path / "manifest.jsonl").read_text().splitlines()]
+    assert records[1]["callsign"] == "EARP"
+    assert st["peers"][0]["callsign"] == "EARP"


### PR DESCRIPTION
The Play system image runs GMS dex2oat and Play Store sync after boot; at
2 cores / 2 GB the headless emulator ANRs through ATAK's EULA and
`android layout` intermittently returns non-JSON, aborting provisioning.

- 3 cores / 4 GB per node; disable com.android.vending before first run
- first-run walk taps Wait on the ANR dialog and treats a bad layout dump
  as "label not on screen"
- wait_for_boot docstring matches the unstarted-bootanim case


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved emulator startup reliability when first-run Android dialogs or transient interface errors appear.
  * Automatically dismisses unexpected “App isn’t responding” prompts so setup can continue.
  * Improved provisioning reliability by preventing unwanted Play Store interruptions.

* **Improvements**
  * Increased fleet emulator capacity for smoother operation and better performance.
  * Updated health checks to support boot animation services that have not started yet.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->