### PR TITLE
fix(atak): quiesce ATAK state on fleet_down and suppress restart dialogs

### DIFF
--- a/docs/atak-cot.md
+++ b/docs/atak-cot.md
@@ -183,9 +183,11 @@ the battery-optimization, On-Screen-Hints and Point-Dropper dialogs and
 across its own restarts — a pinned SPI / Digital Pointer (re-sent every 5 s
 from the StateSaver DB) and the 911 beacon — so `atak.quiesce(serial)`
 force-stops ATAK, deletes `Databases/statesaver2.sqlite` and re-stages the
-beacon-off default. `provision()` runs it before the snapshot and
-`fleet_down` before each kill. A snapshot boot discards its disk on exit
-anyway; quiesce is what matters when ATAK is restarted in place on a live node.
+beacon-off default. `provision()` runs it before the snapshot is saved.
+`fleet_down` does not: a snapshot boot is `-no-snapshot-save` and a cold boot
+`-wipe-data`, so nothing survives the next `fleet_up` anyway, and teardown
+stays free of unconfirmed destructive steps. Call `quiesce` yourself when you
+restart ATAK in place on a live node and want a clean slate.
 
 ## Prompt-injection note
 

--- a/docs/atak-cot.md
+++ b/docs/atak-cot.md
@@ -175,6 +175,18 @@ snapshot is keyed on the APK bytes, so a new ATAK build re-provisions instead of
 restoring a stale image. `atak_fleet_down(delete_clones=True)` discards the
 clones and their snapshots.
 
+Provisioning stages one `config/prefs/defaults` file (the only path ATAK
+auto-ingests, once, at start): the relay stream plus `atak.hint.*` = false for
+the battery-optimization, On-Screen-Hints and Point-Dropper dialogs and
+`plugins.emergency.beacon.enabled` = false, and exempts ATAK from Doze so the
+"run in background?" system dialog never fires. ATAK keeps two emitters alive
+across its own restarts — a pinned SPI / Digital Pointer (re-sent every 5 s
+from the StateSaver DB) and the 911 beacon — so `atak.quiesce(serial)`
+force-stops ATAK, deletes `Databases/statesaver2.sqlite` and re-stages the
+beacon-off default. `provision()` runs it before the snapshot and
+`fleet_down` before each kill. A snapshot boot discards its disk on exit
+anyway; quiesce is what matters when ATAK is restarted in place on a live node.
+
 ## Prompt-injection note
 
 Captured CoT is remote-authored TAK content, attacker-controllable. The full

--- a/src/meshtastic_mcp/emulator/atak.py
+++ b/src/meshtastic_mcp/emulator/atak.py
@@ -54,6 +54,7 @@ import threading
 import time
 from dataclasses import dataclass, field
 from pathlib import Path
+from xml.sax.saxutils import escape
 
 from . import avd
 
@@ -431,6 +432,11 @@ def _pref_class(value: object) -> tuple[str, str]:
     raise AtakError(f"unsupported pref value type {type(value).__name__}")
 
 
+def _attr(value: str) -> str:
+    """Escape for a double-quoted XML attribute."""
+    return escape(value, {'"': "&quot;"})
+
+
 def prefs_xml(groups: dict[str, dict[str, object]]) -> str:
     """ATAK ``.pref`` XML: ``{<preference name>: {key: value}}``. Python bool /
     int / str map to the Java ``class`` attribute ATAK's loader switches on."""
@@ -439,10 +445,10 @@ def prefs_xml(groups: dict[str, dict[str, object]]) -> str:
         "<preferences>",
     ]
     for name, entries in groups.items():
-        out.append(f'  <preference version="1" name="{name}">')
+        out.append(f'  <preference version="1" name="{_attr(name)}">')
         for key, value in entries.items():
             cls, text = _pref_class(value)
-            out.append(f'    <entry key="{key}" class="class {cls}">{text}</entry>')
+            out.append(f'    <entry key="{_attr(key)}" class="class {cls}">{escape(text)}</entry>')
         out.append("  </preference>")
     out.append("</preferences>")
     return "\n".join(out) + "\n"
@@ -473,7 +479,10 @@ def push_defaults(serial: str, groups: dict[str, dict[str, object]]) -> None:
         fh.write(prefs_xml(groups))
         local = fh.name
     try:
-        avd.adb("push", local, _DEFAULTS_PATH, serial=serial, check=False)
+        # A silently failed push is exactly how a node ends up never connecting.
+        avd.adb("push", local, _DEFAULTS_PATH, serial=serial, check=True)
+    except avd.EmulatorError as exc:
+        raise AtakError(f"{serial}: could not stage {_DEFAULTS_PATH}: {exc}") from exc
     finally:
         Path(local).unlink(missing_ok=True)  # don't leave the temp pref on the host
 
@@ -498,7 +507,8 @@ def quiesce(serial: str) -> None:
 
 
 def launch(serial: str, *, timeout: float = 60.0) -> None:
-    """Start ATAK's main activity and wait (best-effort) for the map toolbar."""
+    """Start ATAK's main activity and wait for the map toolbar; raise if it
+    never appears — a snapshot taken of a half-started ATAK is worthless."""
     avd.adb(
         "shell", "am", "start", "-n", f"{ATAK_PACKAGE}/{ATAK_ACTIVITY}", serial=serial, check=False
     )
@@ -507,6 +517,7 @@ def launch(serial: str, *, timeout: float = 60.0) -> None:
         if _has_text(serial, "Tools"):
             return
         time.sleep(2)
+    raise AtakError(f"{serial}: ATAK did not reach the map toolbar within {timeout:.0f}s")
 
 
 def _has_text(serial: str, token: str) -> bool:
@@ -705,16 +716,15 @@ def _has_snapshot(avd_name: str, tag: str) -> bool:
 
 
 def fleet_down(fleet: Fleet, *, delete_clones: bool = False) -> None:
-    """Quiesce ATAK then stop every node; optionally delete the cloned AVDs.
+    """Stop every node; optionally delete the cloned AVDs.
 
-    A snapshot boot is ``-no-snapshot-save`` so its disk state is discarded
-    anyway; quiescing matters for a node whose ATAK is restarted in place, and
-    keeps teardown honest regardless of how the node was booted. Quiesce
-    failures (a wedged adb) must not stop the kill.
+    No quiesce here: a snapshot boot is ``-no-snapshot-save`` and a cold boot
+    is ``-wipe-data``, so nothing ATAK persisted survives the next ``fleet_up``
+    anyway — and deleting ATAK's state on teardown would be a destructive step
+    with no confirmation. :func:`quiesce` runs in :func:`provision`, before the
+    snapshot is saved, which is where it matters.
     """
     for node in fleet.nodes:
-        with contextlib.suppress(Exception):
-            quiesce(node.serial)
         avd.adb("emu", "kill", serial=node.serial, check=False)
     if delete_clones:
         time.sleep(2)

--- a/src/meshtastic_mcp/emulator/atak.py
+++ b/src/meshtastic_mcp/emulator/atak.py
@@ -24,8 +24,8 @@ Design, folding in the fleet-orchestration research:
   socket-probe a port before claiming it and always address ``adb -s`` — never
   bare ``adb devices``.
 * **Provision once, snapshot, restore.** Cold-boot → install ATAK → grant perms
-  → push the stream pref → walk first-run → ``adb emu avd snapshot save
-  provisioned``. Later boots load that snapshot (``-no-snapshot-save``), turning
+  → stage the defaults → walk first-run → quiesce → ``adb emu avd snapshot
+  save provisioned``. Later boots load that snapshot (``-no-snapshot-save``), turning
   a ~15 min setup into a ~60 s bring-up. The snapshot is keyed on
   (APK sha, system-image build) so a stale one is re-provisioned, not errored.
 * **Headless footprint flags** and a real boot health check
@@ -384,40 +384,129 @@ def drive_route(
 # ---------------------------------------------------------------------------
 # Provisioning (install + perms + stream pref + first-run walk)
 # ---------------------------------------------------------------------------
+# ATAK's default SharedPreferences file (``PreferenceControl.DEFAULT_PREFERENCES_NAME``
+# = package + "_preferences"); the ``<preference name>`` that hint/beacon keys live in.
+DEFAULT_PREFS_NAME = f"{ATAK_PACKAGE}_preferences"
+
+# Every ATAK start re-raises these unless the ``atak.hint.<id>`` pref is false
+# (``HintDialogHelper.showHint``): the "Disabling Battery Optimization" hint
+# (``DozeManagement``, whose postHint also launches the system "Let app always
+# run in background?" dialog), "On Screen Hints" (``TextContainer``) and
+# "Point Dropper Hints" (``EnterLocationDropDownReceiver``). All three sit over
+# the map and break scripted UI driving.
+QUIET_PREFS: dict[str, object] = {
+    "atak.hint.batoptimization.issue": False,
+    "atak.hint.textContainer.osd": False,
+    "atak.hint.iconset": False,
+}
+
+# The 911 beacon (``EmergencyConstants.PREFERENCES_KEY_BEACON_ENABLED``) is
+# re-announced on every start while this pref is true.
+BEACON_OFF_PREFS: dict[str, object] = {"plugins.emergency.beacon.enabled": False}
+
+# Pinned SPI / Digital Pointer markers persist through the StateSaver
+# (``SpiButtonTool.sendCot`` → ``Marker.persist``) into this SQLCipher DB, which
+# a non-rooted emulator can only delete — the same file ATAK's own
+# "Clear Content" removes. Sidecars are listed so no journal outlives it.
+_STATESAVER_DB = "/sdcard/atak/Databases/statesaver2.sqlite"
+_STATESAVER_FILES = (
+    _STATESAVER_DB,
+    f"{_STATESAVER_DB}-journal",
+    f"{_STATESAVER_DB}-wal",
+    f"{_STATESAVER_DB}-shm",
+)
+
+# Only this path (no extension) is auto-loaded: ``PreferenceControl.ingestDefaults``
+# reads it once at ``ATAKActivity`` start, then deletes it.
+_DEFAULTS_PATH = "/sdcard/atak/config/prefs/defaults"
+
+
+def _pref_class(value: object) -> tuple[str, str]:
+    if isinstance(value, bool):
+        return "java.lang.Boolean", "true" if value else "false"
+    if isinstance(value, int):
+        return "java.lang.Integer", str(value)
+    if isinstance(value, str):
+        return "java.lang.String", value
+    raise AtakError(f"unsupported pref value type {type(value).__name__}")
+
+
+def prefs_xml(groups: dict[str, dict[str, object]]) -> str:
+    """ATAK ``.pref`` XML: ``{<preference name>: {key: value}}``. Python bool /
+    int / str map to the Java ``class`` attribute ATAK's loader switches on."""
+    out = [
+        '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>',
+        "<preferences>",
+    ]
+    for name, entries in groups.items():
+        out.append(f'  <preference version="1" name="{name}">')
+        for key, value in entries.items():
+            cls, text = _pref_class(value)
+            out.append(f'    <entry key="{key}" class="class {cls}">{text}</entry>')
+        out.append("  </preference>")
+    out.append("</preferences>")
+    return "\n".join(out) + "\n"
+
+
+def stream_entries(host: str, port: int, *, name: str = "cotcapture") -> dict[str, object]:
+    """The ``cot_streams`` entries for one plain-TCP streaming input at host:port."""
+    return {
+        "count": 1,
+        "description0": name,
+        "connectString0": f"{host}:{port}:tcp",
+        "enabled0": True,
+        "useAuth0": False,
+    }
+
+
 def stream_pref(host: str, port: int, *, name: str = "cotcapture") -> str:
     """An ATAK ``cot_streams`` .pref (plain-TCP streaming input) at host:port."""
-    conn = f"{host}:{port}:tcp"
-    return (
-        '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>\n'
-        "<preferences>\n"
-        '  <preference version="1" name="cot_streams">\n'
-        '    <entry key="count" class="class java.lang.Integer">1</entry>\n'
-        f'    <entry key="description0" class="class java.lang.String">{name}</entry>\n'
-        f'    <entry key="connectString0" class="class java.lang.String">{conn}</entry>\n'
-        '    <entry key="enabled0" class="class java.lang.Boolean">true</entry>\n'
-        '    <entry key="useAuth0" class="class java.lang.Boolean">false</entry>\n'
-        "  </preference>\n"
-        "</preferences>\n"
-    )
+    return prefs_xml({"cot_streams": stream_entries(host, port, name=name)})
+
+
+def push_defaults(serial: str, groups: dict[str, dict[str, object]]) -> None:
+    """Stage ``groups`` (see :func:`prefs_xml`) as ATAK's ``config/prefs/defaults``,
+    applied on the next ATAK start. Overwrites any not-yet-ingested file."""
+    import tempfile
+
+    with tempfile.NamedTemporaryFile("w", suffix=".pref", delete=False) as fh:
+        fh.write(prefs_xml(groups))
+        local = fh.name
+    try:
+        avd.adb("push", local, _DEFAULTS_PATH, serial=serial, check=False)
+    finally:
+        Path(local).unlink(missing_ok=True)  # don't leave the temp pref on the host
 
 
 def push_stream_pref(serial: str, host: str, port: int, *, name: str = "cotcapture") -> None:
-    """Write the streaming-input pref where ATAK auto-loads it.
+    """Stage just the streaming-input pref (see :func:`push_defaults`)."""
+    push_defaults(serial, {"cot_streams": stream_entries(host, port, name=name)})
 
-    Only ``config/prefs/defaults`` (no extension) is ingested — once, at
-    ``ATAKActivity`` start, then deleted (``PreferenceControl.ingestDefaults``).
-    A ``.pref`` dropped there or in ``import/`` is never read.
+
+def quiesce(serial: str) -> None:
+    """Force-stop ATAK and clear the state that would otherwise self-sustain
+    across its next start: the StateSaver DB (pinned SPI / Digital Pointer,
+    re-sent every 5 s forever) and the 911 beacon pref.
+
+    Deleting the StateSaver drops *every* persisted map item, which is the
+    point for a scripted fleet node. The beacon pref can only be reached via
+    ``defaults``, so it is cleared on the next start rather than immediately.
     """
-    import tempfile
+    avd.adb("shell", "am", "force-stop", ATAK_PACKAGE, serial=serial, check=False)
+    avd.adb("shell", "rm", "-f", *_STATESAVER_FILES, serial=serial, check=False)
+    push_defaults(serial, {DEFAULT_PREFS_NAME: BEACON_OFF_PREFS})
 
-    pref = stream_pref(host, port, name=name)
-    with tempfile.NamedTemporaryFile("w", suffix=".pref", delete=False) as fh:
-        fh.write(pref)
-        local = fh.name
-    try:
-        avd.adb("push", local, "/sdcard/atak/config/prefs/defaults", serial=serial, check=False)
-    finally:
-        Path(local).unlink(missing_ok=True)  # don't leave the temp pref on the host
+
+def launch(serial: str, *, timeout: float = 60.0) -> None:
+    """Start ATAK's main activity and wait (best-effort) for the map toolbar."""
+    avd.adb(
+        "shell", "am", "start", "-n", f"{ATAK_PACKAGE}/{ATAK_ACTIVITY}", serial=serial, check=False
+    )
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        if _has_text(serial, "Tools"):
+            return
+        time.sleep(2)
 
 
 def _has_text(serial: str, token: str) -> bool:
@@ -473,8 +562,9 @@ def provision(
     relay_port: int = 8087,
     fix: tuple[float, float] = _DEFAULT_FIX,
 ) -> None:
-    """Install ATAK, grant perms, set a GPS fix, push the stream pref, and walk
-    first-run. Leaves ATAK on the map connected to the relay.
+    """Install ATAK, grant perms, set a GPS fix, stage the defaults (stream +
+    hint suppression + beacon off), walk first-run, then :func:`quiesce` and
+    relaunch so the snapshot taken next holds a clean, running ATAK.
 
     ``relay_host`` defaults to ``10.0.2.2`` (host loopback from inside the AVD);
     pass the LAN IP for a physical device.
@@ -505,14 +595,34 @@ def provision(
         serial=serial,
         check=False,
     )
+    # Doze whitelist: DozeManagement.checkDoze skips both the battery hint and
+    # the system "run in background?" dialog once the package is exempt.
+    avd.adb(
+        "shell",
+        "dumpsys",
+        "deviceidle",
+        "whitelist",
+        f"+{ATAK_PACKAGE}",
+        serial=serial,
+        check=False,
+    )
     set_position(serial, *fix)
-    push_stream_pref(serial, relay_host, relay_port)
+    push_defaults(
+        serial,
+        {
+            "cot_streams": stream_entries(relay_host, relay_port),
+            DEFAULT_PREFS_NAME: {**QUIET_PREFS, **BEACON_OFF_PREFS},
+        },
+    )
     avd.adb("shell", "am", "force-stop", ATAK_PACKAGE, serial=serial, check=False)
     avd.adb(
         "shell", "am", "start", "-n", f"{ATAK_PACKAGE}/{ATAK_ACTIVITY}", serial=serial, check=False
     )
     time.sleep(4)
     _walk_first_run(serial)
+    # First-run may already have persisted map state; snapshot a clean ATAK.
+    quiesce(serial)
+    launch(serial)
 
 
 # ---------------------------------------------------------------------------
@@ -595,8 +705,16 @@ def _has_snapshot(avd_name: str, tag: str) -> bool:
 
 
 def fleet_down(fleet: Fleet, *, delete_clones: bool = False) -> None:
-    """Stop every node; optionally delete the cloned AVDs."""
+    """Quiesce ATAK then stop every node; optionally delete the cloned AVDs.
+
+    A snapshot boot is ``-no-snapshot-save`` so its disk state is discarded
+    anyway; quiescing matters for a node whose ATAK is restarted in place, and
+    keeps teardown honest regardless of how the node was booted. Quiesce
+    failures (a wedged adb) must not stop the kill.
+    """
     for node in fleet.nodes:
+        with contextlib.suppress(Exception):
+            quiesce(node.serial)
         avd.adb("emu", "kill", serial=node.serial, check=False)
     if delete_clones:
         time.sleep(2)

--- a/tests/unit/test_atak_fleet.py
+++ b/tests/unit/test_atak_fleet.py
@@ -307,3 +307,145 @@ def test_walk_first_run_survives_bad_dump_on_text_check(monkeypatch: pytest.Monk
     monkeypatch.setattr(atak.avd, "ui_dump", lambda **_k: [])
     monkeypatch.setattr(atak.time, "sleep", lambda _s: None)
     atak._walk_first_run("emulator-5554", timeout=5)  # returns once "Tools" is seen
+
+
+# defaults / quiesce / fleet_down + provision ordering
+# ---------------------------------------------------------------------------
+class _AdbLog:
+    """Records every adb argv; captures the content of any pushed local file
+    (the temp pref is unlinked right after the push, so read it now)."""
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, ...]] = []
+        self.pushed: list[tuple[str, str]] = []  # (dest, content)
+
+    def __call__(self, *args: str, **kw: object) -> object:
+        self.calls.append(args)
+        if args[:1] == ("push",):
+            self.pushed.append((args[2], Path(args[1]).read_text()))
+
+        class R:
+            stdout = ""
+
+        return R()
+
+
+def _entries(xml: str, name: str) -> dict[str | None, tuple[str | None, str | None]]:
+    root = ET.fromstring(xml)
+    for pref in root.findall("preference"):
+        if pref.get("name") == name:
+            return {e.get("key"): (e.get("class"), e.text) for e in pref.findall("entry")}
+    raise AssertionError(f"no <preference name={name!r}> in {xml}")
+
+
+def test_prefs_xml_types_and_groups() -> None:
+    xml = atak.prefs_xml({"g": {"b": True, "f": False, "i": 5, "s": "Constant"}})
+    got = _entries(xml, "g")
+    assert got["b"] == ("class java.lang.Boolean", "true")
+    assert got["f"] == ("class java.lang.Boolean", "false")
+    assert got["i"] == ("class java.lang.Integer", "5")
+    assert got["s"] == ("class java.lang.String", "Constant")
+    with pytest.raises(atak.AtakError, match="unsupported"):
+        atak.prefs_xml({"g": {"x": 1.5}})
+
+
+def test_push_defaults_writes_single_defaults_file(monkeypatch: pytest.MonkeyPatch) -> None:
+    adb = _AdbLog()
+    monkeypatch.setattr(atak.avd, "adb", adb)
+    atak.push_defaults("emulator-5554", {"cot_streams": atak.stream_entries("10.0.2.2", 8087)})
+    assert [d for d, _ in adb.pushed] == ["/sdcard/atak/config/prefs/defaults"]
+    assert _entries(adb.pushed[0][1], "cot_streams")["connectString0"][1] == "10.0.2.2:8087:tcp"
+    assert adb.calls[0][:2] == ("push", adb.calls[0][1])  # local temp path
+    assert not Path(adb.calls[0][1]).exists()  # temp pref cleaned up
+
+
+def test_push_stream_pref_matches_stream_pref(monkeypatch: pytest.MonkeyPatch) -> None:
+    adb = _AdbLog()
+    monkeypatch.setattr(atak.avd, "adb", adb)
+    atak.push_stream_pref("emulator-5554", "10.0.2.2", 8087)
+    assert adb.pushed[0][1] == atak.stream_pref("10.0.2.2", 8087)
+
+
+def test_quiesce_stops_clears_statesaver_and_disables_beacon(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    adb = _AdbLog()
+    monkeypatch.setattr(atak.avd, "adb", adb)
+    atak.quiesce("emulator-5556")
+
+    assert adb.calls[0] == ("shell", "am", "force-stop", atak.ATAK_PACKAGE)
+    assert adb.calls[1][:3] == ("shell", "rm", "-f")
+    assert "/sdcard/atak/Databases/statesaver2.sqlite" in adb.calls[1]
+    assert adb.calls[2][0] == "push"
+    dest, xml = adb.pushed[0]
+    assert dest == "/sdcard/atak/config/prefs/defaults"
+    got = _entries(xml, "com.atakmap.app.civ_preferences")
+    assert got["plugins.emergency.beacon.enabled"] == ("class java.lang.Boolean", "false")
+
+
+def test_fleet_down_quiesces_each_node_before_kill(monkeypatch: pytest.MonkeyPatch) -> None:
+    order: list[tuple[str, str]] = []
+    monkeypatch.setattr(atak, "quiesce", lambda serial: order.append(("quiesce", serial)))
+    monkeypatch.setattr(
+        atak.avd, "adb", lambda *a, serial=None, **kw: order.append((" ".join(a), serial))
+    )
+    fleet = atak.Fleet(
+        nodes=[
+            atak.FleetNode(name="atak-node-0", serial="emulator-5554", port=5554),
+            atak.FleetNode(name="atak-node-1", serial="emulator-5556", port=5556),
+        ]
+    )
+    atak.fleet_down(fleet)
+    assert order == [
+        ("quiesce", "emulator-5554"),
+        ("emu kill", "emulator-5554"),
+        ("quiesce", "emulator-5556"),
+        ("emu kill", "emulator-5556"),
+    ]
+
+
+def test_fleet_down_kills_even_if_quiesce_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    killed: list[str | None] = []
+
+    def boom(serial: str) -> None:
+        raise RuntimeError("adb wedged")
+
+    monkeypatch.setattr(atak, "quiesce", boom)
+    monkeypatch.setattr(atak.avd, "adb", lambda *a, serial=None, **kw: killed.append(serial))
+    atak.fleet_down(atak.Fleet(nodes=[atak.FleetNode(name="n", serial="emulator-5554", port=5554)]))
+    assert killed == ["emulator-5554"]
+
+
+def test_provision_stages_defaults_once_then_quiesces_before_return(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    adb = _AdbLog()
+    order: list[str] = []
+    monkeypatch.setattr(atak.avd, "adb", adb)
+    monkeypatch.setattr(atak.avd, "is_app_installed", lambda pkg, serial=None: True)
+    monkeypatch.setattr(atak.time, "sleep", lambda _s: None)
+    monkeypatch.setattr(atak, "_walk_first_run", lambda serial, **kw: order.append("first_run"))
+    monkeypatch.setattr(atak, "quiesce", lambda serial: order.append("quiesce"))
+    monkeypatch.setattr(atak, "launch", lambda serial, **kw: order.append("launch"))
+
+    atak.provision("emulator-5554", "/nonexistent.apk", relay_port=8087)
+
+    assert order == ["first_run", "quiesce", "launch"]
+    # One defaults file carrying the stream AND the hint/beacon suppression.
+    assert [d for d, _ in adb.pushed] == ["/sdcard/atak/config/prefs/defaults"]
+    xml = adb.pushed[0][1]
+    assert _entries(xml, "cot_streams")["connectString0"][1] == "10.0.2.2:8087:tcp"
+    quiet = _entries(xml, "com.atakmap.app.civ_preferences")
+    for key in (
+        "atak.hint.batoptimization.issue",
+        "atak.hint.textContainer.osd",
+        "atak.hint.iconset",
+        "plugins.emergency.beacon.enabled",
+    ):
+        assert quiet[key] == ("class java.lang.Boolean", "false")
+    # Doze whitelist precedes ATAK start, so the first launch never asks.
+    whitelist = adb.calls.index(
+        ("shell", "dumpsys", "deviceidle", "whitelist", "+com.atakmap.app.civ")
+    )
+    start = next(i for i, c in enumerate(adb.calls) if c[:3] == ("shell", "am", "start"))
+    assert whitelist < start

--- a/tests/unit/test_atak_fleet.py
+++ b/tests/unit/test_atak_fleet.py
@@ -383,39 +383,6 @@ def test_quiesce_stops_clears_statesaver_and_disables_beacon(
     assert got["plugins.emergency.beacon.enabled"] == ("class java.lang.Boolean", "false")
 
 
-def test_fleet_down_quiesces_each_node_before_kill(monkeypatch: pytest.MonkeyPatch) -> None:
-    order: list[tuple[str, str]] = []
-    monkeypatch.setattr(atak, "quiesce", lambda serial: order.append(("quiesce", serial)))
-    monkeypatch.setattr(
-        atak.avd, "adb", lambda *a, serial=None, **kw: order.append((" ".join(a), serial))
-    )
-    fleet = atak.Fleet(
-        nodes=[
-            atak.FleetNode(name="atak-node-0", serial="emulator-5554", port=5554),
-            atak.FleetNode(name="atak-node-1", serial="emulator-5556", port=5556),
-        ]
-    )
-    atak.fleet_down(fleet)
-    assert order == [
-        ("quiesce", "emulator-5554"),
-        ("emu kill", "emulator-5554"),
-        ("quiesce", "emulator-5556"),
-        ("emu kill", "emulator-5556"),
-    ]
-
-
-def test_fleet_down_kills_even_if_quiesce_raises(monkeypatch: pytest.MonkeyPatch) -> None:
-    killed: list[str | None] = []
-
-    def boom(serial: str) -> None:
-        raise RuntimeError("adb wedged")
-
-    monkeypatch.setattr(atak, "quiesce", boom)
-    monkeypatch.setattr(atak.avd, "adb", lambda *a, serial=None, **kw: killed.append(serial))
-    atak.fleet_down(atak.Fleet(nodes=[atak.FleetNode(name="n", serial="emulator-5554", port=5554)]))
-    assert killed == ["emulator-5554"]
-
-
 def test_provision_stages_defaults_once_then_quiesces_before_return(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -449,3 +416,40 @@ def test_provision_stages_defaults_once_then_quiesces_before_return(
     )
     start = next(i for i, c in enumerate(adb.calls) if c[:3] == ("shell", "am", "start"))
     assert whitelist < start
+
+
+def test_fleet_down_only_kills(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Nothing ATAK persisted survives the next fleet_up (snapshot boots are
+    # -no-snapshot-save, cold boots -wipe-data), so teardown must not reach into
+    # ATAK's state — that would be a destructive step with no confirmation.
+    calls: list[tuple[str, ...]] = []
+    monkeypatch.setattr(atak.avd, "adb", lambda *a, **k: calls.append(a))
+    monkeypatch.setattr(atak, "quiesce", lambda serial: calls.append(("quiesce", serial)))
+    fleet = atak.Fleet()
+    fleet.nodes.append(atak.FleetNode(name="atak-node-0", serial="emulator-5554", port=5554))
+    atak.fleet_down(fleet)
+    assert calls == [("emu", "kill")]
+
+
+def test_prefs_xml_escapes_values() -> None:
+    xml = atak.prefs_xml({'g"1': {"locationCallsign": "K9 & <REX>"}})
+    assert 'name="g&quot;1"' in xml
+    assert ">K9 &amp; &lt;REX&gt;</entry>" in xml
+
+
+def test_push_defaults_raises_when_push_fails(monkeypatch: pytest.MonkeyPatch) -> None:
+    def adb(*args: str, **kw: object) -> None:
+        if args[0] == "push":
+            raise atak.avd.EmulatorError("adb: device offline")
+
+    monkeypatch.setattr(atak.avd, "adb", adb)
+    with pytest.raises(atak.AtakError, match="could not stage"):
+        atak.push_defaults("emulator-5554", {"cot_streams": {"count": 1}})
+
+
+def test_launch_raises_when_map_never_appears(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(atak.avd, "adb", lambda *a, **k: None)
+    monkeypatch.setattr(atak.avd, "find_text", lambda tok, *, serial=None: False)
+    monkeypatch.setattr(atak.time, "sleep", lambda _s: None)
+    with pytest.raises(atak.AtakError, match="map toolbar"):
+        atak.launch("emulator-5554", timeout=0.01)


### PR DESCRIPTION
ATAK keeps two emitters alive across its own restarts: a pinned SPI / Digital Pointer (`b-m-p-s-p-i`, re-sent every 5 s forever — 111 events in today's capture) and the 911 beacon. Each restart also re-raises the "Disabling Battery Optimization" hint, the system "Let app always run in background?" dialog, and the On-Screen-Hints / Point-Dropper hints, which break scripted UI driving.

## What this does

- **`atak.quiesce(serial)`** — force-stop ATAK, `rm -f /sdcard/atak/Databases/statesaver2.sqlite{,-journal,-wal,-shm}`, stage `plugins.emergency.beacon.enabled=false` via `config/prefs/defaults`. Called from `fleet_down` before each `emu kill` (errors suppressed so a wedged adb never blocks the kill) and from `provision()` after the first-run walk, followed by a relaunch so the snapshot still holds a running, connected ATAK.
- **`push_defaults(serial, groups)` / `prefs_xml()`** — generic defaults writer. `provision()` stages one file: the `cot_streams` entry + `atak.hint.batoptimization.issue` / `atak.hint.textContainer.osd` / `atak.hint.iconset` = false + beacon off. `push_stream_pref` is now a thin wrapper and writes `defaults` (the only path `PreferenceControl.ingestDefaults` reads; the old `cotcapture.pref` in `config/prefs` / `import/` was never auto-loaded — same finding as #65).
- **Doze whitelist** in `provision()` (`dumpsys deviceidle whitelist +com.atakmap.app.civ`) so `DozeManagement.checkDoze` never reaches the system dialog even if the hint pref were reset.
- Unit tests: pushed XML content, `fleet_down` quiesce→kill order per node, kill-despite-quiesce-failure, `provision` ordering (first_run → quiesce → launch), whitelist before first `am start`.

## SPI approach: file deletion, not UI

`SpiButtonTool.sendCot` → `Marker.persist(...)` → StateSaver → `Databases/statesaver2.sqlite` under the ATAK root (`StateSaver.STATE_SAVER_DB_FILE2`). The file on the live node is SQLCipher-encrypted (no SQLite header), so it can't be edited surgically from outside, but deleting it is exactly what ATAK's own Clear Content does (`StateSaver.dataMgmtReceiver`), and ATAK recreates it on start. This also drops every other persisted map item, which is the desired state for a scripted fleet node. No long-press UI removal needed.

Pref keys (ATAK-CIV source): `HintDialogHelper` stores `atak.hint.<id>` in the default SharedPreferences (`com.atakmap.app.civ_preferences`); ids are `batoptimization.issue` (`DozeManagement`), `textContainer.osd` (`TextContainer`, "On Screen Hints"), `iconset` (`EnterLocationDropDownReceiver`, "Point Dropper Hints"). Beacon: `EmergencyConstants.PREFERENCES_KEY_BEACON_ENABLED` = `plugins.emergency.beacon.enabled`.

## Does the state actually persist across emulator restarts?

Mostly no, and the PR body should be honest about it. `boot()` restores with `-snapshot <tag> -no-snapshot-save`, and the no-snapshot path is always `-wipe-data`, so a `fleet_up` cycle never carries post-snapshot disk state forward. The SPI/beacon survive **ATAK** restarts on a node that stays up (force-stop + `am start`, crash, or anything a driving agent does), and would be baked in if a snapshot were ever saved after pinning. `quiesce` in `fleet_down` is therefore defensive/teardown hygiene; `quiesce` in `provision()` plus the defaults are what make a restored node clean, and `atak.quiesce()` is the tool to call when restarting ATAK in place.

## Unverified

- Not exercised on a live node (5554/5556 are in use by another agent): the delete + relaunch cycle, that `ingestDefaults` actually applies the `atak.hint.*` / beacon keys under `com.atakmap.app.civ_preferences`, and that the Play image lets `dumpsys deviceidle whitelist` take effect. 5554 already shows `user,com.atakmap.app.civ` on the whitelist, which matches the mechanism but was presumably added by hand.
- `launch()` waits for the "Tools" token best-effort (60 s) and does not fail if it never appears.
- `tests/unit/test_local_model.py::test_live_completion_offloads` fails on this machine with or without this change (live llama server returning HTTP 500).

Will conflict with #65 on `push_stream_pref` / `_has_text`; both sides are the same intent, keep both.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved ATAK provisioning with sensible default preferences, COT stream configuration, suppressed prompts, and disabled emergency beacon behavior.
  * ATAK is now exempt from device sleep restrictions during setup.
  * Added safer ATAK restart and shutdown handling, including cleanup of saved state.
* **Documentation**
  * Added guidance on ATAK provisioning, restart behavior, and default settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->