### PR TITLE
feat(atak): meshtastic-mcp-atak CLI + single-node relay bring-up test

### DIFF
--- a/docs/atak-cot.md
+++ b/docs/atak-cot.md
@@ -39,6 +39,47 @@ immediately and you poll `atak_fleet_status`.
 A physical ATAK phone can join too: add a streaming input pointed at the host's
 LAN IP + port (plain TCP, no SSL/auth).
 
+## CLI (`meshtastic-mcp-atak`)
+
+The same library from bash, no MCP server in the loop — so an edit to
+`emulator/atak.py` is live on the next command (the MCP server needs a
+reconnect to pick it up). Foreground commands stop on Ctrl-C; failures exit 1
+with the `AtakError` message.
+
+```bash
+meshtastic-mcp-atak relay start --port 8087 --session s1   # prints outdir; peers + type counts every 30 s
+meshtastic-mcp-atak fleet up --count 2 --apk ATAK-CIV.apk --base-avd medium_phone [--relay-port 8087] [--no-snapshot]
+                                                            # synchronous; prints the nodes as JSON
+meshtastic-mcp-atak provision emulator-5554 --apk ATAK-CIV.apk [--relay-port 8087]
+meshtastic-mcp-atak position emulator-5554 41.60 -93.77 [--speed 3]
+meshtastic-mcp-atak drive emulator-5554 --speed 12 --step 2 41.60,-93.77 41.61,-93.75
+meshtastic-mcp-atak fleet down [--delete-clones]           # finds running atak-node-* emulators itself
+```
+
+`fleet down` is stateless: it kills every running emulator whose AVD name
+starts with `atak-node-` (never a foreign emulator on the same adb server) and,
+with `--delete-clones`, also removes stopped clones from disk.
+
+### Bring-up test (`tests/atak/`)
+
+`tests/atak/test_single_node_relay.py` boots one clone against a relay on an
+ephemeral port and requires a peer with a callsign within 3 minutes — the gate
+the fleet tools originally shipped without. It is `atak`-marked and auto-skips
+unless:
+
+| env var | meaning |
+| --- | --- |
+| `MESHTASTIC_MCP_ATAK_APK` | path to the ATAK-CIV APK (required; unset → skip) |
+| `MESHTASTIC_MCP_ATAK_BASE_AVD` | AVD to clone (default `medium_phone`; missing → skip) |
+
+```bash
+MESHTASTIC_MCP_ATAK_APK=~/ATAK-CIV.apk pytest tests/atak -v
+```
+
+It always provisions (no snapshot restore — the snapshot's pref would point at
+a stale port), so budget ~15 min, and it needs a free console port pair from
+5554 upward alongside any emulators already running.
+
 ## Tailing logs (clean, filtered)
 
 Two feeds matter: what the relay captured, and what each device's ATAK is doing.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,6 +101,7 @@ dev = ["ruff>=0.6", "mypy>=1.10", "pytest>=8"]
 
 [project.scripts]
 meshtastic-mcp = "meshtastic_mcp.__main__:main"
+meshtastic-mcp-atak = "meshtastic_mcp.atak_cli:main"
 meshtastic-mcp-test-tui = "meshtastic_mcp.cli.test_tui:main"
 meshtastic-mcp-web = "meshtastic_mcp.web.__main__:main"
 meshtastic-mcp-menubar = "meshtastic_mcp.menubar:main"
@@ -142,6 +143,7 @@ testpaths = ["tests"]
 markers = [
   "firmware: needs a Meshtastic firmware checkout (variants/pio/userprefs); auto-skipped without MESHTASTIC_FIRMWARE_ROOT",
   "meshtasticd: drives a native meshtasticd virtual radio; auto-skipped without MESHTASTIC_MESHTASTICD_BIN",
+  "atak: brings up a real ATAK emulator; auto-skipped without MESHTASTIC_MCP_ATAK_APK",
   "timing: asserts on wall-clock rate/latency; may flake on a contended runner — deselect with -m 'not timing'",
 ]
 

--- a/src/meshtastic_mcp/atak_cli.py
+++ b/src/meshtastic_mcp/atak_cli.py
@@ -1,0 +1,197 @@
+# SPDX-FileCopyrightText: Meshtastic contributors
+# SPDX-License-Identifier: GPL-3.0-only
+
+"""``meshtastic-mcp-atak`` — drive the ATAK emulator fleet + CoT relay from bash.
+
+Wraps :mod:`meshtastic_mcp.emulator.atak` and
+:class:`meshtastic_mcp.replay.cot_relay.CotRelay` directly — not the MCP
+server — so a fix to the library is exercised by the next shell command, with
+no server reconnect. Stdlib only; every failure exits non-zero with the
+:class:`~meshtastic_mcp.emulator.atak.AtakError` message on stderr.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+import time
+from datetime import UTC, datetime
+from typing import Any, cast
+
+from . import config
+from .emulator import atak
+from .replay.cot_relay import CotRelay
+
+_STATUS_EVERY_S = 30.0
+
+
+def _log(msg: str) -> None:
+    print(f"[{datetime.now(UTC).strftime('%H:%M:%S')}] {msg}", file=sys.stderr, flush=True)
+
+
+def _latlon(text: str) -> tuple[float, float]:
+    try:
+        lat_s, lon_s = text.split(",", 1)
+        return float(lat_s), float(lon_s)
+    except ValueError:
+        raise argparse.ArgumentTypeError(f"expected LAT,LON, got {text!r}") from None
+
+
+def _positive(text: str) -> float:
+    val = float(text)
+    if val <= 0:
+        raise argparse.ArgumentTypeError(f"must be > 0, got {text!r}")
+    return val
+
+
+# ---------------------------------------------------------------------------
+# Subcommands
+# ---------------------------------------------------------------------------
+def cmd_relay_start(args: argparse.Namespace) -> int:
+    name = args.session or datetime.now(UTC).strftime("%Y%m%d-%H%M%S")
+    outdir = config.mcp_data_dir() / "cot_captures" / name
+    relay = CotRelay(outdir=outdir, port=args.port)
+    relay.start()
+    print(f"relay listening on {relay.host}:{relay.port}")
+    print(f"capturing to {outdir}")
+    try:
+        while True:
+            time.sleep(_STATUS_EVERY_S)
+            st = relay.status()
+            peers = ", ".join(
+                f"{p['callsign'] or '?'}@{p['addr']}({p['events']})"
+                for p in cast(list[dict[str, Any]], st["peers"])
+            )
+            _log(f"peers={st['peer_count']} [{peers}] types={json.dumps(st['type_counts'])}")
+    except KeyboardInterrupt:
+        pass
+    finally:
+        relay.stop()
+    print(json.dumps(relay.status(), indent=2))
+    return 0
+
+
+def cmd_fleet_up(args: argparse.Namespace) -> int:
+    _log(f"fleet up: count={args.count} base={args.base_avd} relay_port={args.relay_port}")
+    fleet = atak.fleet_up(
+        args.count,
+        args.apk,
+        base_avd=args.base_avd,
+        relay_port=args.relay_port,
+        use_snapshot=not args.no_snapshot,
+    )
+    _log(f"fleet ready: {fleet.serials()}")
+    print(json.dumps([n.__dict__ for n in fleet.nodes], indent=2))
+    return 0
+
+
+def cmd_fleet_down(args: argparse.Namespace) -> int:
+    fleet = atak.discover_fleet()
+    _log(f"fleet down: {fleet.serials() or 'no running nodes'}")
+    atak.fleet_down(fleet, delete_clones=args.delete_clones)
+    if args.delete_clones:
+        # Clones that were not running are outside the discovered fleet.
+        for name in atak.list_clone_avds():
+            _log(f"deleting clone {name}")
+            atak.delete_clone_avd(name)
+    return 0
+
+
+def cmd_drive(args: argparse.Namespace) -> int:
+    _log(f"drive {args.serial}: {len(args.waypoints)} waypoints @ {args.speed} m/s")
+    try:
+        atak.drive_route(args.serial, args.waypoints, speed_mps=args.speed, step_s=args.step)
+    except KeyboardInterrupt:
+        _log("drive interrupted")
+        return 130
+    _log("route complete")
+    return 0
+
+
+def cmd_position(args: argparse.Namespace) -> int:
+    kwargs = {"speed_mps": args.speed} if args.speed is not None else {}
+    atak.set_position(args.serial, args.lat, args.lon, **kwargs)
+    return 0
+
+
+def cmd_provision(args: argparse.Namespace) -> int:
+    _log(f"provision {args.serial} apk={args.apk} relay_port={args.relay_port}")
+    atak.provision(args.serial, args.apk, relay_port=args.relay_port)
+    _log("provisioned")
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# Parser
+# ---------------------------------------------------------------------------
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="meshtastic-mcp-atak",
+        description="ATAK emulator fleet + CoT relay, straight from the library.",
+    )
+    sub = p.add_subparsers(dest="cmd", required=True)
+
+    relay = sub.add_parser("relay", help="CoT capture + relay server").add_subparsers(
+        dest="relay_cmd", required=True
+    )
+    rs = relay.add_parser("start", help="run a relay in the foreground (Ctrl-C stops)")
+    rs.add_argument("--port", type=int, default=8087)
+    rs.add_argument("--session", help="capture dir name (default: UTC timestamp)")
+    rs.set_defaults(func=cmd_relay_start)
+
+    fleet = sub.add_parser("fleet", help="emulator fleet").add_subparsers(
+        dest="fleet_cmd", required=True
+    )
+    fu = fleet.add_parser("up", help="clone, boot and provision N nodes")
+    fu.add_argument("--count", type=int, required=True)
+    fu.add_argument("--apk", required=True, help="ATAK-CIV APK path")
+    fu.add_argument("--base-avd", required=True, help="AVD to clone from")
+    fu.add_argument("--relay-port", type=int, default=8087)
+    fu.add_argument("--no-snapshot", action="store_true", help="ignore provisioned snapshots")
+    fu.set_defaults(func=cmd_fleet_up)
+    fd = fleet.add_parser("down", help="stop every running atak-node-* emulator")
+    fd.add_argument("--delete-clones", action="store_true", help="also delete the cloned AVDs")
+    fd.set_defaults(func=cmd_fleet_down)
+
+    dr = sub.add_parser("drive", help="feed a moving GPS track (foreground)")
+    dr.add_argument("serial")
+    dr.add_argument("--speed", type=_positive, default=10.0, help="m/s")
+    dr.add_argument("--step", type=_positive, default=2.0, help="seconds between fixes")
+    dr.add_argument("waypoints", type=_latlon, nargs="+", metavar="LAT,LON")
+    # A southern/western waypoint ("-33.9,151.2") starts with "-"; argparse's
+    # stock negative-number matcher only recognises bare numbers, so widen it
+    # to "-<num>," for this subparser or the token is read as an option.
+    dr._negative_number_matcher = re.compile(r"^-\d+(?:\.\d*)?,")
+    dr.set_defaults(func=cmd_drive)
+
+    po = sub.add_parser("position", help="set a single GPS fix")
+    po.add_argument("serial")
+    po.add_argument("lat", type=float)
+    po.add_argument("lon", type=float)
+    po.add_argument("--speed", type=float, default=None, help="m/s (optional)")
+    po.set_defaults(func=cmd_position)
+
+    pr = sub.add_parser("provision", help="install + provision ATAK on a booted emulator")
+    pr.add_argument("serial")
+    pr.add_argument("--apk", required=True)
+    pr.add_argument("--relay-port", type=int, default=8087)
+    pr.set_defaults(func=cmd_provision)
+    return p
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        return int(args.func(args))
+    except atak.AtakError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+    except OSError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/meshtastic_mcp/emulator/atak.py
+++ b/src/meshtastic_mcp/emulator/atak.py
@@ -58,6 +58,7 @@ from pathlib import Path
 from . import avd
 
 ATAK_PACKAGE = "com.atakmap.app.civ"
+FLEET_NODE_PREFIX = "atak-node-"
 ATAK_ACTIVITY = "com.atakmap.app.ATAKActivity"
 
 # Runtime permissions ATAK needs; pre-granting pre-accepts its dialogs. Superset
@@ -568,7 +569,7 @@ def fleet_up(
     fleet = Fleet()
     try:
         for i in range(count):
-            name = f"atak-node-{i}"
+            name = f"{FLEET_NODE_PREFIX}{i}"
             clone_avd(base_avd, name)
             port = alloc_console_port(i)
             have_snap = use_snapshot and _has_snapshot(name, tag)
@@ -600,5 +601,36 @@ def fleet_down(fleet: Fleet, *, delete_clones: bool = False) -> None:
     if delete_clones:
         time.sleep(2)
         for node in fleet.nodes:
-            shutil.rmtree(_avd_home() / f"{node.name}.avd", ignore_errors=True)
-            (_avd_home() / f"{node.name}.ini").unlink(missing_ok=True)
+            delete_clone_avd(node.name)
+
+
+def delete_clone_avd(name: str) -> None:
+    """Remove a cloned AVD (dir + ini) from disk. No-op if absent."""
+    shutil.rmtree(_avd_home() / f"{name}.avd", ignore_errors=True)
+    (_avd_home() / f"{name}.ini").unlink(missing_ok=True)
+
+
+def list_clone_avds() -> list[str]:
+    """Names of every ``atak-node-*`` clone on disk (running or not)."""
+    return sorted(p.stem for p in _avd_home().glob(f"{FLEET_NODE_PREFIX}*.ini"))
+
+
+def discover_fleet() -> Fleet:
+    """Rebuild a :class:`Fleet` from the running ``atak-node-*`` emulators.
+
+    Stateless counterpart to the handle :func:`fleet_up` returns, so a separate
+    process (the CLI) can tear down a fleet it did not start. Only emulators
+    whose AVD name carries the fleet prefix are included — a foreign emulator
+    on the same adb server is never touched.
+    """
+    fleet = Fleet()
+    for serial, state in avd.list_devices():
+        if state != "device" or not avd.is_emulator(serial):
+            continue
+        out = avd.adb("emu", "avd", "name", serial=serial, check=False, timeout=10).stdout
+        name = next((ln.strip() for ln in out.splitlines() if ln.strip() not in ("", "OK")), "")
+        if not name.startswith(FLEET_NODE_PREFIX):
+            continue
+        port = int(serial.rsplit("-", 1)[1])
+        fleet.nodes.append(FleetNode(name=name, serial=serial, port=port))
+    return fleet

--- a/tests/README.md
+++ b/tests/README.md
@@ -14,6 +14,7 @@ concerns rather than generic "unit vs hardware".
 | `telemetry/`    | 2 devices, shared bake  | Is telemetry reporting? Is position broadcast correct?                |
 | `monitor/`      | 1 device, shared bake   | Is the boot log clean (no panics)?                                    |
 | `fleet/`        | varies                  | Are my CI runs isolated from each other? Are reflashes idempotent?    |
+| `atak/`         | 1 Android emulator      | Does a provisioned ATAK node actually reach the CoT relay? (`MESHTASTIC_MCP_ATAK_APK`) |
 
 ## Quick start
 

--- a/tests/atak/__init__.py
+++ b/tests/atak/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: Meshtastic contributors
+# SPDX-License-Identifier: GPL-3.0-only
+

--- a/tests/atak/test_single_node_relay.py
+++ b/tests/atak/test_single_node_relay.py
@@ -1,0 +1,69 @@
+# SPDX-FileCopyrightText: Meshtastic contributors
+# SPDX-License-Identifier: GPL-3.0-only
+
+"""ATAK tier: one provisioned emulator reaches the CoT relay.
+
+The real bring-up gate the fleet tools shipped without — boot a single clone,
+provision ATAK against a relay on an ephemeral port, and require a peer with a
+callsign (ATAK's first PLI) within 3 minutes. Needs ``MESHTASTIC_MCP_ATAK_APK``
+(auto-skipped otherwise) and an AVD named by ``MESHTASTIC_MCP_ATAK_BASE_AVD``
+(default ``medium_phone``). Cold first run is ~15 min (install + first-run
+walk + snapshot); subsequent runs restore the snapshot in ~1 min.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import time
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+
+from meshtastic_mcp.emulator import atak, avd
+from meshtastic_mcp.replay.cot_relay import CotRelay
+
+pytestmark = pytest.mark.atak
+
+PEER_TIMEOUT_S = 180.0
+
+
+@pytest.fixture(scope="module")
+def relay(tmp_path_factory: pytest.TempPathFactory) -> Iterator[CotRelay]:
+    r = CotRelay(outdir=tmp_path_factory.mktemp("cot"), port=0)
+    r.start()
+    yield r
+    r.stop()
+
+
+@pytest.fixture(scope="module")
+def node(relay: CotRelay) -> Iterator[atak.FleetNode]:
+    apk = os.environ["MESHTASTIC_MCP_ATAK_APK"]
+    base = os.environ.get("MESHTASTIC_MCP_ATAK_BASE_AVD", "medium_phone")
+    if not Path(apk).is_file():
+        pytest.skip(f"MESHTASTIC_MCP_ATAK_APK={apk!r} is not a file")
+    if not shutil.which("adb") and avd._sdk_root() is None:
+        pytest.skip("adb / Android SDK not found")
+    if base not in avd.list_avds():
+        pytest.skip(f"base AVD {base!r} not found (MESHTASTIC_MCP_ATAK_BASE_AVD)")
+    # The relay port is ephemeral, so a restored snapshot (whose pref points at
+    # the port used when it was taken) would never connect — always provision.
+    fleet = atak.fleet_up(1, apk, base_avd=base, relay_port=relay.port, use_snapshot=False)
+    try:
+        yield fleet.nodes[0]
+    finally:
+        atak.fleet_down(fleet)
+
+
+def test_node_connects_to_relay_with_callsign(relay: CotRelay, node: atak.FleetNode) -> None:
+    deadline = time.monotonic() + PEER_TIMEOUT_S
+    last: dict[str, object] = {}
+    while time.monotonic() < deadline:
+        last = relay.status()
+        peers = last["peers"]
+        assert isinstance(peers, list)
+        if any(p["callsign"] for p in peers):
+            return
+        time.sleep(5)
+    pytest.fail(f"no peer with a callsign on {node.serial} within {PEER_TIMEOUT_S}s: {last}")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -264,6 +264,12 @@ def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item
         for item in items:
             if item.get_closest_marker("firmware"):
                 item.add_marker(skip_fw)
+    # `atak`-marked tests boot a real ATAK emulator; they need the APK path.
+    if not os.environ.get("MESHTASTIC_MCP_ATAK_APK"):
+        skip_atak = pytest.mark.skip(reason="atak tier: MESHTASTIC_MCP_ATAK_APK not set")
+        for item in items:
+            if item.get_closest_marker("atak"):
+                item.add_marker(skip_atak)
 
 
 # ---------- Session-scoped fixtures ---------------------------------------

--- a/tests/unit/test_atak_cli.py
+++ b/tests/unit/test_atak_cli.py
@@ -1,0 +1,189 @@
+# SPDX-FileCopyrightText: Meshtastic contributors
+# SPDX-License-Identifier: GPL-3.0-only
+
+"""meshtastic-mcp-atak: argparse wiring → library calls (no emulator)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from meshtastic_mcp import atak_cli
+from meshtastic_mcp.emulator import atak
+
+
+@pytest.fixture
+def calls(monkeypatch: pytest.MonkeyPatch) -> list[tuple[str, tuple[Any, ...], dict[str, Any]]]:
+    """Replace every library entry point the CLI touches with a recorder."""
+    rec: list[tuple[str, tuple[Any, ...], dict[str, Any]]] = []
+
+    def fake(name: str, ret: Any = None) -> Any:
+        def _f(*a: Any, **kw: Any) -> Any:
+            rec.append((name, a, kw))
+            return ret
+
+        return _f
+
+    fleet = atak.Fleet(
+        nodes=[atak.FleetNode(name="atak-node-0", serial="emulator-5554", port=5554)]
+    )
+    monkeypatch.setattr(atak, "fleet_up", fake("fleet_up", fleet))
+    monkeypatch.setattr(atak, "fleet_down", fake("fleet_down"))
+    monkeypatch.setattr(atak, "discover_fleet", fake("discover_fleet", fleet))
+    monkeypatch.setattr(atak, "list_clone_avds", fake("list_clone_avds", ["atak-node-1"]))
+    monkeypatch.setattr(atak, "delete_clone_avd", fake("delete_clone_avd"))
+    monkeypatch.setattr(atak, "drive_route", fake("drive_route"))
+    monkeypatch.setattr(atak, "set_position", fake("set_position"))
+    monkeypatch.setattr(atak, "provision", fake("provision"))
+    return rec
+
+
+def test_fleet_up_wiring(calls: list[Any], capsys: pytest.CaptureFixture[str]) -> None:
+    rc = atak_cli.main(
+        ["fleet", "up", "--count", "2", "--apk", "a.apk", "--base-avd", "mp", "--relay-port", "9"]
+    )
+    assert rc == 0
+    assert calls == [
+        ("fleet_up", (2, "a.apk"), {"base_avd": "mp", "relay_port": 9, "use_snapshot": True})
+    ]
+    assert '"serial": "emulator-5554"' in capsys.readouterr().out
+
+
+def test_fleet_up_no_snapshot(calls: list[Any]) -> None:
+    atak_cli.main(["fleet", "up", "--count", "1", "--apk", "a", "--base-avd", "b", "--no-snapshot"])
+    assert calls[0][2]["use_snapshot"] is False
+    assert calls[0][2]["relay_port"] == 8087
+
+
+def test_fleet_down_discovers_running_nodes(calls: list[Any]) -> None:
+    assert atak_cli.main(["fleet", "down"]) == 0
+    assert [c[0] for c in calls] == ["discover_fleet", "fleet_down"]
+    assert calls[1][2] == {"delete_clones": False}
+
+
+def test_fleet_down_delete_clones_sweeps_stopped_clones(calls: list[Any]) -> None:
+    assert atak_cli.main(["fleet", "down", "--delete-clones"]) == 0
+    assert [c[0] for c in calls] == [
+        "discover_fleet",
+        "fleet_down",
+        "list_clone_avds",
+        "delete_clone_avd",
+    ]
+    assert calls[1][2] == {"delete_clones": True}
+    assert calls[3][1] == ("atak-node-1",)
+
+
+def test_drive_wiring(calls: list[Any]) -> None:
+    rc = atak_cli.main(
+        ["drive", "emulator-5554", "--speed", "3.5", "--step", "1", "1.5,2.5", "-3,4.25"]
+    )
+    assert rc == 0
+    assert calls == [
+        (
+            "drive_route",
+            ("emulator-5554", [(1.5, 2.5), (-3.0, 4.25)]),
+            {"speed_mps": 3.5, "step_s": 1.0},
+        )
+    ]
+
+
+def test_drive_rejects_bad_waypoint(calls: list[Any]) -> None:
+    with pytest.raises(SystemExit) as exc:
+        atak_cli.main(["drive", "emulator-5554", "1.5", "2,3"])
+    assert exc.value.code == 2
+    assert calls == []
+
+
+def test_position_wiring(calls: list[Any]) -> None:
+    assert atak_cli.main(["position", "emulator-5554", "1", "2"]) == 0
+    assert calls == [("set_position", ("emulator-5554", 1.0, 2.0), {})]
+    calls.clear()
+    assert atak_cli.main(["position", "emulator-5554", "1", "2", "--speed", "4"]) == 0
+    assert calls == [("set_position", ("emulator-5554", 1.0, 2.0), {"speed_mps": 4.0})]
+
+
+def test_provision_wiring(calls: list[Any]) -> None:
+    assert atak_cli.main(["provision", "emulator-5556", "--apk", "x.apk", "--relay-port", "1"]) == 0
+    assert calls == [("provision", ("emulator-5556", "x.apk"), {"relay_port": 1})]
+
+
+def test_atak_error_exits_nonzero(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    def boom(*a: Any, **kw: Any) -> None:
+        raise atak.AtakError("no free emulator console port")
+
+    monkeypatch.setattr(atak, "provision", boom)
+    assert atak_cli.main(["provision", "s", "--apk", "x"]) == 1
+    assert "no free emulator console port" in capsys.readouterr().err
+
+
+def test_relay_start_uses_session_dir(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setattr(atak_cli.config, "mcp_data_dir", lambda: tmp_path)
+    monkeypatch.setattr(atak_cli, "_STATUS_EVERY_S", 0.01)
+    started: dict[str, Any] = {}
+
+    def fake_sleep(_s: float) -> None:
+        raise KeyboardInterrupt
+
+    monkeypatch.setattr(atak_cli.time, "sleep", fake_sleep)
+
+    class FakeRelay:
+        host = "0.0.0.0"
+
+        def __init__(self, *, outdir: Path, port: int) -> None:
+            started["outdir"], started["port"] = outdir, port
+            self.port = port
+
+        def start(self) -> int:
+            started["started"] = True
+            return self.port
+
+        def stop(self) -> None:
+            started["stopped"] = True
+
+        def status(self) -> dict[str, Any]:
+            return {"peers": [], "peer_count": 0, "type_counts": {}}
+
+    monkeypatch.setattr(atak_cli, "CotRelay", FakeRelay)
+    assert atak_cli.main(["relay", "start", "--port", "0", "--session", "s1"]) == 0
+    assert started == {
+        "outdir": tmp_path / "cot_captures" / "s1",
+        "port": 0,
+        "started": True,
+        "stopped": True,
+    }
+    assert str(tmp_path / "cot_captures" / "s1") in capsys.readouterr().out
+
+
+# ---------------------------------------------------------------------------
+# atak.discover_fleet / list_clone_avds (library side of `fleet down`)
+# ---------------------------------------------------------------------------
+def test_discover_fleet_filters_by_avd_name(monkeypatch: pytest.MonkeyPatch) -> None:
+    names = {"emulator-5554": "atak-node-0\nOK\n", "emulator-5556": "Pixel_7\nOK\n"}
+    monkeypatch.setattr(
+        atak.avd,
+        "list_devices",
+        lambda: [("emulator-5554", "device"), ("emulator-5556", "device"), ("ABC123", "device")],
+    )
+
+    class _CP:
+        def __init__(self, out: str) -> None:
+            self.stdout = out
+
+    monkeypatch.setattr(atak.avd, "adb", lambda *a, serial=None, **kw: _CP(names[serial]))
+    fleet = atak.discover_fleet()
+    assert [(n.name, n.serial, n.port) for n in fleet.nodes] == [
+        ("atak-node-0", "emulator-5554", 5554)
+    ]
+
+
+def test_list_clone_avds(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(atak, "_avd_home", lambda: tmp_path)
+    for n in ("atak-node-1", "atak-node-0", "medium_phone"):
+        (tmp_path / f"{n}.ini").write_text("x")
+    assert atak.list_clone_avds() == ["atak-node-0", "atak-node-1"]


### PR DESCRIPTION
Fixes to `emulator/atak.py` could only be exercised through the MCP server, which needs a reconnect (`/mcp`) to pick them up, and the fleet tools (#62) shipped without a real bring-up ever completing — the bootanim, pref-path and ANR bugs (#63, #65) only surfaced on first real use.

**`meshtastic-mcp-atak`** (`atak_cli.py`, argparse, stdlib only) wraps the library directly:

- `relay start --port 8087 --session NAME` — foreground, prints the outdir, peers + per-type counts every 30 s
- `fleet up --count N --apk PATH --base-avd NAME [--relay-port P] [--no-snapshot]` — synchronous, node list as JSON
- `fleet down [--delete-clones]` — stateless: `atak.discover_fleet()` rebuilds the fleet from running `atak-node-*` emulators by AVD name (never touches a foreign emulator); `--delete-clones` also sweeps stopped clones
- `drive SERIAL --speed M/S --step S LAT,LON ...` — negative (S/W) waypoints parse
- `position SERIAL LAT LON [--speed M/S]`
- `provision SERIAL --apk PATH [--relay-port P]`

Non-zero exit with the `AtakError` message on failure.

**`tests/atak/test_single_node_relay.py`** — new `atak` marker, auto-skipped without `MESHTASTIC_MCP_ATAK_APK` (base AVD via `MESHTASTIC_MCP_ATAK_BASE_AVD`, default `medium_phone`). Boots one clone against a relay on an ephemeral port and requires a callsign-bearing peer within 3 min, then tears down. Documented in `docs/atak-cot.md`.

Tested: unit tier (argparse wiring → library calls with monkeypatched functions, `discover_fleet`/`list_clone_avds`), ruff/mypy/spdx clean. The `atak` tier itself has not been run yet — the bench emulators were in use.
