### PR TITLE
test: stop enumerating serial ports once per test at collection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,8 +79,13 @@ jobs:
       - name: Portable unit tier (hardware- and firmware-free)
         # All extras: the unit tier covers the web (fastapi/aiosqlite) and sdr
           # (numpy) modules too; those tests importorskip on partial installs.
+        # --durations keeps the slowest tests visible in the log so a
+          # collection/fixture regression (this tier once took 8+ min, almost
+          # all of it enumerating serial ports at collection) shows up in the
+          # numbers, not just the wall clock. Per-test timeout: tests/unit/conftest.py.
         run: uv run --python ${{ matrix.python-version }} --all-extras
-          python -m pytest tests/unit -q --cov=meshtastic_mcp --cov-report=xml
+          python -m pytest tests/unit -q --durations=20
+          --cov=meshtastic_mcp --cov-report=xml
       - name: Upload coverage
         if: matrix.python-version == '3.12'
         uses: codecov/codecov-action@v5

--- a/tests/_bench.py
+++ b/tests/_bench.py
@@ -32,6 +32,8 @@ location, env}) or per-role env vars: ``MESHTASTIC_UHUBCTL_LOCATION_<ROLE>`` +
 
 from __future__ import annotations
 
+from collections.abc import Iterable
+
 # role -> {vid, alt_vids, location, env}. Keep this the ONLY place these four
 # facts are written down; conftest.hub_profile, conftest.pytest_generate_tests,
 # _port_discovery._ROLE_VIDS, and test_00_bake all derive from it.
@@ -155,3 +157,23 @@ def device_location(port: str) -> str | None:
     if hub is None or slot is None:
         return None
     return f"{hub}.{slot}"
+
+
+def device_locations(ports: Iterable[str]) -> dict[str, str | None]:
+    """:func:`device_location` for many ports from ONE ``comports()`` pass.
+
+    ``comports()`` walks ``/sys`` (glob + realpath per port) on Linux, so the
+    per-port variant is O(ports²) across a bench — or across the 32 ``ttyS*``
+    stubs a CI runner enumerates. Callers resolving several roles against the
+    same snapshot should use this instead."""
+    from serial.tools import list_ports
+
+    by_device: dict[str, str] = {}
+    try:
+        for p in list_ports.comports():
+            loc = getattr(p, "location", None)
+            if loc and "." in str(loc):
+                by_device[p.device] = str(loc)
+    except Exception:
+        pass
+    return {port: by_device.get(port) for port in ports}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -527,15 +527,31 @@ def _hex_to_int(value: Any) -> int | None:
     return None
 
 
-def _match_role_port(spec: dict[str, Any], found: list[dict]) -> str | None:
+def _found_locations(found: list[dict]) -> dict[str, str | None]:
+    """port → hub-slot location for every port in a `list_devices()` snapshot,
+    from a single `comports()` pass (see `_bench.device_locations`)."""
+    return _bench.device_locations(p for d in found if (p := d.get("port")))
+
+
+def _match_role_port(
+    spec: dict[str, Any],
+    found: list[dict],
+    locations: dict[str, str | None] | None = None,
+) -> str | None:
     """Resolve one hub_profile role spec to a connected `/dev` path.
 
     Prefers the role's pinned hub-slot ``location`` (stable across the
     app↔bootloader USB PID flip and unambiguous when several boards share a
     VID); falls back to VID (+ optional ``pid_contains``) for specs with no
     location (e.g. a ``--hub-profile`` yaml). Returns None if absent.
+
+    Pass ``locations`` (from `_found_locations`) when resolving several roles
+    against the same ``found`` snapshot — otherwise each port costs a full
+    serial-port enumeration.
     """
     location = spec.get("location")
+    if location is not None and locations is None:
+        locations = _found_locations(found)
     vids = (spec["vid"], *tuple(spec.get("alt_vids", ())))
     pid_contains = spec.get("pid_contains")
     for dev in found:
@@ -545,7 +561,7 @@ def _match_role_port(spec: dict[str, Any], found: list[dict]) -> str | None:
         if location is not None:
             # Do NOT fall back to VID here — we want the board on THIS slot,
             # not any same-VID sibling.
-            if _bench.device_location(port) == location:
+            if locations is not None and locations.get(port) == location:
                 return port
             continue
         if _hex_to_int(dev.get("vid")) not in vids:
@@ -587,7 +603,7 @@ def bench_wake(hub_profile: dict[str, dict[str, Any]]) -> None:
         return
     try:
         found = devices_module.list_devices(include_unknown=True)
-        present = {_bench.device_location(p) for d in found if (p := d.get("port"))}
+        present = set(_found_locations(found).values())
         for role, spec in hub_profile.items():
             canonical = role.split("_alt", 1)[0]
             location = spec.get("location")
@@ -617,13 +633,14 @@ def hub_devices(hub_profile: dict[str, dict[str, Any]], bench_wake: None) -> dic
     # include_unknown=True so non-whitelisted VIDs (e.g. CP2102 at 0x10c4) that
     # are configured as hub roles still match.
     found = devices_module.list_devices(include_unknown=True)
+    locations = _found_locations(found)
     resolved: dict[str, str] = {}
     for role, spec in hub_profile.items():
         # Skip legacy `*_alt` aliases if a yaml profile still uses them.
         canonical = role.split("_alt", 1)[0]
         if canonical in resolved:
             continue
-        port = _match_role_port(spec, found)
+        port = _match_role_port(spec, found, locations)
         if port is not None:
             resolved[canonical] = port
     return resolved
@@ -725,15 +742,30 @@ def _reset_transmit_history_state(role: str, port: str) -> str:
     return fresh
 
 
+def _session_touches_hardware(session: pytest.Session) -> bool:
+    """False when every collected item is in the portable unit tier, so the
+    session-wide bench prep (`bench_wake`, transmit-history reset + reboot)
+    is skipped: a unit run on a bench must never power-cycle or reboot the
+    radios another session may be using."""
+    return any("/unit/" not in str(getattr(item, "fspath", item.nodeid)) for item in session.items)
+
+
 @pytest.fixture(scope="session", autouse=True)
-def _session_clear_transmit_history(hub_devices: dict[str, str]) -> None:
+def _session_clear_transmit_history(request: pytest.FixtureRequest) -> None:
     """Wipe transmit_history.dat on each device at session start.
 
     Without this, the firmware's per-portnum last-broadcast cache
     (`src/mesh/TransmitHistory.h`) carries throttle state across sessions
     and suppresses early broadcasts. Mutates `hub_devices` in place with
     post-reboot ports since nRF52 re-enumerates.
+
+    `hub_devices` is requested lazily so a unit-only session never
+    enumerates or wakes the bench.
     """
+    if not _session_touches_hardware(request.session):
+        yield
+        return
+    hub_devices: dict[str, str] = request.getfixturevalue("hub_devices")
     if not hub_devices:
         yield
         return
@@ -863,6 +895,50 @@ def baked_mesh(
     return out
 
 
+_DETECTED_ROLES_CACHE: dict[str | None, list[str]] = {}
+
+
+def _detected_roles(profile_path: str | None) -> list[str]:
+    """Bench roles to parametrize over — detected hardware, or the full
+    profile when nothing is attached. Memoized per session: the snapshot is
+    taken during collection and does not change while items are generated."""
+    if profile_path in _DETECTED_ROLES_CACHE:
+        return _DETECTED_ROLES_CACHE[profile_path]
+
+    # Resolve the role → spec map, honoring --hub-profile if passed; otherwise
+    # the reference bench from tests/_bench.py.
+    profile = _load_hub_profile(profile_path) if profile_path else _bench.hub_profile()
+
+    try:
+        found = devices_module.list_devices(include_unknown=True)
+    except Exception:
+        found = []
+    locations = _found_locations(found)
+
+    # Detect each role by its SPECIFIC board (location, or VID for yaml specs
+    # with no location) — so three same-VID nRF52 boards parametrize as three
+    # distinct roles rather than one.
+    detected: list[str] = []
+    for role, spec in profile.items():
+        canonical = role.split("_alt", 1)[0]
+        if canonical in detected:
+            continue
+        if _match_role_port(spec, found, locations) is not None:
+            detected.append(canonical)
+
+    # Fall back to the full role set when nothing is detected, so the suite
+    # still COLLECTS cleanly off-bench (each variant skips at runtime via the
+    # hub_devices presence check).
+    fallback: list[str] = []
+    for role in profile:
+        canonical = role.split("_alt", 1)[0]
+        if canonical not in fallback:
+            fallback.append(canonical)
+    roles = detected or fallback
+    _DETECTED_ROLES_CACHE[profile_path] = roles
+    return roles
+
+
 def pytest_generate_tests(metafunc: pytest.Metafunc) -> None:
     """Auto-parametrize `baked_single` over every detected hub role, and
     `mesh_pair` over every ordered (tx, rx) pair.
@@ -880,47 +956,25 @@ def pytest_generate_tests(metafunc: pytest.Metafunc) -> None:
     Honors `--hub-profile=<yaml>` for non-default hardware — when set, only
     roles defined in the YAML are parametrized. (So e.g. a yaml with only
     `esp32s3` skips every `[nrf52]` variant at collection time.)
+
+    This hook fires once per collected test function, so it must not touch
+    hardware unless the test actually takes one of the two fixtures — and
+    the bench is enumerated only once per session (`_detected_roles`).
+    Before that guard, every one of the ~830 unit tests enumerated serial
+    ports at collection time: ~38 s per file on the bench, ~8 min in CI.
     """
-    # Resolve the role → spec map, honoring --hub-profile if passed; otherwise
-    # the reference bench from tests/_bench.py.
+    wants_single = "baked_single_role" in metafunc.fixturenames
+    wants_pair = "mesh_pair_roles" in metafunc.fixturenames
+    if not (wants_single or wants_pair):
+        return
+
     profile_path = metafunc.config.getoption("--hub-profile", default=None)
-    if profile_path:
-        profile = _load_hub_profile(profile_path)
-    else:
-        profile = _bench.hub_profile()
+    roles = _detected_roles(profile_path)
 
-    try:
-        from meshtastic_mcp import devices as _dev
-
-        found = _dev.list_devices(include_unknown=True)
-    except Exception:
-        found = []
-
-    # Detect each role by its SPECIFIC board (location, or VID for yaml specs
-    # with no location) — so three same-VID nRF52 boards parametrize as three
-    # distinct roles rather than one.
-    detected: list[str] = []
-    for role, spec in profile.items():
-        canonical = role.split("_alt", 1)[0]
-        if canonical in detected:
-            continue
-        if _match_role_port(spec, found) is not None:
-            detected.append(canonical)
-
-    # Fall back to the full role set when nothing is detected, so the suite
-    # still COLLECTS cleanly off-bench (each variant skips at runtime via the
-    # hub_devices presence check).
-    fallback: list[str] = []
-    for role in profile:
-        canonical = role.split("_alt", 1)[0]
-        if canonical not in fallback:
-            fallback.append(canonical)
-    roles = detected or fallback
-
-    if "baked_single_role" in metafunc.fixturenames:
+    if wants_single:
         metafunc.parametrize("baked_single_role", roles, ids=roles, scope="function")
 
-    if "mesh_pair_roles" in metafunc.fixturenames:
+    if wants_pair:
         pairs = [(a, b) for a in roles for b in roles if a != b]
         ids = [f"{a}->{b}" for a, b in pairs]
         metafunc.parametrize("mesh_pair_roles", pairs, ids=ids, scope="function")

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -13,4 +13,19 @@ an explicit override still wins.
 import os
 import tempfile
 
+import pytest
+
 os.environ.setdefault("MESHTASTIC_MCP_DATA_DIR", tempfile.mkdtemp(prefix="mtmcp-unit-"))
+
+# Per-test budget for the portable tier. Unit tests never wait on radios or
+# airtime, so anything past this is a hang (a real sleep, an unmocked probe,
+# an unbounded queue drain) rather than slow work. Tests that legitimately
+# need longer opt in with an explicit `@pytest.mark.timeout(N)`, which wins.
+# The hardware tiers keep their own per-test marks — no repo-wide default.
+UNIT_TEST_TIMEOUT_S = 60
+
+
+def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
+    for item in items:
+        if item.get_closest_marker("timeout") is None:
+            item.add_marker(pytest.mark.timeout(UNIT_TEST_TIMEOUT_S))


### PR DESCRIPTION
## Problem

The portable unit tier took 8–18 min in CI (last master run: `829 passed in 505.81s`; package install is ~2 s). Locally on the bench, `pytest tests/unit --collect-only` did not finish in 10 minutes.

## Root cause

`pytest_generate_tests` in `tests/conftest.py` runs once per collected test function, and unconditionally called `list_devices(include_unknown=True)` — then `_match_role_port` called `comports()` *again* for every port × every bench role via `_bench.device_location`. pyserial's Linux `comports()` walks `/sys` with glob + realpath per port, so this was O(tests × ports × roles) sysfs walks at collection time.

cProfile of collecting one 22-test file on the bench: 38.2 s, of which 37.5 s was under `_match_role_port` → `hub_slot_for_port` → `comports()` (2336 calls, 2 M `lstat`s). A GitHub runner enumerates 32 `ttyS*` stubs, so the same loop ate most of the 8 min there.

Not imports: `python -X importtime -c "import meshtastic_mcp.server"` is 5.2 s cumulative, all of it fastmcp/mcp/httpx.

## Fix

- `pytest_generate_tests` returns early unless the test takes `baked_single_role` / `mesh_pair_roles` (no unit test does).
- Bench roles are detected once per session (`_detected_roles`, memoized per `--hub-profile`).
- `_bench.device_locations()` resolves every port's hub slot from a single `comports()` pass; `_match_role_port`, `hub_devices` and `bench_wake` use it.
- The session-autouse transmit-history reset (which reboots every bench radio) now no-ops for a unit-only session — `pytest tests/unit` on the bench no longer touches hardware at all.
- Guards: `--durations=20` in the CI step, and a 60 s per-test default for the unit tier (`tests/unit/conftest.py`; explicit `timeout` marks win). No repo-wide `timeout` ini — the hardware tiers carry their own marks and have unmarked tests that legitimately exceed 60 s.

Hardware-tier parametrization is unchanged (`pytest tests/mesh tests/admin --collect-only` still yields `[esp32s3->heltec_t114]` etc.).

## Numbers

| | before | after |
| --- | --- | --- |
| `tests/unit --collect-only`, bench (8-core, load ~15) | >10 min, killed | 1.8 s |
| one file (`test_atak_fleet.py`, 22 tests) collect | 38.2 s | <1 s |
| full unit tier, bench, same load | never finished | 54 s (617 passed, 78 skipped) |
| full unit tier, CI (3.13) | 505.8 s (job 9:04) | 92.3 s (job 2:20) |

Remaining top durations are CPU-bound synthetic-mesh generation (`test_sim_realism` module fixture, `test_replay_metrics::test_scenario_presets_shape_the_mesh`), not sleeps or probes — left as-is, same tests and assertions.