### PR TITLE
feat(atak): atak_share_item broadcasts an existing map item by name

### DIFF
--- a/docs/atak-cot.md
+++ b/docs/atak-cot.md
@@ -17,6 +17,12 @@ this captures what the app actually emits.
   ATAK-CIV emulators pointed at the relay (android capability).
 - **`atak_drive_route`** — feed an emulator a moving GPS track so its self-PLI
   reports a live course/speed.
+- **`atak_share_item`** — broadcast an existing map item (marker, shape, route,
+  R&B, bullseye) by name to every contact, so the relay captures its CoT shape
+  (`u-d-c-c` for a circle, `b-m-r` for a route, …). Drives ATAK by
+  view-hierarchy resource-ids (Overlay Manager → search → details → send →
+  Broadcast); the one pixel tap is the radial menu's "details" slot, which
+  ATAK draws on the GL surface and never exposes to a dump.
 
 ## Quick start
 

--- a/src/meshtastic_mcp/emulator/atak.py
+++ b/src/meshtastic_mcp/emulator/atak.py
@@ -762,3 +762,208 @@ def discover_fleet() -> Fleet:
         port = int(serial.rsplit("-", 1)[1])
         fleet.nodes.append(FleetNode(name=name, serial=serial, port=port))
     return fleet
+
+
+# ---------------------------------------------------------------------------
+# Share an existing map item (Overlay Manager → details → send → Broadcast)
+# ---------------------------------------------------------------------------
+# Everything below navigates by view-hierarchy resource-ids (never screen
+# pixels), with one documented exception: the radial menu, which ATAK draws on
+# the GL map surface and so never appears in any dump — see _tap_radial_details.
+# Resource-ids were verified on ATAK-CIV 5.6.
+
+# Suffixes (lower-cased) of the send control in an item's details pane. Each
+# item type has its own: routes `share_route` (and `route_manager_send_button`
+# in Overlay Manager's expanded row actions), R&B/bullseye `sendLayout`,
+# markers `lastPointSend`, drawing circle `drawingCircleSendButton`, ellipse
+# `sendButton`, casevac `med_sendBtn`.
+_SEND_ID_SUFFIXES = (
+    "sendbutton",
+    "send_button",
+    "sendlayout",
+    "share_route",
+    "lastpointsend",
+    "med_sendbtn",
+)
+_BROADCAST_ID = "contact_list_button_send_to_all"
+_OM_SEARCH_BTN = "hierarchy_search_btn"
+_OM_ROW_TITLE = "hierarchy_manager_list_item_title"
+_NAV_MENU = "tak_nav_menu_button"
+# Map chrome that is present on every screen; anything else with a resource-id
+# in the right-hand pane means a drop-down/details pane is open.
+_MAP_CHROME_IDS = frozenset({_NAV_MENU, "tak_nav_zoom", "tak_nav_center", "compass"})
+
+
+def _rid(el: dict) -> str:
+    """Short resource-id of a dumped element, either dump schema.
+
+    The emulator ``android layout`` path emits ``resource-id`` (hyphen) with
+    the package prefix already stripped; the uiautomator path emits
+    ``resource_id`` as ``pkg:id/name``. Normalise to the bare name.
+    """
+    rid = el.get("resource-id") or el.get("resource_id") or ""
+    return str(rid).rsplit("/", 1)[-1]
+
+
+def _center(el: dict) -> tuple[int, int] | None:
+    c = el.get("center")
+    if isinstance(c, str):  # "[x,y]" (emulator layout path)
+        x, y = (int(v) for v in c.strip("[]").split(","))
+        return x, y
+    if isinstance(c, (list, tuple)) and len(c) == 2:
+        return int(c[0]), int(c[1])
+    return None
+
+
+def _find_id(serial: str, rid: str, *, timeout: float = 0.0) -> tuple[int, int] | None:
+    """Center of the element whose short resource-id == ``rid``; polls up to ``timeout``."""
+    deadline = time.time() + timeout
+    while True:
+        for el in avd.ui_dump(serial=serial):
+            if _rid(el) == rid and (c := _center(el)) is not None:
+                return c
+        if time.time() >= deadline:
+            return None
+        time.sleep(0.5)
+
+
+def _tap_id(serial: str, rid: str, *, timeout: float = 5.0) -> bool:
+    c = _find_id(serial, rid, timeout=timeout)
+    if c is None:
+        return False
+    avd.tap(c[0], c[1], serial=serial)
+    return True
+
+
+def _find_send_control(serial: str) -> tuple[str, tuple[int, int]] | None:
+    """(resource-id, center) of the first send control on screen, if any."""
+    for el in avd.ui_dump(serial=serial):
+        rid = _rid(el)
+        if rid.lower().endswith(_SEND_ID_SUFFIXES) and (c := _center(el)) is not None:
+            return rid, c
+    return None
+
+
+def _keyboard_shown(serial: str) -> bool:
+    # The soft keyboard is not part of the app hierarchy, so a dump cannot tell
+    # us it is covering the list — ask the input-method service instead.
+    out = avd.adb("shell", "dumpsys", "input_method", serial=serial, check=False).stdout
+    return "mInputShown=true" in out
+
+
+def _ensure_map_foreground(serial: str, *, max_back: int = 3) -> None:
+    """BACK out of any open drop-down/details pane until only the map chrome is left."""
+    for _ in range(max_back + 1):
+        els = avd.ui_dump(serial=serial)
+        menu = next((c for el in els if _rid(el) == _NAV_MENU and (c := _center(el))), None)
+        if menu is None:
+            raise AtakError(f"{serial}: ATAK map is not in the foreground ({_NAV_MENU} missing)")
+        # The side pane sits in the right half below the nav bar; the nav bar
+        # and drawing toolbars are not panes and don't block Overlay Manager.
+        pane_open = any(
+            _rid(el) not in _MAP_CHROME_IDS
+            and (c := _center(el)) is not None
+            and c[0] > menu[0] // 2
+            and c[1] > menu[1] + 100
+            for el in els
+            if _rid(el)
+        )
+        if not pane_open:
+            return
+        avd.adb("shell", "input", "keyevent", "KEYCODE_BACK", serial=serial)
+        time.sleep(1.0)
+
+
+def _open_overlay_manager(serial: str) -> None:
+    """Tap the layers (Overlay Manager) nav button.
+
+    The nav toolbar buttons carry no text or resource-id — only
+    ``tak_nav_menu_button`` (rightmost) is named — so we pick the toolbar's
+    unnamed clickable buttons on the same row as the menu button and take the
+    second from the left, which is Overlay Manager in the default layout.
+    """
+    els = avd.ui_dump(serial=serial)
+    menu = next((c for el in els if _rid(el) == _NAV_MENU and (c := _center(el))), None)
+    if menu is None:
+        raise AtakError(f"{serial}: {_NAV_MENU} not found")
+    row = sorted(
+        c
+        for el in els
+        if not _rid(el)
+        and "clickable" in el.get("interactions", [])
+        and (c := _center(el)) is not None
+        and abs(c[1] - menu[1]) <= 10
+        and c[0] < menu[0]
+    )
+    if len(row) < 2:
+        raise AtakError(f"{serial}: nav toolbar buttons not found next to {_NAV_MENU}")
+    avd.tap(row[1][0], row[1][1], serial=serial)
+    if _find_id(serial, _OM_SEARCH_BTN, timeout=5.0) is None:
+        raise AtakError(f"{serial}: Overlay Manager did not open ({_OM_SEARCH_BTN} missing)")
+
+
+def _search_overlay_manager(serial: str, name: str, *, timeout: float) -> tuple[int, int]:
+    """Search Overlay Manager for ``name``; return the matching row's center."""
+    if not _tap_id(serial, _OM_SEARCH_BTN):
+        raise AtakError(f"{serial}: {_OM_SEARCH_BTN} not found")
+    time.sleep(0.5)
+    avd.type_text(name, serial=serial)
+    if _keyboard_shown(serial):
+        avd.adb("shell", "input", "keyevent", "KEYCODE_BACK", serial=serial)
+    deadline = time.time() + timeout
+    while True:
+        for el in avd.ui_dump(serial=serial):
+            if _rid(el) == _OM_ROW_TITLE and el.get("text") == name and (c := _center(el)):
+                return c
+        if time.time() >= deadline:
+            _tap_id(serial, "close_hmv", timeout=0.0)
+            raise AtakError(f"{serial}: no Overlay Manager item named {name!r}")
+        time.sleep(0.5)
+
+
+# Radial-menu geometry, measured on the 2400x1080 fleet AVD with Overlay
+# Manager open: long-pressing a row pans the item to the map pane's focus point
+# (the left half) and opens the radial menu there; its "details" slot is the
+# bottom-right item. The radial is drawn on the map surface and is absent from
+# every hierarchy dump, so this is the one place we tap by pixel.
+_RADIAL_CENTER = (599, 602)
+_RADIAL_DETAILS_OFFSET = (115, 136)
+
+
+def _tap_radial_details(serial: str) -> None:
+    x = _RADIAL_CENTER[0] + _RADIAL_DETAILS_OFFSET[0]
+    y = _RADIAL_CENTER[1] + _RADIAL_DETAILS_OFFSET[1]
+    avd.tap(x, y, serial=serial)
+
+
+def share_item(serial: str, name: str, *, timeout: float = 5.0) -> dict:
+    """Broadcast the existing ATAK map item named ``name`` to all contacts.
+
+    Overlay Manager → search → long-press the row (pans, selects, opens the
+    radial menu — or, for routes, expands the row's action buttons) → details
+    → send → Broadcast. Raises :class:`AtakError` when the item is not found or
+    the details pane exposes no send control. ``timeout`` bounds each wait
+    for a screen to appear.
+    """
+    if not name.strip():
+        raise AtakError("share_item needs a non-empty item name")
+    _ensure_map_foreground(serial)
+    _open_overlay_manager(serial)
+    row = _search_overlay_manager(serial, name, timeout=timeout)
+    avd.swipe(row[0], row[1], row[0], row[1], 1200, serial=serial)  # long-press
+    time.sleep(1.5)
+    send = _find_send_control(serial)
+    if send is None:
+        _tap_radial_details(serial)
+        deadline = time.time() + timeout
+        while send is None and time.time() < deadline:
+            time.sleep(0.5)
+            send = _find_send_control(serial)
+    if send is None:
+        raise AtakError(f"{serial}: no send control found in the details pane for {name!r}")
+    via, (x, y) = send
+    avd.tap(x, y, serial=serial)
+    if not _tap_id(serial, _BROADCAST_ID, timeout=timeout):
+        raise AtakError(f"{serial}: {_BROADCAST_ID} did not appear after tapping {via}")
+    time.sleep(1.0)
+    return {"shared": True, "name": name, "via": via}

--- a/src/meshtastic_mcp/emulator/avd.py
+++ b/src/meshtastic_mcp/emulator/avd.py
@@ -28,6 +28,7 @@ from __future__ import annotations
 import json
 import os
 import re
+import shlex
 import shutil
 import subprocess
 import time
@@ -832,9 +833,10 @@ def type_text(text: str, serial: str | None = None) -> None:
 
     With the ``[android-fast]`` extra this is Unicode-safe (clipboard-paste) and
     the raw string is sent as-is. The plain-adb fallback uses `input text`,
-    which needs spaces as `%s` and mangles shell metacharacters — so the `%s`
-    encoding lives here, on the fallback branch only (encoding it before the
-    fast path would paste a literal `%s`). Callers pass the raw text either way.
+    which needs spaces as `%s` and runs through the device shell (so `&`, `;`,
+    quotes etc. must be shell-quoted) — that encoding lives here, on the
+    fallback branch only (encoding it before the fast path would paste a
+    literal `%s`). Callers pass the raw text either way.
 
     Like :func:`tap_text`, a uiautomator2 failure is not retried on the adb path
     (a lost response could double-insert the text); the connection is reset and
@@ -849,7 +851,7 @@ def type_text(text: str, serial: str | None = None) -> None:
             raise EmulatorError(
                 f"uiautomator2 type_text failed (not retried on adb): {exc}"
             ) from exc
-    adb("shell", "input", "text", text.replace(" ", "%s"), serial=serial)
+    adb("shell", "input", "text", shlex.quote(text.replace(" ", "%s")), serial=serial)
 
 
 def swipe(x1: int, y1: int, x2: int, y2: int, ms: int = 400, serial: str | None = None) -> None:

--- a/src/meshtastic_mcp/server.py
+++ b/src/meshtastic_mcp/server.py
@@ -219,6 +219,7 @@ _ANDROID_TOOLS = (
     "atak_fleet_down",
     "atak_drive_route",
     "atak_drive_stop",
+    "atak_share_item",
 )
 
 # SDR-coupled tools, gated by `sdr_tool` on the sdr capability.
@@ -3188,6 +3189,21 @@ def atak_drive_route(
 
 
 @android_tool()
+def atak_share_item(serial: str, name: str) -> dict[str, Any]:
+    """Broadcast an existing ATAK map item (marker, shape, route, R&B, bullseye)
+    named `name` to all contacts, driving the UI by view-hierarchy resource-ids:
+    Overlay Manager → search → details → send → Broadcast. Blocks ~10-20 s.
+    Returns `{"shared": true, "name", "via": <send control resource-id>}`, or
+    `{"error": ...}` when the item isn't found / has no send control."""
+    from .emulator import atak
+
+    try:
+        return atak.share_item(serial, name)
+    except atak.AtakError as exc:
+        return {"error": str(exc)}
+
+
+@android_tool()
 def atak_drive_stop(serial: str | None = None) -> dict[str, Any]:
     """Stop an active GPS drive (all drives if `serial` is omitted). The self-PLI
     holds at the last fix delivered."""
@@ -3377,6 +3393,7 @@ _DESTRUCTIVE = {
     "atak_fleet_down",
     "atak_drive_route",
     "atak_drive_stop",
+    "atak_share_item",  # drives ATAK UI; broadcasts CoT to every connected peer
     "replay_inject",  # emits packets onto the live connection
     "replay_inject_beacon",  # emits a MESH_BEACON_APP packet
     "replay_inject_fileinfo",  # emits a FileInfo FromRadio onto the live connection
@@ -3475,6 +3492,7 @@ _OPEN_WORLD = {
     "atak_fleet_down",
     "atak_drive_route",
     "atak_drive_stop",
+    "atak_share_item",
 }
 
 

--- a/tests/unit/test_atak_fleet.py
+++ b/tests/unit/test_atak_fleet.py
@@ -324,6 +324,99 @@ class _AdbLog:
         if args[:1] == ("push",):
             self.pushed.append((args[2], Path(args[1]).read_text()))
 
+
+# ---------------------------------------------------------------------------
+# share_item — scripted ATAK screens, driven purely by resource-id dumps
+# ---------------------------------------------------------------------------
+def _el(rid: str, x: int, y: int, text: str = "", *, clickable: bool = True) -> dict[str, object]:
+    # Emulator `android layout` schema: hyphenated key, "[x,y]" string center.
+    el: dict[str, object] = {"text": text, "center": f"[{x},{y}]", "interactions": []}
+    if clickable:
+        el["interactions"] = ["clickable", "focusable"]
+    if rid:
+        el["resource-id"] = rid
+    return el
+
+
+_MAP = [
+    _el("", 1515, 126),
+    _el("", 1652, 126),  # Overlay Manager (2nd unnamed nav button)
+    _el("", 1789, 126),
+    _el("tak_nav_menu_button", 2337, 126),
+    _el("tak_nav_zoom", 63, 456),
+    _el("compass", 63, 133),
+    _el("tak_nav_center", 63, 267),
+]
+_OM = [*_MAP, _el("hierarchy_search_btn", 2353, 246), _el("close_hmv", 2358, 975)]
+_DETAILS = [*_MAP, _el("drawingCircleNameEdit", 1985, 236, "Drawing Circle 1")]
+_CONTACTS = [*_MAP, _el("contact_list_button_send_to_all", 2160, 975, "Broadcast")]
+
+
+class _Atak:
+    """A tiny ATAK state machine: the screen advances on the taps we expect."""
+
+    def __init__(self, items: list[str], *, route: bool = False, start: str = "map") -> None:
+        self.items, self.route, self.screen = items, route, start
+        self.taps: list[tuple[int, int]] = []
+        self.adb: list[tuple[str, ...]] = []
+        self.typed: list[str] = []
+
+    def ui_dump(self, serial: str | None = None, diff: bool = False) -> list[dict[str, object]]:
+        if self.screen == "map":
+            return _MAP
+        if self.screen == "details":  # a pane in the right half → BACK closes it
+            return [*_DETAILS, _el("drawingCircleSendButton", 1635, 969)]
+        if self.screen == "om":
+            return _OM
+        if self.screen == "search":
+            hits = [n for n in self.items if self.typed and self.typed[-1] in n]
+            rows = [
+                _el("hierarchy_manager_list_item_title", 1821, 361 + 140 * i, n, clickable=False)
+                for i, n in enumerate(hits)
+            ]
+            if (
+                self.route
+                and self.screen == "search"
+                and self.taps
+                and self.taps[-1] == (1821, 361)
+            ):
+                rows.append(_el("route_manager_send_button", 1623, 493))
+            return [*_OM, *rows]
+        if self.screen == "radial":  # radial menu is NOT in the hierarchy
+            return _OM
+        if self.screen == "contacts":
+            return _CONTACTS
+        raise AssertionError(self.screen)
+
+    def tap(self, x: int, y: int, serial: str | None = None) -> None:
+        self.taps.append((x, y))
+        if self.screen == "map" and (x, y) == (1652, 126):
+            self.screen = "om"
+        elif self.screen == "om" and (x, y) == (2353, 246):
+            self.screen = "search"
+        elif self.screen == "radial" and (x, y) == (599 + 115, 602 + 136):
+            self.screen = "details"
+        elif self.screen in ("details", "search") and y in (969, 493):
+            self.screen = "contacts"
+        elif self.screen == "contacts" and (x, y) == (2160, 975):
+            self.screen = "map"
+
+    def swipe(
+        self, x1: int, y1: int, x2: int, y2: int, ms: int = 400, serial: str | None = None
+    ) -> None:
+        assert (x1, y1) == (x2, y2) and ms >= 1000, "long-press expected"
+        self.taps.append((x1, y1))
+        if not self.route:
+            self.screen = "radial"
+
+    def type_text(self, text: str, serial: str | None = None) -> None:
+        self.typed.append(text)
+
+    def adb_cmd(self, *args: str, serial: str | None = None, **kw: object) -> object:
+        self.adb.append(args)
+        if args[-1] == "KEYCODE_BACK" and self.screen == "details":
+            self.screen = "map"
+
         class R:
             stdout = ""
 
@@ -453,3 +546,69 @@ def test_launch_raises_when_map_never_appears(monkeypatch: pytest.MonkeyPatch) -
     monkeypatch.setattr(atak.time, "sleep", lambda _s: None)
     with pytest.raises(atak.AtakError, match="map toolbar"):
         atak.launch("emulator-5554", timeout=0.01)
+
+
+@pytest.fixture
+def fake_atak(monkeypatch: pytest.MonkeyPatch):
+    def _make(*a: object, **kw: object) -> _Atak:
+        fake = _Atak(*a, **kw)  # type: ignore[arg-type]
+        monkeypatch.setattr(atak.avd, "ui_dump", fake.ui_dump)
+        monkeypatch.setattr(atak.avd, "tap", fake.tap)
+        monkeypatch.setattr(atak.avd, "swipe", fake.swipe)
+        monkeypatch.setattr(atak.avd, "type_text", fake.type_text)
+        monkeypatch.setattr(atak.avd, "adb", fake.adb_cmd)
+        monkeypatch.setattr(atak.time, "sleep", lambda _s: None)
+        return fake
+
+    return _make
+
+
+def test_share_item_shape_via_radial_details(fake_atak) -> None:
+    fake = fake_atak(["Drawing Circle 1", "Rectangle 1"])
+    out = atak.share_item("emulator-5556", "Drawing Circle 1")
+    assert out == {"shared": True, "name": "Drawing Circle 1", "via": "drawingCircleSendButton"}
+    assert fake.typed == ["Drawing Circle 1"]
+    assert fake.screen == "map"
+    # Overlay Manager was opened from the nav row, not a hard-coded pixel.
+    assert fake.taps[0] == (1652, 126)
+
+
+def test_share_item_route_uses_row_send_button(fake_atak) -> None:
+    fake = fake_atak(["Route 1"], route=True)
+    out = atak.share_item("emulator-5556", "Route 1")
+    assert out["via"] == "route_manager_send_button"
+    assert (599 + 115, 602 + 136) not in fake.taps  # no radial fallback needed
+
+
+def test_share_item_backs_out_of_open_pane_first(fake_atak) -> None:
+    fake = fake_atak(["Drawing Circle 1"], start="details")
+    atak.share_item("emulator-5556", "Drawing Circle 1")
+    assert ("shell", "input", "keyevent", "KEYCODE_BACK") in fake.adb
+
+
+def test_share_item_exact_title_match_only(fake_atak) -> None:
+    # The search is a substring filter; the row we long-press must be the
+    # exact title, not the first hit.
+    fake = fake_atak(["R 10", "R 1"])
+    atak.share_item("emulator-5556", "R 1")
+    assert (1821, 501) in fake.taps  # second row — the exact match
+    assert (1821, 361) not in fake.taps
+
+
+def test_share_item_missing_item_raises_and_closes_om(fake_atak) -> None:
+    fake = fake_atak(["Route 1"])
+    with pytest.raises(atak.AtakError, match="no Overlay Manager item named 'Nope'"):
+        atak.share_item("emulator-5556", "Nope", timeout=0)
+    assert (2358, 975) in fake.taps  # close_hmv
+
+
+def test_share_item_rejects_empty_name(fake_atak) -> None:
+    fake_atak([])
+    with pytest.raises(atak.AtakError):
+        atak.share_item("emulator-5556", "  ")
+
+
+def test_rid_handles_both_dump_schemas() -> None:
+    assert atak._rid({"resource-id": "foo"}) == "foo"
+    assert atak._rid({"resource_id": "com.atakmap.app.civ:id/foo"}) == "foo"
+    assert atak._rid({}) == ""


### PR DESCRIPTION
Adds the `atak_share_item(serial, name)` MCP tool (android capability) and `atak.share_item()`: broadcast an existing ATAK map item — marker, shape, route, R&B, bullseye — to all contacts, driving ATAK by view-hierarchy resource-ids.

Flow: make sure the map is foreground (BACK out of any open pane) → Overlay Manager (picked as the 2nd unnamed nav button on `tak_nav_menu_button`'s row) → `hierarchy_search_btn` → type the name → long-press the exact-title row → details pane → the item's send control (`*SendButton` / `sendLayout` / `share_route` / `lastPointSend` / `med_sendBtn`) → `contact_list_button_send_to_all`.

The radial menu is drawn on the GL map surface and never appears in a dump, so its "details" slot is the one pixel tap; it is isolated in `_tap_radial_details` with the measured geometry. Routes skip it — the long-pressed row exposes `route_manager_send_button` directly.

Also fixes the plain-adb `type_text` fallback to shell-quote its argument: `R&B 1` was being split at the `&` by the device shell.

Verified on ATAK-CIV 5.6 (two-emulator fleet) against the CoT relay, each share landing as the expected event type: circle `u-d-c-c`, rectangle `u-d-r`, route `b-m-r`, R&B `u-rb-a`, bullseye `u-r-b-bullseye`, marker `b-m-p-s-m`. A missing name raises `AtakError` and closes Overlay Manager.

Docs: short entry under "The pieces" in `docs/atak-cot.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability to share existing ATAK map items—such as markers, shapes, routes, and bullseyes—by name.
  * Shared items can be broadcast to all contacts through ATAK.
  * Added clear errors for missing items, empty names, or unavailable sharing controls.

* **Bug Fixes**
  * Improved handling of special characters when entering text through Android’s fallback input method.

* **Documentation**
  * Documented the new map-item sharing capability and supported item types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->