### PR TITLE
fix(web-ui): bump transitive nanoid to 3.3.18, patches CVE-2026-67213

### DIFF
--- a/web-ui/package-lock.json
+++ b/web-ui/package-lock.json
@@ -1912,9 +1912,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
## Summary

Patches Dependabot alert #24 (GHSA-2v37-7h3g-55p8 / CVE-2026-67213, high severity): `nanoid` < 3.3.18 has an infinite loop in `customAlphabet`/`customRandom` when called with `size=0`. Pulled in transitively by `postcss` (`^3.3.16`, already satisfied by `3.3.18`) — lockfile-only change, no `package.json` edits needed.

## Test plan

`npm update nanoid && npm run build` in `web-ui/` — build succeeds, output unchanged in shape (gitignored `src/meshtastic_mcp/web/static/`). Not exploitable in this codebase today (postcss doesn't pass attacker-controlled `size` to nanoid), but zero-risk patch bump, worth taking regardless.

## Checklist

- [x] Gates pass — n/a (pure lockfile bump, no Python changes; `npm run build` verified)
- [x] New MCP tools have read/destructive/openWorld annotations — n/a
- [x] Core changes import/run with no firmware checkout — n/a
- [x] DCO sign-off (`git commit -s`)