### PR TITLE
fix(flash): pin uploads to the requested port and fail loudly on mismatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,7 +81,7 @@ All notable changes are documented here. Format loosely follows
 ### Fixed
 - **Flash tools can no longer flash a different device than the requested port**
   (`flash`/`pio_flash`, `flash_start`, `erase_and_flash`, `update_flash`) — pioarduino's
-  Hybrid-Compile pass (custom sdkconfig → "*** Compile Arduino IDF libs ***") re-invokes a
+  Hybrid-Compile pass (custom sdkconfig → `*** Compile Arduino IDF libs ***`) re-invokes a
   child `pio run -e <env> -t upload` that forwards targets but no CLI options, so the child
   dropped our `--upload-port`, auto-detected a port, and could flash whichever device it
   found first (real incident 2026-08-25: a `meshnology_w10` 16 MB image landed on the 8 MB
@@ -93,7 +93,12 @@ All notable changes are documented here. Format loosely follows
   `upload_port_mismatch` error naming both ports. Empty or glob `port` arguments (which
   PlatformIO silently turns into auto-detection) are rejected up front, and `flash_start`
   jobs now also apply the silent-DFU-failure detection `flash` already had, surfacing
-  `error` through `flash_poll`. — the sim emitted only in-flight
+  `error` through `flash_poll`. Uploads also take the same per-port lock the
+  connect/serial paths use, so they serialize against each other and against a live
+  `connect()` — held across `flash`'s pre-flight too, since `ensure_port_free` reads an
+  in-process holder as a wedged device and would power-cycle the hub slot mid-flash.
+  A busy port fails fast (`flash_start` included, on the calling thread).
+- **Traceroutes now surface in app traceroute logs** — the sim emitted only in-flight
   traceroute *requests* (`request_id` 0), which apps ignore: their traceroute logs persist
   only *responses* (nonzero `decoded.request_id`), so a whole capture streamed with an empty
   traceroute log (found live against the Apple app). The sim now emits request → response

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,7 +79,21 @@ All notable changes are documented here. Format loosely follows
   `achieved_rate`, so a stress run is self-verifying.
 
 ### Fixed
-- **Traceroutes now surface in app traceroute logs** — the sim emitted only in-flight
+- **Flash tools can no longer flash a different device than the requested port**
+  (`flash`/`pio_flash`, `flash_start`, `erase_and_flash`, `update_flash`) — pioarduino's
+  Hybrid-Compile pass (custom sdkconfig → "*** Compile Arduino IDF libs ***") re-invokes a
+  child `pio run -e <env> -t upload` that forwards targets but no CLI options, so the child
+  dropped our `--upload-port`, auto-detected a port, and could flash whichever device it
+  found first (real incident 2026-08-25: a `meshnology_w10` 16 MB image landed on the 8 MB
+  Heltec Wireless Tracker V2 one hub over, boot-looping it while the job reported success).
+  Uploads now also pin the port via `PLATFORMIO_UPLOAD_PORT` in the subprocess environment —
+  the project-option override the child run inherits — and every flash result is post-checked
+  against the ports the output claims were used (`Auto-detected:` / `Using manually
+  specified:` / esptool's `Serial port` lines): a mismatch forces a non-zero exit with an
+  `upload_port_mismatch` error naming both ports. Empty or glob `port` arguments (which
+  PlatformIO silently turns into auto-detection) are rejected up front, and `flash_start`
+  jobs now also apply the silent-DFU-failure detection `flash` already had, surfacing
+  `error` through `flash_poll`. — the sim emitted only in-flight
   traceroute *requests* (`request_id` 0), which apps ignore: their traceroute logs persist
   only *responses* (nonzero `decoded.request_id`), so a whole capture streamed with an empty
   traceroute log (found live against the Apple app). The sim now emits request → response

--- a/src/meshtastic_mcp/flash.py
+++ b/src/meshtastic_mcp/flash.py
@@ -13,6 +13,7 @@ artifacts to exist, so these tools build first if needed.
 from __future__ import annotations
 
 import os
+import re
 import subprocess
 import threading
 import time
@@ -49,6 +50,75 @@ def _require_confirm(confirm: bool, operation: str) -> None:
             f"{operation} is destructive and requires confirm=True. "
             "This will overwrite firmware on the device."
         )
+
+
+def _require_port(port: str, operation: str) -> None:
+    """Reject a port value PlatformIO would silently turn into auto-detection.
+
+    `pio run --upload-port ""` drops the option entirely (click passes the
+    empty string, the run processor treats it as unset), and a glob pattern
+    makes PlatformIO pick whatever port matches — either way the upload can
+    land on a DIFFERENT device than the caller intended. Fail fast instead.
+    """
+    if not port or not port.strip():
+        raise FlashError(
+            f"{operation} requires an explicit non-empty port. An empty port "
+            "makes PlatformIO auto-detect and flash whatever device it finds."
+        )
+    if set("*?[]") & set(port):
+        raise FlashError(
+            f"{operation} got a glob pattern for port ({port!r}). Pass the "
+            "exact device path so the upload cannot land on another device."
+        )
+
+
+def _upload_port_env(port: str, build_flags: dict[str, Any] | None) -> dict[str, str]:
+    """Subprocess env for an upload: build flags + `PLATFORMIO_UPLOAD_PORT`.
+
+    `--upload-port` alone is NOT enough to pin the upload to `port`:
+    pioarduino's Hybrid-Compile pass (triggered by a custom sdkconfig — the
+    "*** Compile Arduino IDF libs ***" stage) re-invokes a child
+    `pio run -e <env> -t upload` that forwards targets but no CLI options, so
+    the child auto-detects a port and can flash a different device (2026-08-25:
+    a meshnology_w10 16MB image landed on a Heltec Wireless Tracker V2 that
+    auto-detect found first, boot-looping it). `PLATFORMIO_UPLOAD_PORT` sets
+    the `upload_port` project option through the process environment, which
+    the child run inherits — closing that hole. The CLI flag still wins in
+    the outer run when both are present (same value here).
+    """
+    out = _build_flags_env(build_flags) if build_flags else {}
+    out["PLATFORMIO_UPLOAD_PORT"] = port
+    return out
+
+
+# Ports the upload output claims to have used. "Auto-detected:"/"Using
+# manually specified:" are printed by PlatformIO's AutodetectUploadPort;
+# "Serial port <port>:" by esptool v5 (also via device-install/update.sh).
+_USED_PORT_RE = re.compile(
+    r"^(?:Auto-detected: |Using manually specified: |Serial port )(\S+?):?\s*$",
+    re.MULTILINE,
+)
+
+
+def _verify_upload_port(requested: str, stdout: str | None, stderr: str | None) -> str | None:
+    """Return an error message if the upload reported using a different port.
+
+    Post-flash assertion backing up `_upload_port_env`: if any path drops the
+    requested port (a future PlatformIO/pioarduino regression, a script that
+    ignores `-p`), the tool result must fail loudly instead of reporting a
+    successful flash of the wrong device. Returns None when the output names
+    no port at all (e.g. nrfutil DFU output) or only the requested one.
+    """
+    blob = f"{stdout or ''}\n{stderr or ''}"
+    used = {m.rstrip(":") for m in _USED_PORT_RE.findall(blob)}
+    wrong = sorted(p for p in used if p != requested)
+    if not wrong:
+        return None
+    return (
+        f"upload used port {', '.join(wrong)} instead of the requested "
+        f"{requested} — the WRONG DEVICE may have been flashed. Check every "
+        "device on the bench before trusting this flash."
+    )
 
 
 def _reject_native_env(env: str, operation: str) -> None:
@@ -232,6 +302,7 @@ def flash(
     """
     _require_confirm(confirm, "flash")
     _reject_native_env(env, "flash")
+    _require_port(port, "flash")
     connection.reject_if_tcp(port, "flash")
     # Pre-flight: a held or wedged port can't be flashed. ensure_port_free waits
     # out a transient holder and, if the device is genuinely wedged (hung
@@ -244,7 +315,7 @@ def flash(
         raise FlashError(
             f"cannot flash {env!r}: serial port {port} could not be made usable ({exc})"
         ) from exc
-    extra_env = _build_flags_env(build_flags) if build_flags else None
+    extra_env = _upload_port_env(port, build_flags)
     with userprefs.temporary_overrides(userprefs_overrides) as effective:
         result = pio.run(
             ["run", "-e", env, "-t", "upload", "--upload-port", port],
@@ -254,10 +325,12 @@ def flash(
             line_cb=progress_cb,
         )
     upload_error = _detect_upload_failure(result.stdout, result.stderr)
+    port_mismatch = _verify_upload_port(port, result.stdout, result.stderr)
     exit_code = result.returncode
-    if upload_error and exit_code == 0:
-        # pio masked a silent DFU failure as success — surface it as non-zero so
-        # the bake/flash/recover paths don't record a flash that never landed.
+    if (upload_error or port_mismatch) and exit_code == 0:
+        # pio masked a silent DFU failure (or flashed a different port) as
+        # success — surface it as non-zero so the bake/flash/recover paths
+        # don't record a flash that never landed (or landed elsewhere).
         exit_code = 1
     out = {
         "exit_code": exit_code,
@@ -269,6 +342,8 @@ def flash(
     }
     if upload_error:
         out["upload_error"] = upload_error
+    if port_mismatch:
+        out["upload_port_mismatch"] = port_mismatch
     return out
 
 
@@ -301,12 +376,19 @@ def _run_install_script(script: Path, port: str, binary: Path) -> dict[str, Any]
         env=env,
     )
     duration = time.monotonic() - t0
-    return {
-        "exit_code": proc.returncode,
+    port_mismatch = _verify_upload_port(port, proc.stdout, proc.stderr)
+    exit_code = proc.returncode
+    if port_mismatch and exit_code == 0:
+        exit_code = 1
+    out = {
+        "exit_code": exit_code,
         "stdout_tail": pio.tail_lines(proc.stdout, 200),
         "stderr_tail": pio.tail_lines(proc.stderr, 200),
         "duration_s": round(duration, 2),
     }
+    if port_mismatch:
+        out["upload_port_mismatch"] = port_mismatch
+    return out
 
 
 def erase_and_flash(
@@ -323,6 +405,7 @@ def erase_and_flash(
     in that case) since a cached factory.bin would not reflect the new prefs.
     """
     _require_confirm(confirm, "erase_and_flash")
+    _require_port(port, "erase_and_flash")
     connection.reject_if_tcp(port, "erase_and_flash")
     _check_esp32_env(env)
 
@@ -381,6 +464,7 @@ def update_flash(
     overrides are provided we always force a rebuild.
     """
     _require_confirm(confirm, "update_flash")
+    _require_port(port, "update_flash")
     connection.reject_if_tcp(port, "update_flash")
     _check_esp32_env(env)
 
@@ -679,7 +763,7 @@ def _poll_job(job_id: str, tail_lines: int = 50) -> dict[str, Any]:
         log_tail = log_path.read_text(encoding="utf-8", errors="replace").splitlines()[-tail_lines:]
 
     elapsed = round((state["finished_at"] or time.time()) - state["started_at"], 1)
-    return {
+    out = {
         "job_id": job_id,
         "kind": state["kind"],
         "env": state["env"],
@@ -691,6 +775,9 @@ def _poll_job(job_id: str, tail_lines: int = 50) -> dict[str, Any]:
         "log_tail": log_tail,
         "log_path": state["log_path"],
     }
+    if state.get("error"):
+        out["error"] = state["error"]
+    return out
 
 
 def build_start(
@@ -753,10 +840,11 @@ def flash_start(
     """
     _require_confirm(confirm, "flash_start")
     _reject_native_env(env, "flash_start")
+    _require_port(port, "flash_start")
     connection.reject_if_tcp(port, "flash_start")
 
     def _body(state: dict[str, Any], log_path: Path) -> None:
-        extra_env = _build_flags_env(build_flags) if build_flags else None
+        extra_env = _upload_port_env(port, build_flags)
         with userprefs.temporary_overrides(userprefs_overrides):
             result = pio.run(
                 ["run", "-e", env, "-t", "upload", "--upload-port", port],
@@ -764,14 +852,23 @@ def flash_start(
                 check=False,
                 extra_env=extra_env,
             )
+        upload_error = _detect_upload_failure(result.stdout, result.stderr)
+        port_mismatch = _verify_upload_port(port, result.stdout, result.stderr)
+        error = port_mismatch or upload_error
+        exit_code = result.returncode
+        if error and exit_code == 0:
+            exit_code = 1
         stderr_section = "\n--- stderr ---\n" + result.stderr if result.stderr.strip() else ""
-        log_path.write_text(result.stdout + stderr_section, encoding="utf-8")
+        error_section = f"\n--- flash job FAILED ---\n{error}\n" if error else ""
+        log_path.write_text(result.stdout + stderr_section + error_section, encoding="utf-8")
         with _jobs_lock:
-            state["status"] = "done" if result.returncode == 0 else "failed"
-            state["exit_code"] = result.returncode
+            state["status"] = "done" if exit_code == 0 else "failed"
+            state["exit_code"] = exit_code
             state["finished_at"] = time.time()
             state["duration_s"] = round(result.duration_s, 2)
             state["port"] = port
+            if error:
+                state["error"] = error
 
     return _start_job("flashes", env, _body)
 

--- a/src/meshtastic_mcp/flash.py
+++ b/src/meshtastic_mcp/flash.py
@@ -81,17 +81,21 @@ def _acquire_port(port: str, operation: str) -> threading.Lock:
     slot mid-flash. Same non-blocking `registry.port_lock` the connect/serial
     paths use, so all of them serialize against each other.
     """
-    active = registry.active_session_for_port(port)
-    if active is not None:
-        raise FlashError(
-            f"{operation}: port {port} is held by serial session {active.id}. "
-            "Call `serial_close` first."
-        )
     lock = registry.port_lock(port)
     if not lock.acquire(blocking=False):
         raise FlashError(
             f"{operation}: port {port} is busy — another device operation is "
             "in flight. Retry shortly."
+        )
+    # Session check under the lock, the order serial_open uses: it registers
+    # while holding this lock, so checking first would miss a session that
+    # registers between the check and the acquire.
+    active = registry.active_session_for_port(port)
+    if active is not None:
+        _release_port(lock)
+        raise FlashError(
+            f"{operation}: port {port} is held by serial session {active.id}. "
+            "Call `serial_close` first."
         )
     return lock
 

--- a/src/meshtastic_mcp/flash.py
+++ b/src/meshtastic_mcp/flash.py
@@ -23,7 +23,7 @@ from typing import Any
 
 import serial
 
-from . import boards, config, connection, devices, pio, port_recovery, userprefs
+from . import boards, config, connection, devices, pio, port_recovery, registry, userprefs
 
 # Meshtastic variants use both `esp32s3` and `esp32-s3` style names across
 # variants/*/platformio.ini (no consistency enforced). Accept both spellings.
@@ -70,6 +70,42 @@ def _require_port(port: str, operation: str) -> None:
             f"{operation} got a glob pattern for port ({port!r}). Pass the "
             "exact device path so the upload cannot land on another device."
         )
+
+
+def _acquire_port(port: str, operation: str) -> threading.Lock:
+    """Take the shared per-port lock for the length of an upload, or fail fast.
+
+    Uploads are the one device operation that must not share a port: two
+    concurrent flashes drive the same serial line, and `connect()` holding it
+    makes `ensure_port_free` read the port as wedged and power-cycle the hub
+    slot mid-flash. Same non-blocking `registry.port_lock` the connect/serial
+    paths use, so all of them serialize against each other.
+    """
+    active = registry.active_session_for_port(port)
+    if active is not None:
+        raise FlashError(
+            f"{operation}: port {port} is held by serial session {active.id}. "
+            "Call `serial_close` first."
+        )
+    lock = registry.port_lock(port)
+    if not lock.acquire(blocking=False):
+        raise FlashError(
+            f"{operation}: port {port} is busy — another device operation is "
+            "in flight. Retry shortly."
+        )
+    return lock
+
+
+def _release_port(lock: threading.Lock) -> None:
+    """Release a lock taken by `_acquire_port`, tolerating a double release.
+
+    `threading.Lock` is unowned — the docs allow release from any thread — so
+    `flash_start` can acquire on the caller's thread and release on the worker's.
+    """
+    try:
+        lock.release()
+    except RuntimeError:
+        pass
 
 
 def _upload_port_env(port: str, build_flags: dict[str, Any] | None) -> dict[str, str]:
@@ -304,26 +340,33 @@ def flash(
     _reject_native_env(env, "flash")
     _require_port(port, "flash")
     connection.reject_if_tcp(port, "flash")
-    # Pre-flight: a held or wedged port can't be flashed. ensure_port_free waits
-    # out a transient holder and, if the device is genuinely wedged (hung
-    # firmware / stale CDC node), power-cycles its own hub slot to re-enumerate
-    # it. Re-enumeration can bring the device back on a DIFFERENT /dev path, so
-    # flash whatever path it returns rather than the one we were handed.
+    # Held across the pre-flight too: an in-process holder makes ensure_port_free
+    # read the port as wedged and power-cycle the hub slot under it. Keyed on the
+    # requested path — a racing caller names that, not the one recovery lands on.
+    lock = _acquire_port(port, "flash")
     try:
-        port = port_recovery.ensure_port_free(port, allow_power_cycle=True)
-    except port_recovery.PortRecoveryError as exc:
-        raise FlashError(
-            f"cannot flash {env!r}: serial port {port} could not be made usable ({exc})"
-        ) from exc
-    extra_env = _upload_port_env(port, build_flags)
-    with userprefs.temporary_overrides(userprefs_overrides) as effective:
-        result = pio.run(
-            ["run", "-e", env, "-t", "upload", "--upload-port", port],
-            timeout=pio.TIMEOUT_UPLOAD,
-            check=False,
-            extra_env=extra_env,
-            line_cb=progress_cb,
-        )
+        # Pre-flight: a held or wedged port can't be flashed. ensure_port_free waits
+        # out a transient holder and, if the device is genuinely wedged (hung
+        # firmware / stale CDC node), power-cycles its own hub slot to re-enumerate
+        # it. Re-enumeration can bring the device back on a DIFFERENT /dev path, so
+        # flash whatever path it returns rather than the one we were handed.
+        try:
+            port = port_recovery.ensure_port_free(port, allow_power_cycle=True)
+        except port_recovery.PortRecoveryError as exc:
+            raise FlashError(
+                f"cannot flash {env!r}: serial port {port} could not be made usable ({exc})"
+            ) from exc
+        extra_env = _upload_port_env(port, build_flags)
+        with userprefs.temporary_overrides(userprefs_overrides) as effective:
+            result = pio.run(
+                ["run", "-e", env, "-t", "upload", "--upload-port", port],
+                timeout=pio.TIMEOUT_UPLOAD,
+                check=False,
+                extra_env=extra_env,
+                line_cb=progress_cb,
+            )
+    finally:
+        _release_port(lock)
     upload_error = _detect_upload_failure(result.stdout, result.stderr)
     port_mismatch = _verify_upload_port(port, result.stdout, result.stderr)
     exit_code = result.returncode
@@ -445,7 +488,11 @@ def erase_and_flash(
         script = config.firmware_root() / "bin" / "device-install.sh"
         if not script.is_file():
             raise FlashError(f"device-install.sh not found at {script}")
-        result = _run_install_script(script, port, factory)
+        lock = _acquire_port(port, "erase_and_flash")
+        try:
+            result = _run_install_script(script, port, factory)
+        finally:
+            _release_port(lock)
 
     result["userprefs"] = _userprefs_summary(effective)
     return result
@@ -502,7 +549,11 @@ def update_flash(
         script = config.firmware_root() / "bin" / "device-update.sh"
         if not script.is_file():
             raise FlashError(f"device-update.sh not found at {script}")
-        result = _run_install_script(script, port, firmware)
+        lock = _acquire_port(port, "update_flash")
+        try:
+            result = _run_install_script(script, port, firmware)
+        finally:
+            _release_port(lock)
 
     result["userprefs"] = _userprefs_summary(effective)
     return result
@@ -752,8 +803,12 @@ def _start_job(kind: str, env: str, worker_body) -> dict[str, Any]:
 
 def _poll_job(job_id: str, tail_lines: int = 50) -> dict[str, Any]:
     """Shared poll for build/flash jobs started via `_start_job`."""
+    # Snapshot under the lock: the worker publishes exit_code/error/status in one
+    # critical section, so reading the live dict later can catch a status
+    # without its reason.
     with _jobs_lock:
-        state = _active_jobs.get(job_id)
+        live = _active_jobs.get(job_id)
+        state = dict(live) if live is not None else None
     if state is None:
         return {"error": f"Unknown job_id {job_id!r} (only this session's jobs are tracked)."}
 
@@ -802,11 +857,11 @@ def build_start(
         stderr_section = "\n--- stderr ---\n" + result.stderr if result.stderr.strip() else ""
         log_path.write_text(result.stdout + stderr_section, encoding="utf-8")
         with _jobs_lock:
-            state["status"] = "done" if result.returncode == 0 else "failed"
             state["exit_code"] = result.returncode
             state["finished_at"] = time.time()
             state["duration_s"] = round(result.duration_s, 2)
             state["artifacts"] = [str(p) for p in _artifacts_for(env)]
+            state["status"] = "done" if result.returncode == 0 else "failed"
 
     out = _start_job("builds", env, _body)
     # Back-compat alias: callers/tests historically read build_id.
@@ -842,16 +897,22 @@ def flash_start(
     _reject_native_env(env, "flash_start")
     _require_port(port, "flash_start")
     connection.reject_if_tcp(port, "flash_start")
+    # Acquired here, not in the worker, so a busy port errors now instead of
+    # becoming a job the caller finds dead on its first poll.
+    lock = _acquire_port(port, "flash_start")
 
     def _body(state: dict[str, Any], log_path: Path) -> None:
-        extra_env = _upload_port_env(port, build_flags)
-        with userprefs.temporary_overrides(userprefs_overrides):
-            result = pio.run(
-                ["run", "-e", env, "-t", "upload", "--upload-port", port],
-                timeout=pio.TIMEOUT_UPLOAD,
-                check=False,
-                extra_env=extra_env,
-            )
+        try:
+            extra_env = _upload_port_env(port, build_flags)
+            with userprefs.temporary_overrides(userprefs_overrides):
+                result = pio.run(
+                    ["run", "-e", env, "-t", "upload", "--upload-port", port],
+                    timeout=pio.TIMEOUT_UPLOAD,
+                    check=False,
+                    extra_env=extra_env,
+                )
+        finally:
+            _release_port(lock)
         upload_error = _detect_upload_failure(result.stdout, result.stderr)
         port_mismatch = _verify_upload_port(port, result.stdout, result.stderr)
         error = port_mismatch or upload_error
@@ -862,15 +923,21 @@ def flash_start(
         error_section = f"\n--- flash job FAILED ---\n{error}\n" if error else ""
         log_path.write_text(result.stdout + stderr_section + error_section, encoding="utf-8")
         with _jobs_lock:
-            state["status"] = "done" if exit_code == 0 else "failed"
             state["exit_code"] = exit_code
             state["finished_at"] = time.time()
             state["duration_s"] = round(result.duration_s, 2)
             state["port"] = port
             if error:
                 state["error"] = error
+            # Status last: a poll treats anything but "running" as terminal, so
+            # publishing it before the reason can hand back a bare failure.
+            state["status"] = "done" if exit_code == 0 else "failed"
 
-    return _start_job("flashes", env, _body)
+    try:
+        return _start_job("flashes", env, _body)
+    except BaseException:
+        _release_port(lock)
+        raise
 
 
 def flash_poll(job_id: str, tail_lines: int = 50) -> dict[str, Any]:

--- a/tests/unit/test_upload_port_guard.py
+++ b/tests/unit/test_upload_port_guard.py
@@ -16,6 +16,7 @@ job loudly when the output shows a different port was used.
 from __future__ import annotations
 
 import time
+from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
@@ -181,6 +182,37 @@ def test_flash_refuses_a_port_another_operation_holds() -> None:
         run.assert_not_called()
     finally:
         lock.release()
+        registry.clear_port_lock(REQUESTED)
+
+
+def test_flash_refuses_a_port_a_serial_session_holds_and_frees_the_lock() -> None:
+    """`serial_open` registers its session while holding this same lock, so the
+    session check has to come after the acquire — and rejecting must not keep it."""
+    session = SimpleNamespace(id="ses-1")
+
+    def _session_only_if_lock_is_held(port: str):
+        probe = registry.port_lock(port)
+        if probe.acquire(blocking=False):
+            # Checked before the acquire — the window serial_open registers in.
+            probe.release()
+            return None
+        return session
+
+    try:
+        with (
+            patch.object(
+                registry, "active_session_for_port", side_effect=_session_only_if_lock_is_held
+            ),
+            patch.object(port_recovery, "ensure_port_free") as recover,
+            pytest.raises(flash.FlashError, match="serial session ses-1"),
+        ):
+            flash.flash("meshnology_w10", REQUESTED, confirm=True)
+        recover.assert_not_called()
+
+        lock = registry.port_lock(REQUESTED)
+        assert lock.acquire(blocking=False), "the rejected flash kept the port lock"
+        lock.release()
+    finally:
         registry.clear_port_lock(REQUESTED)
 
 

--- a/tests/unit/test_upload_port_guard.py
+++ b/tests/unit/test_upload_port_guard.py
@@ -20,7 +20,7 @@ from unittest.mock import patch
 
 import pytest
 
-from meshtastic_mcp import flash, pio, port_recovery
+from meshtastic_mcp import config, flash, pio, port_recovery, registry
 
 REQUESTED = "/dev/cu.usbmodem1201"
 WRONG = "/dev/cu.usbmodem13201"
@@ -153,3 +153,172 @@ def test_flash_start_job_fails_on_port_mismatch(tmp_path, monkeypatch) -> None:
     assert WRONG in polled["error"]
     # The failure must also be visible in the job log an operator tails.
     assert "flash job FAILED" in "\n".join(polled["log_tail"])
+
+
+# --- per-port serialization -------------------------------------------------
+#
+# An upload is the one device operation that must not share a port. Two
+# concurrent flashes drive the same serial line, and — worse — an in-process
+# `connect()` holding the port makes `ensure_port_free` read the device as
+# wedged and power-cycle its hub slot, yanking VBUS out from under a flash in
+# progress. Uploads take the same non-blocking `registry.port_lock` the
+# connect/serial paths use, so they all serialize against each other.
+
+
+def test_flash_refuses_a_port_another_operation_holds() -> None:
+    """And refuses BEFORE the pre-flight: ensure_port_free would treat the
+    in-process holder as a wedged device and power-cycle the hub."""
+    lock = registry.port_lock(REQUESTED)
+    assert lock.acquire(blocking=False)
+    try:
+        with (
+            patch.object(port_recovery, "ensure_port_free") as recover,
+            patch.object(pio, "run") as run,
+            pytest.raises(flash.FlashError, match="busy"),
+        ):
+            flash.flash("meshnology_w10", REQUESTED, confirm=True)
+        recover.assert_not_called()
+        run.assert_not_called()
+    finally:
+        lock.release()
+        registry.clear_port_lock(REQUESTED)
+
+
+def test_flash_start_fails_fast_when_the_port_is_busy(tmp_path, monkeypatch) -> None:
+    """The lock is taken on the caller's thread, so a busy port is an error
+    now — not a job the caller only discovers is dead on the first poll."""
+    monkeypatch.setenv("MESHTASTIC_MCP_DATA_DIR", str(tmp_path))
+    lock = registry.port_lock(REQUESTED)
+    assert lock.acquire(blocking=False)
+    try:
+        with patch.object(pio, "run") as run, pytest.raises(flash.FlashError, match="busy"):
+            flash.flash_start("meshnology_w10", REQUESTED, confirm=True)
+        run.assert_not_called()
+    finally:
+        lock.release()
+        registry.clear_port_lock(REQUESTED)
+
+
+@pytest.mark.firmware
+def test_flash_releases_the_port_lock_on_both_paths() -> None:
+    try:
+        with (
+            patch.object(port_recovery, "ensure_port_free", return_value=REQUESTED),
+            patch.object(pio, "run", return_value=_Result(_WRONG_PORT_STDOUT)),
+        ):
+            flash.flash("meshnology_w10", REQUESTED, confirm=True)
+        with (
+            patch.object(port_recovery, "ensure_port_free", return_value=REQUESTED),
+            patch.object(pio, "run", side_effect=RuntimeError("pio blew up")),
+            pytest.raises(RuntimeError),
+        ):
+            flash.flash("meshnology_w10", REQUESTED, confirm=True)
+
+        lock = registry.port_lock(REQUESTED)
+        assert lock.acquire(blocking=False), "flash leaked the port lock"
+        lock.release()
+    finally:
+        registry.clear_port_lock(REQUESTED)
+
+
+@pytest.mark.firmware
+def test_flash_start_releases_the_port_lock_when_the_job_ends(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("MESHTASTIC_MCP_DATA_DIR", str(tmp_path))
+    try:
+        with patch.object(pio, "run", return_value=_Result(_WRONG_PORT_STDOUT)):
+            started = flash.flash_start("meshnology_w10", REQUESTED, confirm=True)
+            deadline = time.monotonic() + 10.0
+            while time.monotonic() < deadline:
+                polled = flash.flash_poll(started["job_id"])
+                if polled["status"] != "running":
+                    break
+                time.sleep(0.05)
+
+        assert polled["status"] == "failed"
+        lock = registry.port_lock(REQUESTED)
+        assert lock.acquire(blocking=False), "the flash job leaked the port lock"
+        lock.release()
+    finally:
+        registry.clear_port_lock(REQUESTED)
+
+
+@pytest.mark.firmware
+def test_erase_and_flash_holds_the_port_across_the_install_script(tmp_path) -> None:
+    held: dict[str, bool] = {}
+
+    def _stub_script(script, port, binary):
+        probe = registry.port_lock(port)
+        held["locked"] = not probe.acquire(blocking=False)
+        if not held["locked"]:
+            probe.release()
+        return {"exit_code": 0, "stdout_tail": "", "stderr_tail": "", "duration_s": 0.1}
+
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    (bin_dir / "device-install.sh").write_text("#!/bin/sh\n", encoding="utf-8")
+
+    try:
+        with (
+            patch.object(flash, "_check_esp32_env", return_value="esp32"),
+            patch.object(flash, "_factory_bin_for", return_value=tmp_path / "factory.bin"),
+            patch.object(config, "firmware_root", return_value=tmp_path),
+            patch.object(flash, "_run_install_script", side_effect=_stub_script),
+        ):
+            flash.erase_and_flash("meshnology_w10", REQUESTED, confirm=True, skip_build=True)
+
+        assert held["locked"], "erase_and_flash ran the install script without the port lock"
+        lock = registry.port_lock(REQUESTED)
+        assert lock.acquire(blocking=False), "erase_and_flash leaked the port lock"
+        lock.release()
+    finally:
+        registry.clear_port_lock(REQUESTED)
+
+
+def test_poll_snapshots_job_state_before_reading_the_log(tmp_path, monkeypatch) -> None:
+    """A job's terminal status and its reason are published in one critical
+    section, so a poll must read every field under `_jobs_lock` — reading them
+    after the log tail can catch `failed` before the `error` naming the wrong
+    port (or the silent DFU failure) has landed."""
+    job_id = "pollsnapshot0"
+    log_path = tmp_path / f"{job_id}.log"
+    log_path.write_text("", encoding="utf-8")
+    state: dict = {
+        "job_id": job_id,
+        "kind": "flashes",
+        "env": "meshnology_w10",
+        "status": "running",
+        "started_at": time.time(),
+        "finished_at": None,
+        "exit_code": None,
+        "artifacts": [],
+        "log_path": str(log_path),
+    }
+    with flash._jobs_lock:
+        flash._active_jobs[job_id] = state
+
+    real_path = flash.Path
+
+    class _TearingPath:
+        """Publishes a half-written terminal state while the poll reads the log."""
+
+        def __init__(self, raw) -> None:
+            self._p = real_path(raw)
+
+        def exists(self) -> bool:
+            return self._p.exists()
+
+        def read_text(self, *args, **kwargs) -> str:
+            state["status"] = "failed"
+            state["exit_code"] = 1
+            return self._p.read_text(*args, **kwargs)
+
+    try:
+        monkeypatch.setattr(flash, "Path", _TearingPath)
+        polled = flash.flash_poll(job_id)
+        assert polled["status"] == "running", (
+            "poll reported a terminal status it read after the log — the reason "
+            "may not be published yet"
+        )
+    finally:
+        with flash._jobs_lock:
+            flash._active_jobs.pop(job_id, None)

--- a/tests/unit/test_upload_port_guard.py
+++ b/tests/unit/test_upload_port_guard.py
@@ -1,0 +1,155 @@
+# SPDX-FileCopyrightText: Meshtastic contributors
+# SPDX-License-Identifier: GPL-3.0-only
+
+"""Unit tests for the upload-port pinning and post-flash port verification.
+
+Real incident (2026-08-25): pioarduino's Hybrid-Compile pass re-invoked a
+child `pio run -e meshnology_w10 -t upload` without forwarding
+`--upload-port`, PlatformIO auto-detected a different bench device, and a
+16MB-partition image landed on an 8MB Heltec Wireless Tracker V2 —
+boot-looping it while the flash job reported success. These tests pin the
+three defenses: reject ports PlatformIO would ignore, export
+`PLATFORMIO_UPLOAD_PORT` so child pio runs inherit the port, and fail the
+job loudly when the output shows a different port was used.
+"""
+
+from __future__ import annotations
+
+import time
+from unittest.mock import patch
+
+import pytest
+
+from meshtastic_mcp import flash, pio, port_recovery
+
+REQUESTED = "/dev/cu.usbmodem1201"
+WRONG = "/dev/cu.usbmodem13201"
+
+# Condensed from the incident log (flashes/a4170dbb5089.log): the hybrid
+# child run auto-detects, esptool then names the port it actually used.
+_WRONG_PORT_STDOUT = (
+    "*** Compile Arduino IDF libs for meshnology_w10 ***\n"
+    "Configuring upload protocol...\n"
+    "CURRENT: upload_protocol = esptool\n"
+    "Looking for upload port...\n"
+    f"Auto-detected: {WRONG}\n"
+    "Uploading .pio/build/meshnology_w10/firmware.bin\n"
+    "esptool v5.3.0\n"
+    f"Serial port {WRONG}:\n"
+    "Hash of data verified.\n"
+    "========================= [SUCCESS] Took 1571.05 seconds ==============\n"
+)
+
+
+# --- _require_port ----------------------------------------------------------
+
+
+@pytest.mark.parametrize("bad_port", ["", "   ", "/dev/cu.usbmodem*", "/dev/cu.usb?[12]"])
+def test_flash_start_rejects_ports_platformio_would_ignore(bad_port: str) -> None:
+    """An empty port makes `pio run --upload-port` auto-detect; a glob makes
+    it pattern-match. Both can flash a different device — refuse up front."""
+    with pytest.raises(flash.FlashError):
+        flash.flash_start("meshnology_w10", bad_port, confirm=True)
+
+
+def test_all_flash_entrypoints_reject_empty_port() -> None:
+    for fn in (flash.flash, flash.flash_start, flash.erase_and_flash, flash.update_flash):
+        with pytest.raises(flash.FlashError):
+            fn("meshnology_w10", "", confirm=True)
+
+
+# --- _verify_upload_port ----------------------------------------------------
+
+
+def test_verify_flags_the_incident_output() -> None:
+    msg = flash._verify_upload_port(REQUESTED, _WRONG_PORT_STDOUT, "")
+    assert msg is not None
+    assert WRONG in msg and REQUESTED in msg
+
+
+def test_verify_accepts_matching_ports() -> None:
+    ok = f"Using manually specified: {REQUESTED}\nesptool v5.3.0\nSerial port {REQUESTED}:\n"
+    assert flash._verify_upload_port(REQUESTED, ok, "") is None
+
+
+def test_verify_ignores_output_naming_no_port() -> None:
+    # nRF52 DFU output names no port in the recognized formats; the check
+    # must stay silent rather than false-positive.
+    nrf = (
+        "Forcing reset using 1200bps open/close on port /dev/cu.usbmodem143101\n"
+        "Uploading firmware.zip\nDevice programmed.\n"
+    )
+    assert flash._verify_upload_port(REQUESTED, nrf, "") is None
+
+
+def test_upload_port_env_merges_build_flags() -> None:
+    env = flash._upload_port_env(REQUESTED, {"DEBUG_HEAP": True})
+    assert env["PLATFORMIO_UPLOAD_PORT"] == REQUESTED
+    assert "-DDEBUG_HEAP" in env["PLATFORMIO_BUILD_FLAGS"]
+    assert flash._upload_port_env(REQUESTED, None) == {"PLATFORMIO_UPLOAD_PORT": REQUESTED}
+
+
+# --- flash(): pinning + loud failure ----------------------------------------
+
+
+class _Result:
+    def __init__(self, stdout: str, returncode: int = 0):
+        self.returncode = returncode
+        self.stdout = stdout
+        self.stderr = ""
+        self.duration_s = 1.0
+
+
+@pytest.mark.firmware
+def test_flash_pins_port_via_cli_and_env() -> None:
+    captured: dict = {}
+
+    def _stub_run(args, **kwargs):
+        captured["args"] = args
+        captured["extra_env"] = kwargs.get("extra_env")
+        return _Result(f"Using manually specified: {REQUESTED}\n")
+
+    with (
+        patch.object(port_recovery, "ensure_port_free", return_value=REQUESTED),
+        patch.object(pio, "run", side_effect=_stub_run),
+    ):
+        out = flash.flash("meshnology_w10", REQUESTED, confirm=True)
+
+    args = captured["args"]
+    assert args[args.index("--upload-port") + 1] == REQUESTED
+    # The env var is what survives into pioarduino's Hybrid-Compile child run.
+    assert captured["extra_env"]["PLATFORMIO_UPLOAD_PORT"] == REQUESTED
+    assert out["exit_code"] == 0
+    assert "upload_port_mismatch" not in out
+
+
+@pytest.mark.firmware
+def test_flash_fails_loudly_when_wrong_port_was_flashed() -> None:
+    with (
+        patch.object(port_recovery, "ensure_port_free", return_value=REQUESTED),
+        patch.object(pio, "run", return_value=_Result(_WRONG_PORT_STDOUT)),
+    ):
+        out = flash.flash("meshnology_w10", REQUESTED, confirm=True)
+
+    assert out["exit_code"] != 0, "a wrong-device flash must not look like success"
+    assert WRONG in out["upload_port_mismatch"]
+
+
+@pytest.mark.firmware
+def test_flash_start_job_fails_on_port_mismatch(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("MESHTASTIC_MCP_DATA_DIR", str(tmp_path))
+
+    with patch.object(pio, "run", return_value=_Result(_WRONG_PORT_STDOUT)):
+        started = flash.flash_start("meshnology_w10", REQUESTED, confirm=True)
+        deadline = time.monotonic() + 10.0
+        while time.monotonic() < deadline:
+            polled = flash.flash_poll(started["job_id"])
+            if polled["status"] != "running":
+                break
+            time.sleep(0.05)
+
+    assert polled["status"] == "failed"
+    assert polled["exit_code"] != 0
+    assert WRONG in polled["error"]
+    # The failure must also be visible in the job log an operator tails.
+    assert "flash job FAILED" in "\n".join(polled["log_tail"])


### PR DESCRIPTION
## The incident

On 2026-08-25 a `flash_start(env=meshnology_w10, port=/dev/cu.usbmodem1201)` job flashed a **different device**: the log shows `Looking for upload port... / Auto-detected: /dev/cu.usbmodem13201`, and the 16MB-partition-table W10 image landed on an 8MB Heltec Wireless Tracker V2 on the same bench, boot-looping it (`partition 3 invalid ... exceeds flash chip size`). The job reported success.

## Root cause (not an arg-passing bug here)

Every flash path in this repo has always passed `--upload-port`, and the incident tool call carried the correct port. The port is lost inside **pioarduino's Hybrid-Compile pass**: when a custom sdkconfig triggers `*** Compile Arduino IDF libs ***` (e.g. a variant's first build), `idf_lib_copy` in the platform's `espidf.py` re-invokes a child `pio run -e <env> -t upload` that forwards **targets but no CLI options** — the child auto-detects a port and flashes whatever it finds. Telltales in the incident log: the hybrid-compile banner, `Auto-detected:` instead of `Using manually specified:`, and stderr ending `*** [checkprogsize] Explicit exit, status 0` (the outer scons `env.Exit(child_rc)`).

Also proven while investigating: `pio run --upload-port ""` silently drops the option (click passes the empty string, the run processor treats it as unset) → auto-detect.

## The fix (defense in depth, all flash paths)

- **Pin the port where the child run can't lose it**: uploads also export `PLATFORMIO_UPLOAD_PORT=<port>` in the subprocess environment — the project-option override is inherited by nested pio runs (verified on pio 6.1.19; the CLI flag still wins in the outer run).
- **Post-flash assertion**: `_verify_upload_port` compares every port the output claims was used (`Auto-detected:` / `Using manually specified:` / esptool's `Serial port X:`) against the requested one. A mismatch forces exit 1 with an `upload_port_mismatch` error naming both ports — in `flash`/`pio_flash`, `flash_start` jobs (also appended to the job log; `flash_poll` now surfaces `error`), and the `erase_and_flash`/`update_flash` script wrappers.
- **Reject ports PlatformIO silently ignores**: empty or glob `port` arguments now raise `FlashError` up front in all four entry points.
- `flash_start` also gains the silent-DFU-failure detection `flash()` already had.

## Testing

- 12 new tests in `tests/unit/test_upload_port_guard.py`, including a reproduction condensed from the incident log.
- Targeted flash suites 25/25; full unit suite green apart from two pre-existing local-env failures (proto descriptor clash, boards-filter assert) that fail identically on a clean tree.
- Ruff check + format clean.

The root-cause fix — forwarding `--upload-port` in the HybridCompile child command — belongs in meshtastic/pioarduino-platform-espressif32 and is being prepared separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved device flashing safety by rejecting missing or ambiguous port selections.
  * Prevented uploads from targeting a different device through automatic port detection.
  * Added verification that flashing uses the requested port and reports mismatches as failures.
  * Prevented concurrent uploads and active connections from sharing a port, including during pre-flight checks.
  * Improved reporting for failed background and asynchronous flashing operations.

* **Tests**
  * Added coverage for port validation, locking, port matching, environment propagation, and synchronous/asynchronous failure reporting.

* **Documentation**
  * Updated the changelog with the flash-port safety improvements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->